### PR TITLE
[Update] ThingTransactionException namespace; fixes #154

### DIFF
--- a/CDP4Dal/Exceptions/TransactionException.cs
+++ b/CDP4Dal/Exceptions/TransactionException.cs
@@ -22,7 +22,7 @@
 // </copyright>
 // -------------------------------------------------------------------------------------------------------------------------------
 
-namespace CDP4Common.Exceptions
+namespace CDP4Dal.Exceptions
 {
     using System;
     using System.Runtime.Serialization;

--- a/CDP4Dal/Operations/ThingTransaction.cs
+++ b/CDP4Dal/Operations/ThingTransaction.cs
@@ -32,13 +32,14 @@ namespace CDP4Dal.Operations
 
     using CDP4Common;
     using CDP4Common.EngineeringModelData;
-    using CDP4Common.Exceptions;
     using CDP4Common.Extensions;
     using CDP4Common.Polyfills;
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.CommonData;
     using CDP4Common.Types;
-    
+
+    using CDP4Dal.Exceptions;
+
     using NLog;
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Updated the ThingTransactionException namespace to Dal. This is a braking change that warrants a major release

<!-- Thanks for contributing to COMET-SDK! -->