### PR TITLE
[Implement] extension methods from webapp; fixes #251

### DIFF
--- a/CDP4Common.NetCore.Tests/Helpers/ValueArrayUtilsTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Helpers/ValueArrayUtilsTestFixture.cs
@@ -25,8 +25,10 @@
 namespace CDP4Common.Tests.Helpers
 {
     using System;
+    using System.Collections.Generic;
 
     using CDP4Common.Helpers;
+    using CDP4Common.Types;
 
     using NUnit.Framework;
 
@@ -50,6 +52,24 @@ namespace CDP4Common.Tests.Helpers
             var result = ValueArrayUtils.CreateDefaultValueArray(size);
 
             Assert.AreEqual(size, result.Count);
+        }
+
+        [Test]
+        public void VerifyThatContainsSameValuesWorks()
+        {
+            var valueArray1 = new ValueArray<string>(new List<string>() { "1", "ABC", "Test" });
+            var valueArray2 = new ValueArray<string>(new List<string>() { "1", "ABC", "Test" });
+            var valueArray3 = new ValueArray<string>(new List<string>() { "1", "ABC" });
+            var valueArray4 = new ValueArray<string>(new List<string>() { "1", "ABCa", "Test" });
+            var valueArray5 = new ValueArray<string>(new List<string>() { "1.0", "ABC", "Test" });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(valueArray1.ContainsSameValues(valueArray2), Is.True);
+                Assert.That(valueArray1.ContainsSameValues(valueArray3), Is.False);
+                Assert.That(valueArray1.ContainsSameValues(valueArray4), Is.False);
+                Assert.That(valueArray1.ContainsSameValues(valueArray5), Is.False);
+            });
         }
     }
 }

--- a/CDP4Common.Tests/Extensions/ElementBaseExtensionsTestFixture.cs
+++ b/CDP4Common.Tests/Extensions/ElementBaseExtensionsTestFixture.cs
@@ -1,0 +1,153 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ElementBaseExtensionsTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.Tests.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.Extensions;
+    using CDP4Common.SiteDirectoryData;
+    
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ElementBaseExtensionsTestFixture
+    {
+        private List<ElementBase> elementDefinitions;
+        private ActualFiniteState actualFiniteState;
+        private ElementDefinition elementDefinition;
+        private ElementUsage elementUsage;
+        private ElementBase elementBase;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.actualFiniteState = new ActualFiniteState()
+            {
+                Iid = Guid.NewGuid(),
+            };
+
+            var parameterType1 = new TextParameterType()
+            {
+                Iid = Guid.NewGuid(),
+                Name = "parameter1",
+                ShortName = "param1"
+            };
+
+            var parameterType2 = new SimpleQuantityKind()
+            {
+                Iid = Guid.NewGuid(),
+                Name = "parameter2",
+                ShortName = "param2"
+            };
+
+            var parameter1 = new Parameter
+            {
+                Iid = Guid.NewGuid(),
+                ParameterType = parameterType1,
+                ValueSet =
+                {
+                    new ParameterValueSet()
+                    {
+                        ActualState = this.actualFiniteState
+                    }
+                }
+            };
+
+            var parameter2 = new Parameter
+            {
+                Iid = Guid.NewGuid(),
+                ParameterType = parameterType2,
+            };
+
+            var parameter3 = new ParameterOverride
+            {
+                Parameter = parameter1,
+                Iid = Guid.NewGuid(),
+            };
+
+            var parameter4 = new ParameterOverride
+            {
+                Parameter = parameter2,
+                Iid = Guid.NewGuid(),
+            };
+
+            this.elementDefinition = new ElementDefinition()
+            {
+                Parameter = { parameter1, parameter2 }
+            };
+
+            this.elementUsage = new ElementUsage()
+            {
+                ElementDefinition = this.elementDefinition,
+                ParameterOverride = { parameter3, parameter4 }
+            };
+
+            this.elementBase = new ElementDefinition()
+            {
+                Parameter = { parameter2 }
+            };
+
+            this.elementDefinitions = new List<ElementBase>()
+            {
+                this.elementUsage,
+                this.elementDefinition,
+                this.elementBase
+            };
+        }
+
+        [Test]
+        public void VerifyThatParametersCanBeRetrievedFromElements()
+        {
+            var result1 = this.elementUsage.QueryParametersInUse().ToList();
+            var result2 = this.elementDefinition.QueryParametersInUse().ToList();
+            var result3 = this.elementBase.QueryParametersInUse().ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result1, Is.Not.Null);
+                Assert.That(result1, Has.Count.EqualTo(2));
+                Assert.That(result2, Is.Not.Null);
+                Assert.That(result2, Has.Count.EqualTo(2));
+                Assert.That(result3, Is.Not.Null);
+                Assert.That(result3, Has.Count.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public void VerifyThatFilterByStateWorks()
+        {
+            var result = this.elementDefinitions.FilterByState(this.actualFiniteState);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(this.elementDefinitions, Has.Count.EqualTo(3));
+                Assert.That(result, Has.Count.EqualTo(2));
+            });
+        }
+    }
+}

