### PR TITLE
Move BooleanExpression => Expression string logic from IME to SDK; fixes #220

### DIFF
--- a/CDP4Common.NetCore.Tests/Extensions/BooleanExpressionExtensionsTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Extensions/BooleanExpressionExtensionsTestFixture.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BooleanExpressionExtensionsTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2022 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
@@ -26,9 +26,13 @@ namespace CDP4Common.NetCore.Tests.Extensions
 {
     using System;
     using System.Collections.Generic;
+    using System.Reflection;
 
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.Extensions;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
 
     using NUnit.Framework;
 
@@ -98,6 +102,11 @@ namespace CDP4Common.NetCore.Tests.Extensions
                 { ExpressionNumber.Relational3, this.relationalExpression3 },
                 { ExpressionNumber.Relational4, this.relationalExpression4 }
             };
+
+            this.SetClassKind(this.andExpression, ClassKind.AndExpression);
+            this.SetClassKind(this.orExpression, ClassKind.OrExpression);
+            this.SetClassKind(this.exclusiveOrExpression, ClassKind.ExclusiveOrExpression);
+            this.SetClassKind(this.notExpression, ClassKind.NotExpression);
         }
 
         [Test]
@@ -246,6 +255,59 @@ namespace CDP4Common.NetCore.Tests.Extensions
             {
                 CollectionAssert.DoesNotContain(toplevelCollection, this.testCaseList[expressionNumber]);
             }
+        }
+
+        [Test]
+        public void VerifyExpressionStringsAtThingLevel()
+        {
+            this.andExpression.Term.Add(this.relationalExpression1);
+            this.andExpression.Term.Add(this.relationalExpression2);
+
+            this.orExpression.Term.Add(this.relationalExpression3);
+            this.orExpression.Term.Add(this.relationalExpression4);
+
+            this.exclusiveOrExpression.Term.Add(this.orExpression);
+            this.exclusiveOrExpression.Term.Add(this.andExpression);
+
+            this.notExpression.Term = this.exclusiveOrExpression;
+
+            this.FillRelationalExpression(this.relationalExpression1, "length", 180);
+            this.FillRelationalExpression(this.relationalExpression2, "width", 40);
+            this.FillRelationalExpression(this.relationalExpression3, "mass", 100);
+            this.FillRelationalExpression(this.relationalExpression4, "accel", "pretty_fast");
+
+            Assert.AreEqual("(length = 180) AND (width = 40)", this.andExpression.ToExpressionString());
+            Assert.AreEqual("(mass = 100) OR (accel = pretty_fast)", this.orExpression.ToExpressionString());
+            Assert.AreEqual("((mass = 100) OR (accel = pretty_fast)) XOR ((length = 180) AND (width = 40))", this.exclusiveOrExpression.ToExpressionString());
+            Assert.AreEqual("NOT (((mass = 100) OR (accel = pretty_fast)) XOR ((length = 180) AND (width = 40)))", this.notExpression.ToExpressionString());
+        }
+
+        /// <summary>
+        /// Fills properties on a <see cref="RelationalExpression"/>
+        /// </summary>
+        /// <param name="relationalExpression">The <see cref="RelationalExpression"/></param>
+        /// <param name="parameterShortName">The <see cref="Parameter"/>'s ShortName'</param>
+        /// <param name="value">The <see cref="Parameter"/>'s Value</param>
+        private void FillRelationalExpression(RelationalExpression relationalExpression, string parameterShortName, object value)
+        {
+            relationalExpression.ParameterType = new SimpleQuantityKind { ShortName = parameterShortName };
+
+            this.SetClassKind(relationalExpression, ClassKind.RelationalExpression);
+
+            relationalExpression.RelationalOperator = RelationalOperatorKind.EQ;
+            relationalExpression.Value = new ValueArray<string>(new[] { value.ToString() });
+        }
+
+        /// <summary>
+        /// Sets the readonly ClassKind property of an object using reflection 
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> of the object</typeparam>
+        /// <param name="obj">The object</param>
+        /// <param name="classKind">The <see cref="ClassKind"/></param>
+        private void SetClassKind<T>(T obj, ClassKind classKind)
+        {
+            var field = typeof(RelationalExpression).GetField("<ClassKind>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+            field?.SetValue(obj, classKind);
         }
     }
 }

