### PR TITLE
[Refactor] NestedElementTreeGenerator

### DIFF
--- a/CDP4Common.NetCore.Tests/Helpers/NestedElementTreeGeneratorTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Helpers/NestedElementTreeGeneratorTestFixture.cs
@@ -56,7 +56,8 @@ namespace CDP4Common.Tests.Helpers
         private Option option_B;
         private Parameter parameter;
         private ParameterOverride parameterOverride;
-        private Parameter parameter2;
+        private Parameter parameter2; 
+        private Parameter parameter3;
         private ActualFiniteState actualState_3;
         private ActualFiniteState actualState_4;
 
@@ -142,6 +143,12 @@ namespace CDP4Common.Tests.Helpers
                 ParameterType = simpleQuantityKind2
             };
 
+            this.parameter3 = new Parameter(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Owner = this.domainOfExpertise,
+                ParameterType = simpleQuantityKind2
+            };
+
             this.parameterOverride = new ParameterOverride(Guid.NewGuid(), this.cache, this.uri)
             {
                 Owner = this.domainOfExpertise,
@@ -193,6 +200,12 @@ namespace CDP4Common.Tests.Helpers
                 Iid = Guid.NewGuid()
             };
 
+            var parameterValueset_5 = new ParameterValueSet()
+            {
+                ActualOption = this.option_A,
+                Iid = Guid.NewGuid()
+            };
+
             var values_1 = new List<string> { "2" };
             var values_2 = new List<string> { "3" };
             var values_3 = new List<string> { "220" };
@@ -232,6 +245,11 @@ namespace CDP4Common.Tests.Helpers
             parameterValueset_4.Formula = new CDP4Common.Types.ValueArray<string>(values_4);
             parameterValueset_4.ValueSwitch = ParameterSwitchKind.MANUAL;
 
+            parameterValueset_5.Manual = null;
+            parameterValueset_5.Reference = null;
+            parameterValueset_5.Computed = null;
+            parameterValueset_5.Formula = null;
+
             overrideValueset.Manual = new CDP4Common.Types.ValueArray<string>(values_1);
             overrideValueset.Reference = new CDP4Common.Types.ValueArray<string>(values_1);
             overrideValueset.Computed = new CDP4Common.Types.ValueArray<string>(values_1);
@@ -253,6 +271,7 @@ namespace CDP4Common.Tests.Helpers
             this.elementDefinition_1.ContainedElement.Add(this.elementUsage_2);
             this.elementDefinition_2.Parameter.Add(this.parameter);
             this.elementDefinition_2.Parameter.Add(this.parameter2);
+            this.elementDefinition_2.Parameter.Add(this.parameter3);
 
             this.iteration.Element.Add(this.elementDefinition_1);
             this.iteration.Element.Add(this.elementDefinition_2);

--- a/CDP4Common.NetCore.Tests/Helpers/NestedElementTreeGeneratorTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Helpers/NestedElementTreeGeneratorTestFixture.cs
@@ -131,6 +131,11 @@ namespace CDP4Common.Tests.Helpers
                 ShortName = "v"
             };
 