--- a/CDP4Common.Tests/Helpers/ValueArrayUtilsTestFixture.cs
+++ b/CDP4Common.Tests/Helpers/ValueArrayUtilsTestFixture.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ValueArrayUtilsTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2023 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
 //
@@ -22,11 +22,14 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-using System;
-
 namespace CDP4Common.Tests.Helpers
 {
+    using System;
+    using System.Collections.Generic;
+
     using CDP4Common.Helpers;
+    using CDP4Common.Types;
+
     using NUnit.Framework;
 
     /// <summary>
@@ -49,6 +52,24 @@ namespace CDP4Common.Tests.Helpers
             var result = ValueArrayUtils.CreateDefaultValueArray(size);
 
             Assert.AreEqual(size, result.Count);
+        }
+
+        [Test]
+        public void VerifyThatContainsSameValuesWorks()
+        {
+            var valueArray1 = new ValueArray<string>(new List<string>() { "1", "ABC", "Test" });
+            var valueArray2 = new ValueArray<string>(new List<string>() { "1", "ABC", "Test" });
+            var valueArray3 = new ValueArray<string>(new List<string>() { "1", "ABC" });
+            var valueArray4 = new ValueArray<string>(new List<string>() { "1", "ABCa", "Test" });
+            var valueArray5 = new ValueArray<string>(new List<string>() { "1.0", "ABC", "Test" });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(valueArray1.ContainsSameValues(valueArray2), Is.True);
+                Assert.That(valueArray1.ContainsSameValues(valueArray3), Is.False);
+                Assert.That(valueArray1.ContainsSameValues(valueArray4), Is.False);
+                Assert.That(valueArray1.ContainsSameValues(valueArray5), Is.False);
+            });
         }
     }
 }

--- a/CDP4Common.Tests/Poco/IterationTestFixture.cs
+++ b/CDP4Common.Tests/Poco/IterationTestFixture.cs
@@ -1,7 +1,6 @@
-﻿#region Copyright
-// --------------------------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IterationTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2023 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
 //
@@ -22,14 +21,18 @@
 //    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