--- a/CDP4Common.NetCore.Tests/Extensions/ParametricConstraintExtensionsTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Extensions/ParametricConstraintExtensionsTestFixture.cs
@@ -1,0 +1,139 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ParametricConstraintExtensionsTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2022 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.NetCore.Tests.Extensions
+{
+    using System;
+    using System.Reflection;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.Extensions;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ParametricConstraintExtensions"/> class
+    /// </summary>
+    [TestFixture]
+    public class ParametricConstraintExtensionsTestFixture
+    {
+        private AndExpression andExpression;
+
+        private OrExpression orExpression;
+
+        private ExclusiveOrExpression exclusiveOrExpression;
+
+        private NotExpression notExpression;
+
+        private RelationalExpression relationalExpression1;
+
+        private RelationalExpression relationalExpression2;
+
+        private RelationalExpression relationalExpression3;
+
+        private RelationalExpression relationalExpression4;
+
+        private RelationalExpression relationalExpression5;
+
+        private ParametricConstraint parametricConstraint;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.andExpression = new AndExpression();
+            this.orExpression = new OrExpression();
+            this.exclusiveOrExpression = new ExclusiveOrExpression();
+            this.notExpression = new NotExpression();
+            this.relationalExpression1 = new RelationalExpression();
+            this.relationalExpression2 = new RelationalExpression();
+            this.relationalExpression3 = new RelationalExpression();
+            this.relationalExpression4 = new RelationalExpression();
+            this.relationalExpression5 = new RelationalExpression();
+            this.parametricConstraint = new ParametricConstraint();
+
+            this.SetClassKind(this.andExpression, ClassKind.AndExpression);
+            this.SetClassKind(this.orExpression, ClassKind.OrExpression);
+            this.SetClassKind(this.exclusiveOrExpression, ClassKind.ExclusiveOrExpression);
+            this.SetClassKind(this.notExpression, ClassKind.NotExpression);
+            this.SetClassKind(this.parametricConstraint, ClassKind.ParametricConstraint);
+        }
+
+        [Test]
+        public void VerifyExpressionStringsAtThingLevel()
+        {
+            this.andExpression.Term.Add(this.relationalExpression1);
+            this.andExpression.Term.Add(this.relationalExpression2);
+
+            this.orExpression.Term.Add(this.relationalExpression3);
+            this.orExpression.Term.Add(this.relationalExpression4);
+
+            this.exclusiveOrExpression.Term.Add(this.orExpression);
+            this.exclusiveOrExpression.Term.Add(this.andExpression);
+
+            this.notExpression.Term = this.exclusiveOrExpression;
+
+            this.parametricConstraint.Expression.Add(this.notExpression);
+            this.parametricConstraint.Expression.Add(this.relationalExpression5);
+
+            this.FillRelationalExpression(this.relationalExpression1, "length", 180);
+            this.FillRelationalExpression(this.relationalExpression2, "width", 40);
+            this.FillRelationalExpression(this.relationalExpression3, "mass", 100);
+            this.FillRelationalExpression(this.relationalExpression4, "accel", "pretty_fast");
+            this.FillRelationalExpression(this.relationalExpression5, "comment", "lx_is_awesome");
+
+            Assert.AreEqual("NOT (((mass = 100) OR (accel = pretty_fast)) XOR ((length = 180) AND (width = 40))) AND (comment = lx_is_awesome)", this.parametricConstraint.ToExpressionString());
+        }
+
+        /// <summary>
+        /// Fills properties on a <see cref="RelationalExpression"/>
+        /// </summary>
+        /// <param name="relationalExpression">The <see cref="RelationalExpression"/></param>
+        /// <param name="parameterShortName">The <see cref="Parameter"/>'s ShortName'</param>
+        /// <param name="value">The <see cref="Parameter"/>'s Value</param>
+        private void FillRelationalExpression(RelationalExpression relationalExpression, string parameterShortName, object value)
+        {
+            relationalExpression.ParameterType = new SimpleQuantityKind { ShortName = parameterShortName };
+
+            this.SetClassKind(relationalExpression, ClassKind.RelationalExpression);
+
+            relationalExpression.RelationalOperator = RelationalOperatorKind.EQ;
+            relationalExpression.Value = new ValueArray<string>(new[] { value.ToString() });
+        }
+
+        /// <summary>
+        /// Sets the readonly ClassKind property of an object using reflection 
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> of the object</typeparam>
+        /// <param name="obj">The object</param>
+        /// <param name="classKind">The <see cref="ClassKind"/></param>
+        private void SetClassKind<T>(T obj, ClassKind classKind)
+        {
+            var field = typeof(RelationalExpression).GetField("<ClassKind>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+            field?.SetValue(obj, classKind);
+        }
+    }
+}