+            var simpleQuantityKind3 = new SimpleQuantityKind(Guid.NewGuid(), null, null)
+            {
+                ShortName = "q"
+            };
+
             this.parameter = new Parameter(Guid.NewGuid(), this.cache, this.uri)
             {
                 Owner = this.domainOfExpertise,
@@ -146,7 +151,7 @@ namespace CDP4Common.Tests.Helpers
             this.parameter3 = new Parameter(Guid.NewGuid(), this.cache, this.uri)
             {
                 Owner = this.domainOfExpertise,
-                ParameterType = simpleQuantityKind2
+                ParameterType = simpleQuantityKind3
             };
 
             this.parameterOverride = new ParameterOverride(Guid.NewGuid(), this.cache, this.uri)
@@ -509,6 +514,150 @@ namespace CDP4Common.Tests.Helpers
             Assert.AreEqual(@"Sat.bat_a\v\1\OPT_B", this.nestedElementTreeGenerator.GetNestedParameterPath(this.parameter2, this.option_B, this.actualState_3));
             Assert.AreEqual(@"Sat.bat_a\v\2\OPT_B", this.nestedElementTreeGenerator.GetNestedParameterPath(this.parameter2, this.option_B, this.actualState_4));
             Assert.AreEqual(@"Sat\m\\OPT_B", this.nestedElementTreeGenerator.GetNestedParameterPath(this.parameterOverride, this.option_B));
+        }
+
+        [Test]
+        public void Verify_that_a_nested_parameter_for_an_override_references_the_override_and_not_the_a_parameter()
+        {
+            var testiteration = new Iteration(Guid.NewGuid(), this.cache, this.uri);
+            
+            var option = new Option(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ShortName = "option_1",
+                Name = "option 1"
+            };
+
+            testiteration.Option.Add(option);
+
+            var system_engineering = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ShortName = "SYS",
+                Name = "System"
+            };
+
+            var mass = new SimpleQuantityKind(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ShortName = "m"
+            };
+            
+            var power = new SimpleQuantityKind(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ShortName = "p"
+            };
+
+            var values_1 = new List<string> { "1" };
+            var values_2 = new List<string> { "2" };
+
+            var satellite_definition = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ShortName = "SAT",
+                Name = "Satellite",
+                Owner = system_engineering
+            };
+
+            testiteration.Element.Add(satellite_definition);
+            testiteration.TopElement = satellite_definition;
+
+            var battery_definition = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ShortName = "BAT",
+                Name = "Battery",
+                Owner = system_engineering
+            };
+
+            var mass_parameter = new Parameter(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Owner = system_engineering,
+                ParameterType = mass
+            };
+
+            var mass_parameterValueset = new ParameterValueSet(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Iid = Guid.NewGuid(),
+                Manual = new CDP4Common.Types.ValueArray<string>(values_1),
+                Reference = new CDP4Common.Types.ValueArray<string>(values_1),
+                Computed = new CDP4Common.Types.ValueArray<string>(values_1),
+                Formula = new CDP4Common.Types.ValueArray<string>(values_1),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            };
+            
+            mass_parameter.ValueSet.Add(mass_parameterValueset);
+            
+            var power_parameter = new Parameter(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Owner = system_engineering,
+                ParameterType = power
+            };
+
+            var power_parameterValueset = new ParameterValueSet(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Iid = Guid.NewGuid(),
+                Manual = new CDP4Common.Types.ValueArray<string>(values_1),
+                Reference = new CDP4Common.Types.ValueArray<string>(values_1),
+                Computed = new CDP4Common.Types.ValueArray<string>(values_1),
+                Formula = new CDP4Common.Types.ValueArray<string>(values_1),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            };
+
+            power_parameter.ValueSet.Add(power_parameterValueset);
+
+            battery_definition.Parameter.Add(mass_parameter);
+            battery_definition.Parameter.Add(power_parameter);
+
+            testiteration.Element.Add(battery_definition);
+
+            var battery_usage = new ElementUsage(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ShortName = "BAT_a",
+                Name = "Battery A",
+                ElementDefinition = battery_definition,
+                Owner = system_engineering
+            };
+
+            var mass_parameteroverride = new ParameterOverride(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Owner = system_engineering,
+                Parameter = mass_parameter,
+            };
+
+            var mass_parameterOverrideValueset = new ParameterOverrideValueSet(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Iid = Guid.NewGuid(),
+                Manual = new CDP4Common.Types.ValueArray<string>(values_2),
+                Reference = new CDP4Common.Types.ValueArray<string>(values_2),
+                Computed = new CDP4Common.Types.ValueArray<string>(values_2),
+                Formula = new CDP4Common.Types.ValueArray<string>(values_2),
+                ValueSwitch = ParameterSwitchKind.MANUAL,
+                ParameterValueSet = mass_parameterValueset
+            };
+
+            mass_parameteroverride.ValueSet.Add(mass_parameterOverrideValueset);
+
+            battery_usage.ParameterOverride.Add(mass_parameteroverride);
+
+            satellite_definition.ContainedElement.Add(battery_usage);
+            
+            var nestedElements =this.nestedElementTreeGenerator.Generate(option, system_engineering, false).ToList();
+            
+            foreach (var nestedElement in nestedElements)
+            {
+                Console.WriteLine($"NE: - {nestedElement.ShortName}:{nestedElement.Name}");
+
+                foreach (var nestedParameter in nestedElement.NestedParameter)
+                {
+                    Console.WriteLine($"NP: - {nestedParameter.Path}:{nestedParameter.UserFriendlyShortName}:{nestedParameter.ActualValue}");
+                }
+            }
+
+            var nested_battery_a = nestedElements.Single(x => x.ShortName == "SAT.BAT_a");
+
+            var nested_mass_parameter = nested_battery_a.NestedParameter.Single(x => x.Path == @"SAT.BAT_a\m\\option_1");
+
+            Assert.That(nested_mass_parameter.AssociatedParameter, Is.EqualTo(mass_parameteroverride));
+
+            var nested_power_parameter = nested_battery_a.NestedParameter.Single(x => x.Path == @"SAT.BAT_a\p\\option_1");
+
+            Assert.That(nested_power_parameter.AssociatedParameter, Is.EqualTo(power_parameter));
         }
     }
 }