-#endregion
 
 namespace CDP4Common.Tests.Poco
 {
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.Linq;
 
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
 
     using NUnit.Framework;
 
@@ -39,6 +42,332 @@ namespace CDP4Common.Tests.Poco
     [TestFixture]
     public class IterationTestFixture
     {
+        private Iteration iteration;
+        private List<ParameterValueSetBase> parameterValueSetBase;
+        private List<ParameterSubscription> parameterSubscriptions;
+        private List<ElementDefinition> unReferencedElements;
+        private List<ElementDefinition> unUsedElements;
+        private DomainOfExpertise currentDomainOfExpertise;
+        private DomainOfExpertise domainOfExpertise;
+        private SiteDirectory siteDirectory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var uri = new Uri("http://www.rheagroup.com");
+            var cache = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+            var person = new Person(Guid.NewGuid(), cache, uri);
+
+            var referenceDataLibrary = new ModelReferenceDataLibrary(Guid.NewGuid(), cache, uri)
+            {
+                ShortName = "ARDL"
+            };
+
+            var participant = new Participant(Guid.NewGuid(), cache, uri)
+            {
+                Person = person
+            };
+
+            var engineeringSetup = new EngineeringModelSetup(Guid.NewGuid(), cache, uri)
+            {
+                RequiredRdl =
+                {
+                    referenceDataLibrary
+                },
+                Participant = { participant }
+            };
+
+            this.iteration = new Iteration(Guid.NewGuid(), cache, uri)
+            {
+                Container = new EngineeringModel(Guid.NewGuid(), cache, uri)
+                {
+                    EngineeringModelSetup = new EngineeringModelSetup(Guid.NewGuid(), cache, uri)
+                    {
+                        RequiredRdl =
+                        {
+                            new ModelReferenceDataLibrary(Guid.NewGuid(), cache, uri)
+                            {
+                                FileType =
+                                {
+                                    new FileType(Guid.NewGuid(), cache, uri) { Extension = "tar" },
+                                    new FileType(Guid.NewGuid(), cache, uri) { Extension = "gz" },
+                                    new FileType(Guid.NewGuid(), cache, uri) { Extension = "zip" }
+                                }
+                            }
+                        },
+                        Participant = { participant }
+                    }
+                },
+                IterationSetup = new IterationSetup(Guid.NewGuid(), cache, uri)
+                {
+                    Container = engineeringSetup
+                },
+                DomainFileStore =
+                {
+                    new DomainFileStore(Guid.NewGuid(), cache, uri) { Owner = this.domainOfExpertise }
+                }
+            };
+
+            this.domainOfExpertise = new DomainOfExpertise(Guid.NewGuid(), cache, uri)
+            {
+                ShortName = "SYS",
+                Name = "System"
+            };
+
+            this.currentDomainOfExpertise = new DomainOfExpertise(Guid.NewGuid(), cache, uri)
+            {
+                ShortName = "AOCS",
+                Name = "Attitude and orbit control system"
+            };
+
+            this.siteDirectory = new SiteDirectory(Guid.NewGuid(), cache, uri);
+            this.siteDirectory.Person.Add(person);
+            this.siteDirectory.Domain.Add(this.domainOfExpertise);
+            this.siteDirectory.Domain.Add(this.currentDomainOfExpertise);
+
+            var optionA = new Option(Guid.NewGuid(), cache, uri)
+            {
+                ShortName = "OPT_A",
+                Name = "Option A"
+            };
+
+            var elementDefinition1 = new ElementDefinition(Guid.NewGuid(), cache, uri)
+            {
+                Owner = this.domainOfExpertise,
+                ShortName = "Sat",
+                Name = "Satellite"
+            };
+
+            var elementDefinition2 = new ElementDefinition(Guid.NewGuid(), cache, uri)
+            {
+                Owner = this.domainOfExpertise,
+                ShortName = "Bat",
+                Name = "Battery"
+            };
+
+            var elementDefinition3 = new ElementDefinition(Guid.NewGuid(), cache, uri)
+            {
+                Owner = this.domainOfExpertise,
+                ShortName = "solar_panel",
+                Name = "Solar Panel"
+            };
+
+            var elementUsage1 = new ElementUsage(Guid.NewGuid(), cache, uri)
+            {
+                ElementDefinition = elementDefinition2,
+                ShortName = "bat_a",
+                Name = "battery a"
+            };
+
+            var elementUsage2 = new ElementUsage(Guid.NewGuid(), cache, uri)
+            {
+                ElementDefinition = elementDefinition2,
+                ShortName = "bat_b",
+                Name = "battery b"
+            };
+
+            var simpleQuantityKind = new SimpleQuantityKind(Guid.NewGuid(), null, null)
+            {
+                ShortName = "m",
+                Name = "mass"
+            };
+
+            var simpleQuantityKind2 = new SimpleQuantityKind(Guid.NewGuid(), null, null)
+            {
+                ShortName = "v",
+                Name = "volume"
+            };
+
+            var parameter = new Parameter(Guid.NewGuid(), cache, uri)
+            {
+                Owner = this.domainOfExpertise,
+                ParameterType = simpleQuantityKind
+            };
+
+            var parameter2 = new Parameter(Guid.NewGuid(), cache, uri)
+            {
+                Owner = this.domainOfExpertise,
+                ParameterType = simpleQuantityKind2
+            };
+
+            var parameterValueset1 = new ParameterValueSet
+            {
+                ActualOption = optionA,
+                Iid = Guid.NewGuid()
+            };
+
+            var parameterValueset2 = new ParameterValueSet
+            {
+                ActualOption = optionA,
+                Iid = Guid.NewGuid()
+            };
+
+            var values1 = new List<string> { "2" };
+            var values2 = new List<string> { "3" };
+            var publishedValues = new List<string> { "123" };
+
+            this.iteration.Option.Add(optionA);
+            this.iteration.DefaultOption = optionA;
+
+            parameterValueset1.Manual = new ValueArray<string>(values1);
+            parameterValueset1.Reference = new ValueArray<string>(values1);
+            parameterValueset1.Computed = new ValueArray<string>(values1);
+            parameterValueset1.Formula = new ValueArray<string>(values1);
+            parameterValueset1.Published = new ValueArray<string>(publishedValues);
+            parameterValueset1.ValueSwitch = ParameterSwitchKind.MANUAL;
+
+            parameterValueset2.Manual = new ValueArray<string>(values2);
+            parameterValueset2.Reference = new ValueArray<string>(values2);
+            parameterValueset2.Computed = new ValueArray<string>(values2);
+            parameterValueset2.Formula = new ValueArray<string>(values2);
+            parameterValueset2.Published = new ValueArray<string>(publishedValues);
+            parameterValueset2.ValueSwitch = ParameterSwitchKind.MANUAL;
+
+            parameter.ValueSet.Add(parameterValueset1);
+            parameter.ValueSet.Add(parameterValueset2);
+
+            elementDefinition1.Parameter.Add(parameter);
+            elementDefinition1.ContainedElement.Add(elementUsage1);
+            elementDefinition1.ContainedElement.Add(elementUsage2);
+
+            elementDefinition2.Parameter.Add(parameter2);
+
+            this.iteration.Element.Add(elementDefinition1);
+            this.iteration.Element.Add(elementDefinition2);
+            this.iteration.Element.Add(elementDefinition3);
+            this.iteration.TopElement = elementDefinition1;
+
+            var parameterSubscriptionValueSet = new ParameterSubscriptionValueSet
+            {
+                Iid = Guid.NewGuid(),
+                Manual = new ValueArray<string>(new List<string> { "1" }),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            };
+
+            var parameterSubscription = new ParameterSubscription()
+            {
+                Owner = this.currentDomainOfExpertise,
+                ValueSet = { parameterSubscriptionValueSet }
+            };
+
+            parameter.ParameterSubscription.Add(parameterSubscription);
+
+            this.parameterValueSetBase = new List<ParameterValueSetBase>
+            {
+                parameterValueset1,
+                parameterValueset2
+            };
+
+            this.unReferencedElements = new List<ElementDefinition>
+            {
+                elementDefinition3
+            };
+
+            this.unUsedElements = new List<ElementDefinition>
+            {
+                elementDefinition3
+            };
+
+            parameterSubscriptionValueSet.SubscribedValueSet = parameterValueset1;
+
+            this.parameterSubscriptions = new List<ParameterSubscription> { parameterSubscription };
+        }
+
+        [Test]
+        public void VerifyGetNestedElements()
+        {
+            Assert.That(this.iteration.QueryNestedElements(), Is.Not.Empty);
+        }
+
+        [Test]
+        public void VerifyGetNestedElementsByOption()
+        {
+            var nestedElements = this.iteration.QueryNestedElements(this.iteration.Option[0]).ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(nestedElements, Is.Not.Empty);
+                Assert.That(nestedElements, Has.Count.EqualTo(this.iteration.QueryNestedElements().Count()));
+            });
+        }
+
+        [Test]
+        public void VerifyGetNestedParameters()
+        {
+            Assert.That(this.iteration.QueryNestedParameters(this.iteration.Option[0]), Is.Not.Empty);
+        }
+
+        [Test]
+        public void VerifyGetParameterSubscriptionsByElement()
+        {
+            var subscriptions = this.iteration.TopElement.QueryOwnedParameterSubscriptions(this.currentDomainOfExpertise).ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(subscriptions, Has.Count.EqualTo(1));
+                Assert.That(subscriptions, Does.Contain(this.parameterSubscriptions[0]));
+            });
+        }
+
+        [Test]
+        public void VerifyGetSubscribedParameters()
+        {
+            var subscriptions = this.iteration.QuerySubscribedParameterByOthers(this.domainOfExpertise).ToList();
+            Assert.That(subscriptions, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public void VerifyGetParameterTypes()
+        {
+            var parameterTypes = this.iteration.QueryUsedParameterTypes().ToList();
+            Assert.That(parameterTypes, Has.Count.EqualTo(2));
+
+            var parameterTypeNames = new List<string>();
+            parameterTypes.ForEach(p => parameterTypeNames.Add(p.Name));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(parameterTypeNames, Does.Contain("mass"));
+                Assert.That(parameterTypeNames, Does.Contain("volume"));
+            });
+        }
+
+        [Test]
+        public void VerifyGetParameterValueSetBase()
+        {
+            var valueSets = this.iteration.QueryParameterValueSetBase().ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(valueSets, Is.Not.Empty);
+                Assert.That(valueSets, Is.EqualTo(this.parameterValueSetBase));
+            });
+        }
+
+        [Test]
+        public void VerifyGetUnreferencedElements()
+        {
+            var unreferencedElements = this.iteration.QueryUnreferencedElements().ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(unreferencedElements, Is.Not.Empty);
+                Assert.That(unreferencedElements, Is.EqualTo(this.unReferencedElements));
+            });
+        }
+
+        [Test]
+        public void VerifyGetUnusedElementDefinitions()
+        {
+            var unusedElements = this.iteration.QueryUnusedElementDefinitions().ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(unusedElements, Is.Not.Empty);
+                Assert.That(unusedElements, Is.EqualTo(this.unUsedElements));
+            });
+        }
+
         [Test]
         public void VerifyThatRequiredRdlRdlsReturnsExpectedResult()
         {

--- a/CDP4Common/Extensions/ElementBaseExtensions.cs
+++ b/CDP4Common/Extensions/ElementBaseExtensions.cs
@@ -1,0 +1,100 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ElementBaseExtensions.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.Extensions
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// Extension methods for the <see cref="ElementBase"/> class.
+    /// </summary>
+    public static class ElementBaseExtensions
+    {
+        /// <summary>
+        /// Filters the <paramref name="elements"/> by the <paramref name="state"/>
+        /// </summary>
+        /// <param name="elements">
+        /// the elements to filter
+        /// </param>
+        /// <param name="state">
+        /// the state used to filter
+        /// </param>
+        /// <returns>
+        /// the filtered elements
+        /// </returns>
+        public static IEnumerable<ElementBase> FilterByState(this IEnumerable<ElementBase> elements, ActualFiniteState state)
+        {
+            var filteredElements = new List<ElementBase>();
+
+            foreach (var element in elements)
+            {
+                if (element is ElementDefinition elementDefinition)
+                {
+                    elementDefinition.Parameter.ForEach(p =>
+                    {
+                        p.ValueSet.ForEach(v =>
+                        {
+                            if (v.ActualState != null && v.ActualState == state)
+                            {
+                                filteredElements.Add(element);
+                            }
+                        });
+                    });
+                }
+                else if (element is ElementUsage elementUsage)
+                {
+                    if (elementUsage.ParameterOverride.Any())
+                    {
+                        elementUsage.ParameterOverride.ForEach(p =>
+                        {
+                            p.ValueSet.ForEach(v =>
+                            {
+                                if (v.ActualState != null && v.ActualState == state)
+                                {
+                                    filteredElements.Add(element);
+                                }
+                            });
+                        });
+                    }
+
+                    elementUsage.ElementDefinition.Parameter.ForEach(p =>
+                    {
+                        p.ValueSet.ForEach(v =>
+                        {
+                            if (v.ActualState != null && v.ActualState == state)
+                            {
+                                filteredElements.Add(element);
+                            }
+                        });
+                    });
+                }
+            }
+
+            return filteredElements;
+        }
+    }
+}