--- a/CDP4Common.Tests/Extensions/ParametricConstraintExtensionsTestFixture.cs
+++ b/CDP4Common.Tests/Extensions/ParametricConstraintExtensionsTestFixture.cs
@@ -1,0 +1,139 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ParametricConstraintExtensionsTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2022 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.Tests.Extensions
+{
+    using System;
+    using System.Reflection;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.Extensions;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ParametricConstraintExtensions"/> class
+    /// </summary>
+    [TestFixture]
+    public class ParametricConstraintExtensionsTestFixture
+    {
+        private AndExpression andExpression;
+
+        private OrExpression orExpression;
+
+        private ExclusiveOrExpression exclusiveOrExpression;
+
+        private NotExpression notExpression;
+
+        private RelationalExpression relationalExpression1;
+
+        private RelationalExpression relationalExpression2;
+
+        private RelationalExpression relationalExpression3;
+
+        private RelationalExpression relationalExpression4;
+
+        private RelationalExpression relationalExpression5;
+
+        private ParametricConstraint parametricConstraint;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.andExpression = new AndExpression();
+            this.orExpression = new OrExpression();
+            this.exclusiveOrExpression = new ExclusiveOrExpression();
+            this.notExpression = new NotExpression();
+            this.relationalExpression1 = new RelationalExpression();
+            this.relationalExpression2 = new RelationalExpression();
+            this.relationalExpression3 = new RelationalExpression();
+            this.relationalExpression4 = new RelationalExpression();
+            this.relationalExpression5 = new RelationalExpression();
+            this.parametricConstraint = new ParametricConstraint();
+
+            this.SetClassKind(this.andExpression, ClassKind.AndExpression);
+            this.SetClassKind(this.orExpression, ClassKind.OrExpression);
+            this.SetClassKind(this.exclusiveOrExpression, ClassKind.ExclusiveOrExpression);
+            this.SetClassKind(this.notExpression, ClassKind.NotExpression);
+            this.SetClassKind(this.parametricConstraint, ClassKind.ParametricConstraint);
+        }
+
+        [Test]
+        public void VerifyExpressionStringsAtThingLevel()
+        {
+            this.andExpression.Term.Add(this.relationalExpression1);
+            this.andExpression.Term.Add(this.relationalExpression2);
+
+            this.orExpression.Term.Add(this.relationalExpression3);
+            this.orExpression.Term.Add(this.relationalExpression4);
+
+            this.exclusiveOrExpression.Term.Add(this.orExpression);
+            this.exclusiveOrExpression.Term.Add(this.andExpression);
+
+            this.notExpression.Term = this.exclusiveOrExpression;
+
+            this.parametricConstraint.Expression.Add(this.notExpression);
+            this.parametricConstraint.Expression.Add(this.relationalExpression5);
+
+            this.FillRelationalExpression(this.relationalExpression1, "length", 180);
+            this.FillRelationalExpression(this.relationalExpression2, "width", 40);
+            this.FillRelationalExpression(this.relationalExpression3, "mass", 100);
+            this.FillRelationalExpression(this.relationalExpression4, "accel", "pretty_fast");
+            this.FillRelationalExpression(this.relationalExpression5, "comment", "lx_is_awesome");
+
+            Assert.AreEqual("NOT (((mass = 100) OR (accel = pretty_fast)) XOR ((length = 180) AND (width = 40))) AND (comment = lx_is_awesome)", this.parametricConstraint.ToExpressionString());
+        }
+
+        /// <summary>
+        /// Fills properties on a <see cref="RelationalExpression"/>
+        /// </summary>
+        /// <param name="relationalExpression">The <see cref="RelationalExpression"/></param>
+        /// <param name="parameterShortName">The <see cref="Parameter"/>'s ShortName'</param>
+        /// <param name="value">The <see cref="Parameter"/>'s Value</param>
+        private void FillRelationalExpression(RelationalExpression relationalExpression, string parameterShortName, object value)
+        {
+            relationalExpression.ParameterType = new SimpleQuantityKind { ShortName = parameterShortName };
+
+            this.SetClassKind(relationalExpression, ClassKind.RelationalExpression);
+
+            relationalExpression.RelationalOperator = RelationalOperatorKind.EQ;
+            relationalExpression.Value = new ValueArray<string>(new[] { value.ToString() });
+        }
+
+        /// <summary>
+        /// Sets the readonly ClassKind property of an object using reflection 
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> of the object</typeparam>
+        /// <param name="obj">The object</param>
+        /// <param name="classKind">The <see cref="ClassKind"/></param>
+        private void SetClassKind<T>(T obj, ClassKind classKind)
+        {
+            var field = typeof(RelationalExpression).GetField("<ClassKind>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+            field?.SetValue(obj, classKind);
+        }
+    }
+}