--- a/CDP4Common/Helpers/NestedElementTreeGenerator.cs
+++ b/CDP4Common/Helpers/NestedElementTreeGenerator.cs
@@ -683,9 +683,9 @@ namespace CDP4Common.Helpers
         /// </returns>
         private NestedParameter CreatedNestedParameter(ParameterOrOverrideBase parameter, ParameterTypeComponent component, ParameterValueSetBase valueSet, Option option)
         {
-            var componentIndex = component == null ? 0 : component.Index;
-            var actualValue = valueSet.ActualValue[componentIndex];
-            var formula = valueSet.Formula[componentIndex];
+            var componentIndex = component?.Index ?? 0;
+            var actualValue = valueSet.ActualValue == null ? "-" :  valueSet.ActualValue[componentIndex];
+            var formula = valueSet.Formula == null ? "-" : valueSet.Formula[componentIndex];
 
             var nestedParameter = new NestedParameter(Guid.NewGuid(), parameter.Cache, parameter.IDalUri)
             {
@@ -726,9 +726,9 @@ namespace CDP4Common.Helpers
         /// </returns>
         private NestedParameter CreateNestedParameter(ParameterSubscription subscription, ParameterTypeComponent component, ParameterSubscriptionValueSet valueSet, Option option)
         {
-            var componentIndex = component == null ? 0 : component.Index;
-            var actualValue = valueSet.ActualValue[componentIndex];
-
+            var componentIndex = component?.Index ?? 0;
+            var actualValue = valueSet.ActualValue == null ? "-" : valueSet.ActualValue[componentIndex];
+            
             var nestedParameter = new NestedParameter(Guid.NewGuid(), subscription.Cache, subscription.IDalUri)
             {
                 IsVolatile = true,

--- a/CDP4Common/Helpers/NestedElementTreeGenerator.cs
+++ b/CDP4Common/Helpers/NestedElementTreeGenerator.cs
@@ -588,7 +588,7 @@ namespace CDP4Common.Helpers
                         {
                             if (compoundParameterType == null)
                             {
-                                var nestedParameter = this.CreatedNestedParameter(parameter, null, parameterOverrideValueSet, option);
+                                var nestedParameter = this.CreatedNestedParameter(parameterOveride, null, parameterOverrideValueSet, option);
                                 yield return nestedParameter;
                             }
                             else
@@ -596,7 +596,7 @@ namespace CDP4Common.Helpers
                                 foreach (var component in compoundParameterType.Component)
                                 {
                                     var comp = (ParameterTypeComponent) component;
-                                    var nestedParameter = this.CreatedNestedParameter(parameter, comp, parameterOverrideValueSet, option);
+                                    var nestedParameter = this.CreatedNestedParameter(parameterOveride, comp, parameterOverrideValueSet, option);
                                     yield return nestedParameter;
                                 }
                             }

--- a/RemoveObjAndBin.ps1
+++ b/RemoveObjAndBin.ps1
@@ -1,0 +1,1 @@
+Get-ChildItem .\ -include bin,obj -Recurse | foreach ($_) { remove-item $_.fullname -Force -Recurse }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
  - Add null reference check before trying to access the `formula` or `actualvalue` property; fixes #243 
  - [Fix] incorrect setting of NestedParameter.AssociatedParameter when is ParameterOverride; fixes #241

<!-- Thanks for contributing to COMET-SDK! -->