--- a/CDP4Common/Extensions/ParameterOrOverrideBaseExtensions.cs
+++ b/CDP4Common/Extensions/ParameterOrOverrideBaseExtensions.cs
@@ -1,0 +1,67 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ParameterOrOverrideBaseExtensions.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
+//
+//    This file is part of CDP4-SDK Community Edition
+//
+//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.Extensions
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Extension methods for <see cref="ParameterOrOverrideBase"/>
+    /// </summary>
+    public static class ParameterOrOverrideBaseExtensions
+    {
+        /// <summary>
+        /// Queries all <see cref="ParameterSubscription" /> owned by a given <see cref="DomainOfExpertise" />
+        /// contained into a collection of <see cref="ParameterOrOverrideBase" />
+        /// </summary>
+        /// <param name="parameterOrOverrideBases">The collection of <see cref="ParameterOrOverrideBase" /></param>
+        /// <param name="domain">The <see cref="DomainOfExpertise" /></param>
+        /// <returns>A collection of <see cref="ParameterSubscription" /></returns>
+        public static IEnumerable<ParameterSubscription> QueryOwnedParameterSubscriptions(this IEnumerable<ParameterOrOverrideBase> parameterOrOverrideBases,
+            DomainOfExpertise domain)
+        {
+            return parameterOrOverrideBases.Where(x => x.Owner.Iid != domain.Iid)
+                .SelectMany(x => x.ParameterSubscription.Where(p => p.Owner.Iid == domain.Iid));
+        }
+
+        /// <summary>
+        /// Queries all owned <see cref="ParameterOrOverrideBase" /> contained into a collection of
+        /// <see cref="ParameterOrOverrideBase" />
+        /// that contains <see cref="ParameterSubscription" /> of other <see cref="DomainOfExpertise" />
+        /// </summary>
+        /// <param name="parameterOrOverrideBases">The collection of <see cref="ParameterOrOverrideBase" /></param>
+        /// <param name="domain">The <see cref="DomainOfExpertise" /></param>
+        /// <returns>A collection of <see cref="ParameterSubscription" /></returns>
+        public static IEnumerable<ParameterOrOverrideBase> QuerySubscribedParameterByOthers(this IEnumerable<ParameterOrOverrideBase> parameterOrOverrideBases,
+            DomainOfExpertise domain)
+        {
+            return parameterOrOverrideBases.Where(x => x.Owner.Iid == domain.Iid
+                                                       && x.ParameterSubscription.Any(p => p.Owner.Iid != domain.Iid));
+        }
+    }
+}