--- a/CDP4Common/CDP4Common.csproj
+++ b/CDP4Common/CDP4Common.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net45;net451;net452;net46;net461;net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4Common Community Edition</Title>
-    <VersionPrefix>8.1.0</VersionPrefix>
+    <VersionPrefix>8.2.0</VersionPrefix>
     <Description>CDP4 Common Class Library that contains DTOs, POCOs</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael, Ahmed</Authors>

--- a/CDP4Common/Extensions/ParametricConstraintExtensions.cs
+++ b/CDP4Common/Extensions/ParametricConstraintExtensions.cs
@@ -1,0 +1,64 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ParametricConstraintExtensions.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2022 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Yevhen Ikonnykov
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.Extensions
+{
+    using System.Linq;
+    using System.Text;
+
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// This class contains methods for specific ParametricConstraint related functionality 
+    /// </summary>
+    public static class ParametricConstraintExtensions
+    {
+        /// <summary>
+        /// Creates a string that represents a tree of (nested) <see cref="BooleanExpression"/>s for a <see cref="ParametricConstraint"/>.
+        /// </summary>
+        /// <param name="parametricConstraint">The <see cref="ParametricConstraint"/> for which the tree will be built</param>
+        /// <returns>A <see cref="string"/> that represents the <see cref="BooleanExpression"/> tree</returns>
+        public static string ToExpressionString(this ParametricConstraint parametricConstraint)
+        {
+            var stringBuilder = new StringBuilder();
+
+            var expressions = parametricConstraint.Expression.GetTopLevelExpressions();
+
+            if (expressions.Any())
+            {
+                foreach (var expression in expressions)
+                {
+                    if (stringBuilder.Length > 0)
+                    {
+                        stringBuilder.Append(" AND ");
+                    }
+
+                    stringBuilder.Append(expression.ToExpressionString());
+                }
+            }
+
+            return stringBuilder.ToString();
+        }
+    }
+}