--- a/CDP4Common/Helpers/ValueArrayUtils.cs
+++ b/CDP4Common/Helpers/ValueArrayUtils.cs
@@ -62,5 +62,35 @@ namespace CDP4Common.Helpers
 
             return result;
         }
+
+        /// <summary>
+        /// Checks if two <see cref="ValueArray{T}"/> contains the same exact values 
+        /// </summary>
+        /// <typeparam name="T">the type of the parameter</typeparam>
+        /// <param name="valueArray">the first value array to compare</param>
+        /// <param name="comparison">the second value array to compare</param>
+        /// <returns>True if the contained values are the same, false otherwise</returns>
+        public static bool ContainsSameValues<T>(this ValueArray<T> valueArray, ValueArray<T> comparison) where T : class
+        {
+            if (comparison is null)
+            {
+                throw new ArgumentNullException(nameof(comparison));
+            }
+
+            if (valueArray.Count != comparison.Count)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < valueArray.Count; i++)
+            {
+                if (valueArray[i] != comparison[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/CDP4Common/Poco/Iteration.cs
+++ b/CDP4Common/Poco/Iteration.cs
@@ -24,9 +24,12 @@
 
 namespace CDP4Common.EngineeringModelData
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
+    using CDP4Common.Extensions;
+    using CDP4Common.Helpers;
     using CDP4Common.SiteDirectoryData;
 
     /// <summary>
@@ -48,6 +51,212 @@ namespace CDP4Common.EngineeringModelData
                 requiredRdls.UnionWith(requiredModelReferenceDataLibrary.GetRequiredRdls());
                 return requiredRdls;
             }
+        }
+
+        /// <summary>
+        /// Queries the name of the associated <see cref="Iteration" />
+        /// </summary>
+        /// <returns>
+        /// The name of the <see cref="Iteration" /> composed of the container
+        /// Engineering Model name and Iteration number
+        /// </returns>
+        public string QueryName()
+        {
+            var engineeringSetup = (EngineeringModelSetup)this.IterationSetup.Container;
+            return $"{engineeringSetup.Name} - Iteration {this.IterationSetup.IterationNumber}";
+        }
+
+        /// <summary>
+        /// Queries the used <see cref="ParameterType" /> inside an <see cref="Iteration" />
+        /// </summary>
+        /// <returns>
+        /// An <see cref="IEnumerable{T}"/> of used <see cref="ParameterType" />
+        /// </returns>
+        public IEnumerable<ParameterType> QueryUsedParameterTypes()
+        {
+            return this.Element.SelectMany(x => x.Parameter).Select(x => x.ParameterType).DistinctBy(x => x.Iid);
+        }
+
+        /// <summary>
+        /// Queries all <see cref="ParameterValueSetBase" /> of the given iteration
+        /// </summary>
+        /// <returns>A collection of <see cref="ParameterValueSetBase" /></returns>
+        public IEnumerable<ParameterValueSetBase> QueryParameterValueSetBase()
+        {
+            var valueSets = new List<ParameterValueSetBase>();
+
+            if (this.TopElement != null)
+            {
+                valueSets.AddRange(this.TopElement.Parameter.SelectMany(x => x.ValueSet));
+            }
+
+            foreach (var elementUsage in this.Element.SelectMany(elementDefinition => elementDefinition.ContainedElement))
+            {
+                if (!elementUsage.ParameterOverride.Any())
+                {
+                    valueSets.AddRange(elementUsage.ElementDefinition.Parameter.SelectMany(x => x.ValueSet));
+                }
+                else
+                {
+                    valueSets.AddRange(elementUsage.ParameterOverride.SelectMany(x => x.ValueSet));
+
+                    valueSets.AddRange(elementUsage.ElementDefinition.Parameter.Where(x => elementUsage.ParameterOverride.All(o => o.Parameter.Iid != x.Iid))
+                        .SelectMany(x => x.ValueSet));
+                }
+            }
+
+            return valueSets.DistinctBy(x => x.Iid);
+        }
+
+        /// <summary>
+        /// Queries all <see cref="NestedParameter" /> that belongs to a given <see cref="Option" />
+        /// </summary>
+        /// <param name="option">
+        /// The <see cref="Option" /> for which the <see cref="NestedParameter"/>s are to be queried
+        /// </param>
+        /// <returns>
+        /// An <see cref="IEnumerable{T}"/> of <see cref="NestedParameter" />
+        /// </returns>
+        public IEnumerable<NestedParameter> QueryNestedParameters(Option option)
+        {
+            var generator = new NestedElementTreeGenerator();
+            return this.TopElement == null ? Enumerable.Empty<NestedParameter>() : generator.GetNestedParameters(option);
+        }
+
+        /// <summary>
+        /// Queries all the unreferenced <see cref="ElementDefinition" /> in an <see cref="Iteration" />
+        /// An unreferenced element is an element with no associated ElementUsage
+        /// </summary>
+        /// <returns>
+        /// All unreferenced <see cref="ElementDefinition" />
+        /// </returns>
+        public IEnumerable<ElementDefinition> QueryUnreferencedElements()
+        {
+            var elementUsages = this.Element.SelectMany(x => x.ContainedElement).ToList();
+
+            var associatedElementDefinitions = elementUsages.Select(x => x.ElementDefinition);
+
+            var unreferencedElementDefinitions = this.Element.ToList();
+            unreferencedElementDefinitions.RemoveAll(x => associatedElementDefinitions.Any(e => e.Iid == x.Iid));
+            unreferencedElementDefinitions.RemoveAll(x => x.Iid == this.TopElement.Iid);
+
+            return unreferencedElementDefinitions;
+        }
+
+        /// <summary>
+        /// Queries unused <see cref="ElementDefinition" /> in an <see cref="Iteration" />
+        /// An unused element is an element not used in an option
+        /// </summary>
+        /// <returns>All unused <see cref="ElementDefinition" /></returns>
+        public IEnumerable<ElementDefinition> QueryUnusedElementDefinitions()
+        {
+            var nestedElements = this.QueryNestedElements().ToList();
+
+            var associatedElements = nestedElements.SelectMany(x => x.ElementUsage.Select(e => e.ElementDefinition))
+                .DistinctBy(x => x.Iid).ToList();
+
+            var unusedElementDefinitions = this.Element.ToList();
+            unusedElementDefinitions.RemoveAll(e => associatedElements.Any(x => x.Iid == e.Iid));
+            unusedElementDefinitions.RemoveAll(x => x.Iid == this.TopElement?.Iid);
+            return unusedElementDefinitions;
+        }
+
+        /// <summary>
+        /// Queries all <see cref="NestedElement" /> of the given <see cref="Iteration" />
+        /// </summary>
+        /// <returns>A collection of <see cref="NestedElement" /></returns>
+        public IEnumerable<NestedElement> QueryNestedElements()
+        {
+            var nestedElementTreeGenerator = new NestedElementTreeGenerator();
+            var nestedElements = new List<NestedElement>();
+
+            if (this.TopElement != null)
+            {
+                nestedElements.AddRange(this.Option.SelectMany(o => nestedElementTreeGenerator.Generate(o)));
+            }
+
+            return nestedElements;
+        }
+
+        /// <summary>
+        /// Queries all <see cref="NestedElement" /> of the given <see cref="Iteration" /> based on <see cref="Option" />
+        /// </summary>
+        /// <param name="option">
+        /// The <see cref="Option" />
+        /// </param>
+        /// <returns>
+        /// A collection of <see cref="NestedElement" />
+        /// </returns>
+        public IEnumerable<NestedElement> QueryNestedElements(Option option)
+        {
+            var nestedElementTreeGenerator = new NestedElementTreeGenerator();
+            var nestedElements = new List<NestedElement>();
+
+            if (this.TopElement != null)
+            {
+                nestedElements.AddRange(nestedElementTreeGenerator.Generate(option));
+            }
+
+            return nestedElements;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ElementBase"/> from this iteration
+        /// </summary>
+        /// <returns>an <see cref="IEnumerable{ElementBase}"/></returns>
+        /// <exception cref="ArgumentNullException">if the iteration is null</exception>
+        public IEnumerable<ElementBase> QueryElementsBase()
+        {
+            var elements = new List<ElementBase>();
+
+            if (this.TopElement != null)
+            {
+                elements.Add(this.TopElement);
+            }
+
+            this.Element.ForEach(e => elements.AddRange(e.ContainedElement));
+
+            return elements;
+        }
+
+        /// <summary>
+        /// Queries all <see cref="ParameterSubscription" /> owned by a given <see cref="DomainOfExpertise" />
+        /// contained into an <see cref="Iteration" />
+        /// </summary>
+        /// <param name="iteration">The <see cref="Iteration" /></param>
+        /// <param name="domain">The <see cref="DomainOfExpertise" /></param>
+        /// <returns>A collection of <see cref="ParameterSubscription" /></returns>
+        public IEnumerable<ParameterSubscription> QueryOwnedParameterSubscriptions(DomainOfExpertise domain)
+        {
+            var subscriptions = new List<ParameterSubscription>();
+
+            if (this.TopElement != null)
+            {
+                subscriptions.AddRange(this.TopElement.QueryOwnedParameterSubscriptions(domain));
+            }
+
+            subscriptions.AddRange(this.Element.SelectMany(x => x.ContainedElement).SelectMany(x => x.QueryOwnedParameterSubscriptions(domain)));
+            return subscriptions.DistinctBy(x => x.Iid).OrderBy(p => p.ParameterType.Name);
+        }
+
+        /// <summary>
+        /// Queries owned <see cref="ParameterOrOverrideBase" /> contained into an <see cref="Iteration" />
+        /// that contains <see cref="ParameterSubscription" /> of other <see cref="DomainOfExpertise" />
+        /// </summary>
+        /// <param name="iteration">The <see cref="Iteration" /></param>
+        /// <param name="domain">The <see cref="DomainOfExpertise" /></param>
+        /// <returns>A collection of <see cref="ParameterSubscription" /></returns>
+        public IEnumerable<ParameterOrOverrideBase> QuerySubscribedParameterByOthers(DomainOfExpertise domain)
+        {
+            var subscriptions = new List<ParameterOrOverrideBase>();
+
+            if (this.TopElement != null)
+            {
+                subscriptions.AddRange(this.TopElement.QuerySubscribedParameterByOthers(domain));
+            }
+
+            subscriptions.AddRange(this.Element.SelectMany(x => x.ContainedElement).SelectMany(x => x.QuerySubscribedParameterByOthers(domain)));
+            return subscriptions.DistinctBy(x => x.Iid).OrderBy(p => p.ParameterType.Name);
         }
     }
 }

--- a/CDP4Common/Poco/ParameterSubscription.cs
+++ b/CDP4Common/Poco/ParameterSubscription.cs
@@ -29,7 +29,8 @@ namespace CDP4Common.EngineeringModelData
 
     using CDP4Common.Exceptions;
     using CDP4Common.SiteDirectoryData;
-    
+    using CDP4Common.Types;
+
     /// <summary>
     /// Extended part for the auto-generated <see cref="ParameterSubscription"/>
     /// </summary>

--- a/CDP4Common/Poco/ParameterSubscriptionValueSet.cs
+++ b/CDP4Common/Poco/ParameterSubscriptionValueSet.cs
@@ -26,7 +26,7 @@ namespace CDP4Common.EngineeringModelData
 {
     using System;
     using System.Collections.Generic;
-
+    using System.Linq;
     using CDP4Common.Exceptions;
     using CDP4Common.Helpers;
     using CDP4Common.SiteDirectoryData;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Copy extensions and helper methods from web app to SDK. Once new SDK release is made, comet web app should use these methods instead

<!-- Thanks for contributing to COMET-SDK! -->