--- a/CDP4Common/Poco/AndExpression.cs
+++ b/CDP4Common/Poco/AndExpression.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="AndExpression.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2022 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
@@ -40,6 +40,6 @@ namespace CDP4Common.EngineeringModelData
         /// Gets the expressions that are direct children of this class
         /// </summary>
         /// <returns><see cref="IReadOnlyList{BooleanExpression}"/> containing <see cref="BooleanExpression"/>s that are direct children of this class</returns>
-        protected override IReadOnlyList<BooleanExpression> GetMyExpressions() => this.Term;
+        public override IReadOnlyList<BooleanExpression> GetMyExpressions() => this.Term;
     }
 }

--- a/CDP4Common/Poco/BooleanExpression.cs
+++ b/CDP4Common/Poco/BooleanExpression.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BooleanExpression.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2022 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
@@ -62,7 +62,7 @@ namespace CDP4Common.EngineeringModelData
         /// Gets the expressions that are direct children of this class
         /// </summary>
         /// <returns><see cref="IReadOnlyList{BooleanExpression}"/> containing <see cref="BooleanExpression"/>s that are direct children of this class</returns>
-        protected abstract IReadOnlyList<BooleanExpression> GetMyExpressions();
+        public abstract IReadOnlyList<BooleanExpression> GetMyExpressions();
 
         /// <summary>
         /// Gets all descendant expressions of this class

--- a/CDP4Common/Poco/ExclusiveOrExpression.cs
+++ b/CDP4Common/Poco/ExclusiveOrExpression.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ExclusiveOrExpression.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2022 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
@@ -40,6 +40,6 @@ namespace CDP4Common.EngineeringModelData
         /// Gets the expressions that are direct children of this class
         /// </summary>
         /// <returns><see cref="IReadOnlyList{BooleanExpression}"/> containing <see cref="BooleanExpression"/>s that are direct children of this class</returns>
-        protected override IReadOnlyList<BooleanExpression> GetMyExpressions() => this.Term;
+        public override IReadOnlyList<BooleanExpression> GetMyExpressions() => this.Term;
     }
 }

--- a/CDP4Common/Poco/NotExpression.cs
+++ b/CDP4Common/Poco/NotExpression.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NotExpression.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2022 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
@@ -40,7 +40,7 @@ namespace CDP4Common.EngineeringModelData
         /// Gets the expressions that are direct children of this class
         /// </summary>
         /// <returns><see cref="IReadOnlyList{BooleanExpression}"/> containing <see cref="BooleanExpression"/>s that are direct children of this class</returns>
-        protected override IReadOnlyList<BooleanExpression> GetMyExpressions()
+        public override IReadOnlyList<BooleanExpression> GetMyExpressions()
         {
             var result = new List<BooleanExpression>();
 

--- a/CDP4Common/Poco/OrExpression.cs
+++ b/CDP4Common/Poco/OrExpression.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="OrExpression.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2022 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
@@ -40,6 +40,6 @@ namespace CDP4Common.EngineeringModelData
         /// Gets the expressions that are direct children of this class
         /// </summary>
         /// <returns><see cref="IReadOnlyList{BooleanExpression}"/> containing <see cref="BooleanExpression"/>s that are direct children of this class</returns>
-        protected override IReadOnlyList<BooleanExpression> GetMyExpressions() => this.Term;
+        public override IReadOnlyList<BooleanExpression> GetMyExpressions() => this.Term;
     }
 }

--- a/CDP4Common/Poco/RelationalExpression.cs
+++ b/CDP4Common/Poco/RelationalExpression.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RelationalExpression.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2022 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
@@ -52,6 +52,6 @@ namespace CDP4Common.EngineeringModelData
         /// Gets the expressions that are direct children of this class
         /// </summary>
         /// <returns><see cref="IReadOnlyList{BooleanExpression}"/> containing <see cref="BooleanExpression"/>s that are direct children of this class</returns>
-        protected override IReadOnlyList<BooleanExpression> GetMyExpressions() => new List<BooleanExpression>();
+        public override IReadOnlyList<BooleanExpression> GetMyExpressions() => new List<BooleanExpression>();
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Move BooleanExpression => Expression string logic from IME to SDK