### PR TITLE
[Add] ThingEquatable and concrete DTO Equatable extension methods

### DIFF
--- a/CDP4Common.NetCore.Tests/AutoGenEquatable/ActionItemEquatableTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/AutoGenEquatable/ActionItemEquatableTestFixture.cs
@@ -1,0 +1,83 @@
+﻿// ---------------------------------------------------------------------------------------------
+// <copyright file="ActionItemEquatableTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ---------------------------------------------------------------------------------------------
+
+namespace CDP4Common.Tests.AutoGenEquatable
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+
+	using CDP4Common.DTO.Equatable;
+
+	using NUnit.Framework;
+
+	using ActionItem = CDP4Common.DTO.ActionItem;
+
+	/// <summary>
+	/// Suite of tests for the <see cref="ActionItemEquatable"/>
+	/// </summary>
+	[TestFixture]
+	public class ActionItemEquatableTestFixture
+	{
+		[Test]
+		public void Verify_That_ActionItems_are_equal()
+		{
+			var me = new ActionItem(Guid.Parse("5b5843fb-9310-4f19-aea6-2419d92fc65c"), 1)
+			{
+				Actionee =  Guid.Parse("ace42ef8-0e5d-459d-9b9b-47aff4ff1cdc"),
+				ApprovedBy = new List<Guid> { Guid.Parse("f60ea509-b7fc-4a87-bdf1-aab7d91a77f0"), Guid.Parse("eb4e96ba-f964-4466-bacf-33537458d1c4") },
+				Classification = CDP4Common.ReportingData.AnnotationClassificationKind.MAJOR,
+				CloseOutDate = null,
+				Content = "some content"
+			};
+
+			var other = new ActionItem(Guid.Parse("5b5843fb-9310-4f19-aea6-2419d92fc65c"), 1)
+			{
+				Actionee = Guid.Parse("ace42ef8-0e5d-459d-9b9b-47aff4ff1cdc"),
+				ApprovedBy = new List<Guid> { Guid.Parse("f60ea509-b7fc-4a87-bdf1-aab7d91a77f0"), Guid.Parse("eb4e96ba-f964-4466-bacf-33537458d1c4") },
+				Classification = CDP4Common.ReportingData.AnnotationClassificationKind.MAJOR,
+				CloseOutDate = null,
+				Content = "some content"
+			};
+
+			Assert.That(me.ArePropertiesEqual(other), Is.True);
+			
+			me.CloseOutDate = new DateTime(1976, 8, 20);
+			other.CloseOutDate = new DateTime(1976, 8, 20);
+			Assert.That(me.ArePropertiesEqual(other), Is.True);
+
+			me.CloseOutDate = null;
+			Assert.That(me.ArePropertiesEqual(other), Is.False);
+			me.CloseOutDate = new DateTime(1976, 8, 20);
+
+			other.Content = null;
+			Assert.That(me.ArePropertiesEqual(other), Is.False);
+			other.Content = "some content";
+
+			me.Content = null;
+			Assert.That(me.ArePropertiesEqual(other), Is.False);
+		}
+	}
+}

--- a/CDP4Common.NetCore.Tests/AutoGenEquatable/ConstantEquatableTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/AutoGenEquatable/ConstantEquatableTestFixture.cs
@@ -1,0 +1,66 @@
+﻿// ---------------------------------------------------------------------------------------------
+// <copyright file="ConstantEquatableTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ---------------------------------------------------------------------------------------------
+
+namespace CDP4Common.Tests.AutoGenEquatable
+{
+	using System;
+	using System.Collections.Generic;
+
+	using CDP4Common.DTO.Equatable;
+	using CDP4Common.Types;
+
+	using NUnit.Framework;
+
+	using Constant = CDP4Common.DTO.Constant;
+
+	/// <summary>
+	/// Suite of tests for the <see cref="ConstantEquatable"/>
+	/// </summary>
+	[TestFixture]
+	public class ConstantEquatableTestFixture
+	{
+		[Test]
+		public void Verify_That_ActionItems_are_equal()
+		{
+			var me = new Constant(Guid.Parse("5b5843fb-9310-4f19-aea6-2419d92fc65c"), 1)
+			{
+				Alias = new List<Guid> { Guid.Parse("f60ea509-b7fc-4a87-bdf1-aab7d91a77f0"), Guid.Parse("eb4e96ba-f964-4466-bacf-33537458d1c4") },
+				Value = new ValueArray<string>(new List<string> {"-", "1", "2"})
+			};
+
+			var other = new Constant(Guid.Parse("5b5843fb-9310-4f19-aea6-2419d92fc65c"), 1)
+			{
+				Alias = new List<Guid> { Guid.Parse("f60ea509-b7fc-4a87-bdf1-aab7d91a77f0"), Guid.Parse("eb4e96ba-f964-4466-bacf-33537458d1c4") },
+				Value = new ValueArray<string>(new List<string> { "-", "1", "2" })
+			};
+
+			Assert.That(me.ArePropertiesEqual(other), Is.True);
+
+			other.Value = new ValueArray<string>(new List<string> { "-", "1", "1" });
+
+			Assert.That(me.ArePropertiesEqual(other), Is.False);
+		}
+	}
+}

--- a/CDP4Common.NetCore.Tests/AutoGenEquatable/DefinitionItemEquatableTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/AutoGenEquatable/DefinitionItemEquatableTestFixture.cs
@@ -1,0 +1,81 @@
+﻿// ---------------------------------------------------------------------------------------------
+// <copyright file="DefinitionEquatableTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ---------------------------------------------------------------------------------------------
+
+namespace CDP4Common.Tests.AutoGenEquatable
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+
+	using CDP4Common.DTO.Equatable;
+	using CDP4Common.Types;
+
+	using NUnit.Framework;
+
+	using Definition = CDP4Common.DTO.Definition;
+
+	/// <summary>
+	/// Suite of tests for the <see cref="DefinitionEquatable"/>
+	/// </summary>
+	[TestFixture]
+	public class DefinitionEquatableTestFixture
+	{
+		[Test]
+		public void Verify_That_ActionItems_are_equal()
+		{
+			var me = new Definition(Guid.Parse("5b5843fb-9310-4f19-aea6-2419d92fc65c"), 1)
+			{
+				Note = new List<OrderedItem>
+				{
+					new OrderedItem { K = 1, V = "value 1"},
+					new OrderedItem { K = 2, V = "value 2"}
+				}
+			};
+
+			var other = new Definition(Guid.Parse("5b5843fb-9310-4f19-aea6-2419d92fc65c"), 1)
+			{
+				Note = new List<OrderedItem>
+				{
+					new OrderedItem { K = 1, V = "value 1"},
+					new OrderedItem { K = 2, V = "value 2"}
+				}
+			};
+
+			Assert.That(me.ArePropertiesEqual(other), Is.True);
+
+			me.Note.First().K = 3;
+
+			Assert.That(me.ArePropertiesEqual(other), Is.False);
+
+			me.Note.First().K = 1;
+
+			Assert.That(me.ArePropertiesEqual(other), Is.True);
+
+			me.Note.First().V = "value 3";
+
+			Assert.That(me.ArePropertiesEqual(other), Is.False);
+		}
+	}
+}

--- a/CDP4Common/AutoGenEquatable/ActionItemEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ActionItemEquatable.cs
@@ -1,0 +1,159 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ActionItemEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | actionee                             | Guid                         | 1..1        |  1.1.0  |
+ | 3     | approvedBy                           | Guid                         | 0..*        |  1.1.0  |
+ | 4     | author                               | Guid                         | 1..1        |  1.1.0  |
+ | 5     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 6     | classification                       | AnnotationClassificationKind | 1..1        |  1.1.0  |
+ | 7     | closeOutDate                         | DateTime                     | 0..1        |  1.1.0  |
+ | 8     | closeOutStatement                    | string                       | 0..1        |  1.1.0  |
+ | 9     | content                              | string                       | 1..1        |  1.1.0  |
+ | 10    | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 11    | discussion                           | Guid                         | 0..*        |  1.1.0  |
+ | 12    | dueDate                              | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 15    | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 16    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 17    | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 18    | primaryAnnotatedThing                | Guid                         | 0..1        |  1.1.0  |
+ | 19    | relatedThing                         | Guid                         | 0..*        |  1.1.0  |
+ | 20    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 21    | sourceAnnotation                     | Guid                         | 0..*        |  1.1.0  |
+ | 22    | status                               | AnnotationStatusKind         | 1..1        |  1.1.0  |
+ | 23    | title                                | string                       | 1..1        |  1.1.0  |
+ | 24    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ActionItem"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ActionItemEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ActionItem"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ActionItem"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ActionItem"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ActionItem"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ActionItem me, ActionItem other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Actionee.Equals(other.Actionee)) return false;
+
+            if (!me.ApprovedBy.OrderBy(x => x).SequenceEqual(other.ApprovedBy.OrderBy(x => x))) return false;
+
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Classification.Equals(other.Classification)) return false;
+
+            if (!me.CloseOutDate.HasValue && other.CloseOutDate.HasValue) return false;
+            if (!me.CloseOutDate.Equals(other.CloseOutDate)) return false;
+
+            if (me.CloseOutStatement == null && other.CloseOutStatement != null) return false;
+            if (me.CloseOutStatement != null && !me.CloseOutStatement.Equals(other.CloseOutStatement)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.Discussion.OrderBy(x => x).SequenceEqual(other.Discussion.OrderBy(x => x))) return false;
+
+            if (!me.DueDate.Equals(other.DueDate)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
+
+            if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.SourceAnnotation.OrderBy(x => x).SequenceEqual(other.SourceAnnotation.OrderBy(x => x))) return false;
+
+            if (!me.Status.Equals(other.Status)) return false;
+
+            if (me.Title == null && other.Title != null) return false;
+            if (me.Title != null && !me.Title.Equals(other.Title)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ActionItemEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ActionItemEquatable.cs
@@ -105,7 +105,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Classification.Equals(other.Classification)) return false;
 
-            if (!me.CloseOutDate.HasValue && other.CloseOutDate.HasValue) return false;
+            if (me.CloseOutDate.HasValue != other.CloseOutDate.HasValue) return false;
             if (!me.CloseOutDate.Equals(other.CloseOutDate)) return false;
 
             if (me.CloseOutStatement == null && other.CloseOutStatement != null) return false;
@@ -131,7 +131,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Owner.Equals(other.Owner)) return false;
 
-            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (me.PrimaryAnnotatedThing.HasValue != other.PrimaryAnnotatedThing.HasValue) return false;
             if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
 
             if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/ActualFiniteStateEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ActualFiniteStateEquatable.cs
@@ -1,0 +1,101 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ActualFiniteStateEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | kind                                 | ActualFiniteStateKind        | 1..1        |  1.0.0  |
+ | 3     | possibleState                        | Guid                         | 1..*        |  1.0.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ActualFiniteState"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ActualFiniteStateEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ActualFiniteState"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ActualFiniteState"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ActualFiniteState"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ActualFiniteState"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ActualFiniteState me, ActualFiniteState other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Kind.Equals(other.Kind)) return false;
+
+            if (!me.PossibleState.OrderBy(x => x).SequenceEqual(other.PossibleState.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ActualFiniteStateListEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ActualFiniteStateListEquatable.cs
@@ -1,0 +1,108 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ActualFiniteStateListEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | actualState                          | Guid                         | 0..*        |  1.0.0  |
+ | 3     | excludeOption                        | Guid                         | 0..*        |  1.0.0  |
+ | 4     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 5     | possibleFiniteStateList              | Guid                         | 1..*        |  1.0.0  |
+ | 6     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ActualFiniteStateList"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ActualFiniteStateListEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ActualFiniteStateList"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ActualFiniteStateList"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ActualFiniteStateList"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ActualFiniteStateList"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ActualFiniteStateList me, ActualFiniteStateList other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ActualState.OrderBy(x => x).SequenceEqual(other.ActualState.OrderBy(x => x))) return false;
+
+            if (!me.ExcludeOption.OrderBy(x => x).SequenceEqual(other.ExcludeOption.OrderBy(x => x))) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.PossibleFiniteStateList.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.PossibleFiniteStateList.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.PossibleFiniteStateList.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.PossibleFiniteStateList.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/AliasEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/AliasEquatable.cs
@@ -1,0 +1,106 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="AliasEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | content                              | string                       | 1..1        |  1.0.0  |
+ | 3     | isSynonym                            | bool                         | 1..1        |  1.0.0  |
+ | 4     | languageCode                         | string                       | 1..1        |  1.0.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Alias"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class AliasEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Alias"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Alias"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Alias"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Alias"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Alias me, Alias other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.IsSynonym.Equals(other.IsSynonym)) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/AndExpressionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/AndExpressionEquatable.cs
@@ -1,0 +1,98 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="AndExpressionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | term                                 | Guid                         | 2..*        |  1.0.0  |
+ | 3     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 6     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="AndExpression"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class AndExpressionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="AndExpression"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="AndExpression"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="AndExpression"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="AndExpression"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this AndExpression me, AndExpression other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Term.OrderBy(x => x).SequenceEqual(other.Term.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ApprovalEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ApprovalEquatable.cs
@@ -1,0 +1,115 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ApprovalEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | author                               | Guid                         | 1..1        |  1.1.0  |
+ | 3     | classification                       | AnnotationApprovalKind       | 1..1        |  1.1.0  |
+ | 4     | content                              | string                       | 1..1        |  1.1.0  |
+ | 5     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 6     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Approval"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ApprovalEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Approval"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Approval"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Approval"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Approval"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Approval me, Approval other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (!me.Classification.Equals(other.Classification)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ArrayParameterTypeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ArrayParameterTypeEquatable.cs
@@ -1,0 +1,136 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ArrayParameterTypeEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | component                            | Guid                         | 1..*        |  1.0.0  |
+ | 5     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 6     | dimension                            | int                          | 1..*        |  1.0.0  |
+ | 7     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 8     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 9     | isFinalized                          | bool                         | 1..1        |  1.0.0  |
+ | 10    | isTensor                             | bool                         | 1..1        |  1.0.0  |
+ | 11    | name                                 | string                       | 1..1        |  1.0.0  |
+ | 12    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 13    | symbol                               | string                       | 1..1        |  1.0.0  |
+ | 14    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 15    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 16    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 17    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ArrayParameterType"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ArrayParameterTypeEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ArrayParameterType"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ArrayParameterType"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ArrayParameterType"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ArrayParameterType"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ArrayParameterType me, ArrayParameterType other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Component.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.Component.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.Component.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.Component.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.Dimension.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.Dimension.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.Dimension.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.Dimension.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.IsFinalized.Equals(other.IsFinalized)) return false;
+
+            if (!me.IsTensor.Equals(other.IsTensor)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Symbol == null && other.Symbol != null) return false;
+            if (me.Symbol != null && !me.Symbol.Equals(other.Symbol)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/BinaryNoteEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/BinaryNoteEquatable.cs
@@ -1,0 +1,119 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BinaryNoteEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | caption                              | string                       | 1..1        |  1.1.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 4     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | fileType                             | Guid                         | 1..1        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | name                                 | string                       | 1..1        |  1.1.0  |
+ | 10    | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 11    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="BinaryNote"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class BinaryNoteEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="BinaryNote"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="BinaryNote"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="BinaryNote"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="BinaryNote"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this BinaryNote me, BinaryNote other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (me.Caption == null && other.Caption != null) return false;
+            if (me.Caption != null && !me.Caption.Equals(other.Caption)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.FileType.Equals(other.FileType)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/BinaryRelationshipEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/BinaryRelationshipEquatable.cs
@@ -1,0 +1,114 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BinaryRelationshipEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 3     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 4     | source                               | Guid                         | 1..1        |  1.0.0  |
+ | 5     | target                               | Guid                         | 1..1        |  1.0.0  |
+ | 6     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | parameterValue                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | name                                 | string                       | 0..1        |  1.2.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="BinaryRelationship"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class BinaryRelationshipEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="BinaryRelationship"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="BinaryRelationship"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="BinaryRelationship"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="BinaryRelationship"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this BinaryRelationship me, BinaryRelationship other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.Source.Equals(other.Source)) return false;
+
+            if (!me.Target.Equals(other.Target)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.ParameterValue.OrderBy(x => x).SequenceEqual(other.ParameterValue.OrderBy(x => x))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/BinaryRelationshipRuleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/BinaryRelationshipRuleEquatable.cs
@@ -1,0 +1,132 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BinaryRelationshipRuleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | forwardRelationshipName              | string                       | 1..1        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | inverseRelationshipName              | string                       | 1..1        |  1.0.0  |
+ | 7     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 8     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 9     | relationshipCategory                 | Guid                         | 1..1        |  1.0.0  |
+ | 10    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 11    | sourceCategory                       | Guid                         | 1..1        |  1.0.0  |
+ | 12    | targetCategory                       | Guid                         | 1..1        |  1.0.0  |
+ | 13    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 15    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 16    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="BinaryRelationshipRule"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class BinaryRelationshipRuleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="BinaryRelationshipRule"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="BinaryRelationshipRule"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="BinaryRelationshipRule"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="BinaryRelationshipRule"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this BinaryRelationshipRule me, BinaryRelationshipRule other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (me.ForwardRelationshipName == null && other.ForwardRelationshipName != null) return false;
+            if (me.ForwardRelationshipName != null && !me.ForwardRelationshipName.Equals(other.ForwardRelationshipName)) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (me.InverseRelationshipName == null && other.InverseRelationshipName != null) return false;
+            if (me.InverseRelationshipName != null && !me.InverseRelationshipName.Equals(other.InverseRelationshipName)) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.RelationshipCategory.Equals(other.RelationshipCategory)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.SourceCategory.Equals(other.SourceCategory)) return false;
+
+            if (!me.TargetCategory.Equals(other.TargetCategory)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/BookEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/BookEquatable.cs
@@ -1,0 +1,116 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BookEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 3     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.1.0  |
+ | 8     | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 9     | section                              | Guid                         | 0..*        |  1.1.0  |
+ | 10    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Book"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class BookEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Book"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Book"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Book"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Book"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Book me, Book other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.Section.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.Section.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.Section.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.Section.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/BooleanParameterTypeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/BooleanParameterTypeEquatable.cs
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BooleanParameterTypeEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | symbol                               | string                       | 1..1        |  1.0.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="BooleanParameterType"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class BooleanParameterTypeEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="BooleanParameterType"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="BooleanParameterType"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="BooleanParameterType"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="BooleanParameterType"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this BooleanParameterType me, BooleanParameterType other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Symbol == null && other.Symbol != null) return false;
+            if (me.Symbol != null && !me.Symbol.Equals(other.Symbol)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/BoundsEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/BoundsEquatable.cs
@@ -1,0 +1,111 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BoundsEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | height                               | float                        | 1..1        |  1.1.0  |
+ | 5     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 6     | name                                 | string                       | 1..1        |  1.1.0  |
+ | 7     | width                                | float                        | 1..1        |  1.1.0  |
+ | 8     | x                                    | float                        | 1..1        |  1.1.0  |
+ | 9     | y                                    | float                        | 1..1        |  1.1.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Bounds"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class BoundsEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Bounds"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Bounds"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Bounds"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Bounds"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Bounds me, Bounds other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.Height.Equals(other.Height)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Width.Equals(other.Width)) return false;
+
+            if (!me.X.Equals(other.X)) return false;
+
+            if (!me.Y.Equals(other.Y)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/BuiltInRuleVerificationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/BuiltInRuleVerificationEquatable.cs
@@ -81,7 +81,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
 
-            if (!me.ExecutedOn.HasValue && other.ExecutedOn.HasValue) return false;
+            if (me.ExecutedOn.HasValue != other.ExecutedOn.HasValue) return false;
             if (!me.ExecutedOn.Equals(other.ExecutedOn)) return false;
 
             if (!me.IsActive.Equals(other.IsActive)) return false;

--- a/CDP4Common/AutoGenEquatable/BuiltInRuleVerificationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/BuiltInRuleVerificationEquatable.cs
@@ -1,0 +1,112 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BuiltInRuleVerificationEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | executedOn                           | DateTime                     | 0..1        |  1.0.0  |
+ | 3     | isActive                             | bool                         | 1..1        |  1.0.0  |
+ | 4     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 5     | status                               | RuleVerificationStatusKind   | 1..1        |  1.0.0  |
+ | 6     | violation                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="BuiltInRuleVerification"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class BuiltInRuleVerificationEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="BuiltInRuleVerification"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="BuiltInRuleVerification"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="BuiltInRuleVerification"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="BuiltInRuleVerification"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this BuiltInRuleVerification me, BuiltInRuleVerification other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExecutedOn.HasValue && other.ExecutedOn.HasValue) return false;
+            if (!me.ExecutedOn.Equals(other.ExecutedOn)) return false;
+
+            if (!me.IsActive.Equals(other.IsActive)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Status.Equals(other.Status)) return false;
+
+            if (!me.Violation.OrderBy(x => x).SequenceEqual(other.Violation.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/CategoryEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/CategoryEquatable.cs
@@ -1,0 +1,124 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="CategoryEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isAbstract                           | bool                         | 1..1        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | permissibleClass                     | ClassKind                    | 1..*        |  1.0.0  |
+ | 9     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 10    | superCategory                        | Guid                         | 0..*        |  1.0.0  |
+ | 11    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 13    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 14    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Category"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class CategoryEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Category"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Category"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Category"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Category"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Category me, Category other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsAbstract.Equals(other.IsAbstract)) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.PermissibleClass.OrderBy(x => x).SequenceEqual(other.PermissibleClass.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.SuperCategory.OrderBy(x => x).SequenceEqual(other.SuperCategory.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ChangeProposalEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ChangeProposalEquatable.cs
@@ -1,0 +1,148 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ChangeProposalEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | approvedBy                           | Guid                         | 0..*        |  1.1.0  |
+ | 3     | author                               | Guid                         | 1..1        |  1.1.0  |
+ | 4     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 5     | changeRequest                        | Guid                         | 1..1        |  1.1.0  |
+ | 6     | classification                       | AnnotationClassificationKind | 1..1        |  1.1.0  |
+ | 7     | content                              | string                       | 1..1        |  1.1.0  |
+ | 8     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | discussion                           | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 13    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 14    | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 15    | primaryAnnotatedThing                | Guid                         | 0..1        |  1.1.0  |
+ | 16    | relatedThing                         | Guid                         | 0..*        |  1.1.0  |
+ | 17    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 18    | sourceAnnotation                     | Guid                         | 0..*        |  1.1.0  |
+ | 19    | status                               | AnnotationStatusKind         | 1..1        |  1.1.0  |
+ | 20    | title                                | string                       | 1..1        |  1.1.0  |
+ | 21    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ChangeProposal"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ChangeProposalEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ChangeProposal"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ChangeProposal"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ChangeProposal"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ChangeProposal"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ChangeProposal me, ChangeProposal other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ApprovedBy.OrderBy(x => x).SequenceEqual(other.ApprovedBy.OrderBy(x => x))) return false;
+
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.ChangeRequest.Equals(other.ChangeRequest)) return false;
+
+            if (!me.Classification.Equals(other.Classification)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.Discussion.OrderBy(x => x).SequenceEqual(other.Discussion.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
+
+            if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.SourceAnnotation.OrderBy(x => x).SequenceEqual(other.SourceAnnotation.OrderBy(x => x))) return false;
+
+            if (!me.Status.Equals(other.Status)) return false;
+
+            if (me.Title == null && other.Title != null) return false;
+            if (me.Title != null && !me.Title.Equals(other.Title)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ChangeProposalEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ChangeProposalEquatable.cs
@@ -120,7 +120,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Owner.Equals(other.Owner)) return false;
 
-            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (me.PrimaryAnnotatedThing.HasValue != other.PrimaryAnnotatedThing.HasValue) return false;
             if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
 
             if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/ChangeRequestEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ChangeRequestEquatable.cs
@@ -117,7 +117,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Owner.Equals(other.Owner)) return false;
 
-            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (me.PrimaryAnnotatedThing.HasValue != other.PrimaryAnnotatedThing.HasValue) return false;
             if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
 
             if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/ChangeRequestEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ChangeRequestEquatable.cs
@@ -1,0 +1,145 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ChangeRequestEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | approvedBy                           | Guid                         | 0..*        |  1.1.0  |
+ | 3     | author                               | Guid                         | 1..1        |  1.1.0  |
+ | 4     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 5     | classification                       | AnnotationClassificationKind | 1..1        |  1.1.0  |
+ | 6     | content                              | string                       | 1..1        |  1.1.0  |
+ | 7     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | discussion                           | Guid                         | 0..*        |  1.1.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 14    | primaryAnnotatedThing                | Guid                         | 0..1        |  1.1.0  |
+ | 15    | relatedThing                         | Guid                         | 0..*        |  1.1.0  |
+ | 16    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 17    | sourceAnnotation                     | Guid                         | 0..*        |  1.1.0  |
+ | 18    | status                               | AnnotationStatusKind         | 1..1        |  1.1.0  |
+ | 19    | title                                | string                       | 1..1        |  1.1.0  |
+ | 20    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ChangeRequest"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ChangeRequestEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ChangeRequest"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ChangeRequest"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ChangeRequest"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ChangeRequest"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ChangeRequest me, ChangeRequest other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ApprovedBy.OrderBy(x => x).SequenceEqual(other.ApprovedBy.OrderBy(x => x))) return false;
+
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Classification.Equals(other.Classification)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.Discussion.OrderBy(x => x).SequenceEqual(other.Discussion.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
+
+            if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.SourceAnnotation.OrderBy(x => x).SequenceEqual(other.SourceAnnotation.OrderBy(x => x))) return false;
+
+            if (!me.Status.Equals(other.Status)) return false;
+
+            if (me.Title == null && other.Title != null) return false;
+            if (me.Title != null && !me.Title.Equals(other.Title)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/CitationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/CitationEquatable.cs
@@ -1,0 +1,113 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="CitationEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | isAdaptation                         | bool                         | 1..1        |  1.0.0  |
+ | 3     | location                             | string                       | 0..1        |  1.0.0  |
+ | 4     | remark                               | string                       | 0..1        |  1.0.0  |
+ | 5     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 6     | source                               | Guid                         | 1..1        |  1.0.0  |
+ | 7     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Citation"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class CitationEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Citation"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Citation"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Citation"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Citation"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Citation me, Citation other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.IsAdaptation.Equals(other.IsAdaptation)) return false;
+
+            if (me.Location == null && other.Location != null) return false;
+            if (me.Location != null && !me.Location.Equals(other.Location)) return false;
+
+            if (me.Remark == null && other.Remark != null) return false;
+            if (me.Remark != null && !me.Remark.Equals(other.Remark)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.Source.Equals(other.Source)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ColorEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ColorEquatable.cs
@@ -1,0 +1,108 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ColorEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | blue                                 | int                          | 1..1        |  1.0.0  |
+ | 3     | green                                | int                          | 1..1        |  1.0.0  |
+ | 4     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 5     | red                                  | int                          | 1..1        |  1.0.0  |
+ | 6     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Color"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ColorEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Color"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Color"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Color"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Color"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Color me, Color other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Blue.Equals(other.Blue)) return false;
+
+            if (!me.Green.Equals(other.Green)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Red.Equals(other.Red)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/CommonFileStoreEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/CommonFileStoreEquatable.cs
@@ -1,0 +1,111 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="CommonFileStoreEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | createdOn                            | DateTime                     | 1..1        |  1.0.0  |
+ | 3     | file                                 | Guid                         | 0..*        |  1.0.0  |
+ | 4     | folder                               | Guid                         | 0..*        |  1.0.0  |
+ | 5     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 6     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 7     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="CommonFileStore"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class CommonFileStoreEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="CommonFileStore"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="CommonFileStore"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="CommonFileStore"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="CommonFileStore"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this CommonFileStore me, CommonFileStore other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.File.OrderBy(x => x).SequenceEqual(other.File.OrderBy(x => x))) return false;
+
+            if (!me.Folder.OrderBy(x => x).SequenceEqual(other.Folder.OrderBy(x => x))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/CompoundParameterTypeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/CompoundParameterTypeEquatable.cs
@@ -1,0 +1,129 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="CompoundParameterTypeEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | component                            | Guid                         | 1..*        |  1.0.0  |
+ | 5     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 6     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 8     | isFinalized                          | bool                         | 1..1        |  1.0.0  |
+ | 9     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 10    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 11    | symbol                               | string                       | 1..1        |  1.0.0  |
+ | 12    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 13    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 15    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="CompoundParameterType"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class CompoundParameterTypeEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="CompoundParameterType"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="CompoundParameterType"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="CompoundParameterType"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="CompoundParameterType"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this CompoundParameterType me, CompoundParameterType other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Component.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.Component.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.Component.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.Component.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.IsFinalized.Equals(other.IsFinalized)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Symbol == null && other.Symbol != null) return false;
+            if (me.Symbol != null && !me.Symbol.Equals(other.Symbol)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ConstantEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ConstantEquatable.cs
@@ -101,7 +101,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ParameterType.Equals(other.ParameterType)) return false;
 
-            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (me.Scale.HasValue != other.Scale.HasValue) return false;
             if (!me.Scale.Equals(other.Scale)) return false;
 
             if (me.ShortName == null && other.ShortName != null) return false;

--- a/CDP4Common/AutoGenEquatable/ConstantEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ConstantEquatable.cs
@@ -1,0 +1,128 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ConstantEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | parameterType                        | Guid                         | 1..1        |  1.0.0  |
+ | 9     | scale                                | Guid                         | 0..1        |  1.0.0  |
+ | 10    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 11    | value                                | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 12    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 13    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 15    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Constant"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ConstantEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Constant"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Constant"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Constant"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Constant"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Constant me, Constant other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.ParameterType.Equals(other.ParameterType)) return false;
+
+            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (!me.Scale.Equals(other.Scale)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.Value.SequenceEqual(other.Value)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ContractChangeNoticeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ContractChangeNoticeEquatable.cs
@@ -1,0 +1,148 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ContractChangeNoticeEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | approvedBy                           | Guid                         | 0..*        |  1.1.0  |
+ | 3     | author                               | Guid                         | 1..1        |  1.1.0  |
+ | 4     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 5     | changeProposal                       | Guid                         | 1..1        |  1.1.0  |
+ | 6     | classification                       | AnnotationClassificationKind | 1..1        |  1.1.0  |
+ | 7     | content                              | string                       | 1..1        |  1.1.0  |
+ | 8     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | discussion                           | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 13    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 14    | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 15    | primaryAnnotatedThing                | Guid                         | 0..1        |  1.1.0  |
+ | 16    | relatedThing                         | Guid                         | 0..*        |  1.1.0  |
+ | 17    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 18    | sourceAnnotation                     | Guid                         | 0..*        |  1.1.0  |
+ | 19    | status                               | AnnotationStatusKind         | 1..1        |  1.1.0  |
+ | 20    | title                                | string                       | 1..1        |  1.1.0  |
+ | 21    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ContractChangeNotice"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ContractChangeNoticeEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ContractChangeNotice"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ContractChangeNotice"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ContractChangeNotice"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ContractChangeNotice"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ContractChangeNotice me, ContractChangeNotice other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ApprovedBy.OrderBy(x => x).SequenceEqual(other.ApprovedBy.OrderBy(x => x))) return false;
+
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.ChangeProposal.Equals(other.ChangeProposal)) return false;
+
+            if (!me.Classification.Equals(other.Classification)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.Discussion.OrderBy(x => x).SequenceEqual(other.Discussion.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
+
+            if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.SourceAnnotation.OrderBy(x => x).SequenceEqual(other.SourceAnnotation.OrderBy(x => x))) return false;
+
+            if (!me.Status.Equals(other.Status)) return false;
+
+            if (me.Title == null && other.Title != null) return false;
+            if (me.Title != null && !me.Title.Equals(other.Title)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ContractChangeNoticeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ContractChangeNoticeEquatable.cs
@@ -120,7 +120,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Owner.Equals(other.Owner)) return false;
 
-            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (me.PrimaryAnnotatedThing.HasValue != other.PrimaryAnnotatedThing.HasValue) return false;
             if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
 
             if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/CyclicRatioScaleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/CyclicRatioScaleEquatable.cs
@@ -1,0 +1,153 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="CyclicRatioScaleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 6     | isMaximumInclusive                   | bool                         | 1..1        |  1.0.0  |
+ | 7     | isMinimumInclusive                   | bool                         | 1..1        |  1.0.0  |
+ | 8     | mappingToReferenceScale              | Guid                         | 0..*        |  1.0.0  |
+ | 9     | maximumPermissibleValue              | string                       | 0..1        |  1.0.0  |
+ | 10    | minimumPermissibleValue              | string                       | 0..1        |  1.0.0  |
+ | 11    | modulus                              | string                       | 1..1        |  1.0.0  |
+ | 12    | name                                 | string                       | 1..1        |  1.0.0  |
+ | 13    | negativeValueConnotation             | string                       | 0..1        |  1.0.0  |
+ | 14    | numberSet                            | NumberSetKind                | 1..1        |  1.0.0  |
+ | 15    | positiveValueConnotation             | string                       | 0..1        |  1.0.0  |
+ | 16    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 17    | unit                                 | Guid                         | 1..1        |  1.0.0  |
+ | 18    | valueDefinition                      | Guid                         | 0..*        |  1.0.0  |
+ | 19    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 20    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 21    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 22    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="CyclicRatioScale"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class CyclicRatioScaleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="CyclicRatioScale"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="CyclicRatioScale"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="CyclicRatioScale"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="CyclicRatioScale"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this CyclicRatioScale me, CyclicRatioScale other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.IsMaximumInclusive.Equals(other.IsMaximumInclusive)) return false;
+
+            if (!me.IsMinimumInclusive.Equals(other.IsMinimumInclusive)) return false;
+
+            if (!me.MappingToReferenceScale.OrderBy(x => x).SequenceEqual(other.MappingToReferenceScale.OrderBy(x => x))) return false;
+
+            if (me.MaximumPermissibleValue == null && other.MaximumPermissibleValue != null) return false;
+            if (me.MaximumPermissibleValue != null && !me.MaximumPermissibleValue.Equals(other.MaximumPermissibleValue)) return false;
+
+            if (me.MinimumPermissibleValue == null && other.MinimumPermissibleValue != null) return false;
+            if (me.MinimumPermissibleValue != null && !me.MinimumPermissibleValue.Equals(other.MinimumPermissibleValue)) return false;
+
+            if (me.Modulus == null && other.Modulus != null) return false;
+            if (me.Modulus != null && !me.Modulus.Equals(other.Modulus)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.NegativeValueConnotation == null && other.NegativeValueConnotation != null) return false;
+            if (me.NegativeValueConnotation != null && !me.NegativeValueConnotation.Equals(other.NegativeValueConnotation)) return false;
+
+            if (!me.NumberSet.Equals(other.NumberSet)) return false;
+
+            if (me.PositiveValueConnotation == null && other.PositiveValueConnotation != null) return false;
+            if (me.PositiveValueConnotation != null && !me.PositiveValueConnotation.Equals(other.PositiveValueConnotation)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.Unit.Equals(other.Unit)) return false;
+
+            if (!me.ValueDefinition.OrderBy(x => x).SequenceEqual(other.ValueDefinition.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/DateParameterTypeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DateParameterTypeEquatable.cs
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DateParameterTypeEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | symbol                               | string                       | 1..1        |  1.0.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="DateParameterType"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class DateParameterTypeEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="DateParameterType"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="DateParameterType"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="DateParameterType"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="DateParameterType"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this DateParameterType me, DateParameterType other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Symbol == null && other.Symbol != null) return false;
+            if (me.Symbol != null && !me.Symbol.Equals(other.Symbol)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/DateTimeParameterTypeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DateTimeParameterTypeEquatable.cs
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DateTimeParameterTypeEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | symbol                               | string                       | 1..1        |  1.0.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="DateTimeParameterType"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class DateTimeParameterTypeEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="DateTimeParameterType"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="DateTimeParameterType"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="DateTimeParameterType"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="DateTimeParameterType"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this DateTimeParameterType me, DateTimeParameterType other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Symbol == null && other.Symbol != null) return false;
+            if (me.Symbol != null && !me.Symbol.Equals(other.Symbol)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/DecompositionRuleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DecompositionRuleEquatable.cs
@@ -98,7 +98,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
 
-            if (!me.MaxContained.HasValue && other.MaxContained.HasValue) return false;
+            if (me.MaxContained.HasValue != other.MaxContained.HasValue) return false;
             if (!me.MaxContained.Equals(other.MaxContained)) return false;
 
             if (!me.MinContained.Equals(other.MinContained)) return false;

--- a/CDP4Common/AutoGenEquatable/DecompositionRuleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DecompositionRuleEquatable.cs
@@ -1,0 +1,128 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DecompositionRuleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | containedCategory                    | Guid                         | 1..*        |  1.0.0  |
+ | 4     | containingCategory                   | Guid                         | 1..1        |  1.0.0  |
+ | 5     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 6     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 8     | maxContained                         | int                          | 0..1        |  1.0.0  |
+ | 9     | minContained                         | int                          | 1..1        |  1.0.0  |
+ | 10    | name                                 | string                       | 1..1        |  1.0.0  |
+ | 11    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 12    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 13    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 15    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="DecompositionRule"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class DecompositionRuleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="DecompositionRule"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="DecompositionRule"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="DecompositionRule"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="DecompositionRule"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this DecompositionRule me, DecompositionRule other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.ContainedCategory.OrderBy(x => x).SequenceEqual(other.ContainedCategory.OrderBy(x => x))) return false;
+
+            if (!me.ContainingCategory.Equals(other.ContainingCategory)) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.MaxContained.HasValue && other.MaxContained.HasValue) return false;
+            if (!me.MaxContained.Equals(other.MaxContained)) return false;
+
+            if (!me.MinContained.Equals(other.MinContained)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/DefinitionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DefinitionEquatable.cs
@@ -1,0 +1,114 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DefinitionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | citation                             | Guid                         | 0..*        |  1.0.0  |
+ | 3     | content                              | string                       | 1..1        |  1.0.0  |
+ | 4     | example                              | string                       | 0..*        |  1.0.0  |
+ | 5     | languageCode                         | string                       | 1..1        |  1.0.0  |
+ | 6     | note                                 | string                       | 0..*        |  1.0.0  |
+ | 7     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Definition"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class DefinitionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Definition"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Definition"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Definition"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Definition"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Definition me, Definition other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Citation.OrderBy(x => x).SequenceEqual(other.Citation.OrderBy(x => x))) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.Example.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.Example.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.Example.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.Example.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.Note.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.Note.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.Note.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.Note.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/DependentParameterTypeAssignmentEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DependentParameterTypeAssignmentEquatable.cs
@@ -84,7 +84,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
 
-            if (!me.MeasurementScale.HasValue && other.MeasurementScale.HasValue) return false;
+            if (me.MeasurementScale.HasValue != other.MeasurementScale.HasValue) return false;
             if (!me.MeasurementScale.Equals(other.MeasurementScale)) return false;
 
             if (!me.ParameterType.Equals(other.ParameterType)) return false;

--- a/CDP4Common/AutoGenEquatable/DependentParameterTypeAssignmentEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DependentParameterTypeAssignmentEquatable.cs
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DependentParameterTypeAssignmentEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | measurementScale                     | Guid                         | 0..1        |  1.2.0  |
+ | 6     | parameterType                        | Guid                         | 1..1        |  1.2.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="DependentParameterTypeAssignment"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class DependentParameterTypeAssignmentEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="DependentParameterTypeAssignment"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="DependentParameterTypeAssignment"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="DependentParameterTypeAssignment"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="DependentParameterTypeAssignment"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this DependentParameterTypeAssignment me, DependentParameterTypeAssignment other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.MeasurementScale.HasValue && other.MeasurementScale.HasValue) return false;
+            if (!me.MeasurementScale.Equals(other.MeasurementScale)) return false;
+
+            if (!me.ParameterType.Equals(other.ParameterType)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/DerivedQuantityKindEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DerivedQuantityKindEquatable.cs
@@ -1,0 +1,136 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DerivedQuantityKindEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | defaultScale                         | Guid                         | 1..1        |  1.0.0  |
+ | 5     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 6     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 8     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 9     | possibleScale                        | Guid                         | 0..*        |  1.0.0  |
+ | 10    | quantityDimensionSymbol              | string                       | 0..1        |  1.0.0  |
+ | 11    | quantityKindFactor                   | Guid                         | 1..*        |  1.0.0  |
+ | 12    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 13    | symbol                               | string                       | 1..1        |  1.0.0  |
+ | 14    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 15    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 16    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 17    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="DerivedQuantityKind"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class DerivedQuantityKindEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="DerivedQuantityKind"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="DerivedQuantityKind"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="DerivedQuantityKind"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="DerivedQuantityKind"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this DerivedQuantityKind me, DerivedQuantityKind other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.DefaultScale.Equals(other.DefaultScale)) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.PossibleScale.OrderBy(x => x).SequenceEqual(other.PossibleScale.OrderBy(x => x))) return false;
+
+            if (me.QuantityDimensionSymbol == null && other.QuantityDimensionSymbol != null) return false;
+            if (me.QuantityDimensionSymbol != null && !me.QuantityDimensionSymbol.Equals(other.QuantityDimensionSymbol)) return false;
+
+            if (!me.QuantityKindFactor.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.QuantityKindFactor.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.QuantityKindFactor.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.QuantityKindFactor.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Symbol == null && other.Symbol != null) return false;
+            if (me.Symbol != null && !me.Symbol.Equals(other.Symbol)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/DerivedUnitEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DerivedUnitEquatable.cs
@@ -1,0 +1,119 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DerivedUnitEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 6     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 7     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 8     | unitFactor                           | Guid                         | 1..*        |  1.0.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="DerivedUnit"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class DerivedUnitEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="DerivedUnit"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="DerivedUnit"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="DerivedUnit"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="DerivedUnit"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this DerivedUnit me, DerivedUnit other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.UnitFactor.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.UnitFactor.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.UnitFactor.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.UnitFactor.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/DiagramCanvasEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DiagramCanvasEquatable.cs
@@ -1,0 +1,108 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DiagramCanvasEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | bounds                               | Guid                         | 0..1        |  1.1.0  |
+ | 3     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 4     | diagramElement                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | name                                 | string                       | 1..1        |  1.1.0  |
+ | 9     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="DiagramCanvas"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class DiagramCanvasEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="DiagramCanvas"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="DiagramCanvas"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="DiagramCanvas"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="DiagramCanvas"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this DiagramCanvas me, DiagramCanvas other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Bounds.OrderBy(x => x).SequenceEqual(other.Bounds.OrderBy(x => x))) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.DiagramElement.OrderBy(x => x).SequenceEqual(other.DiagramElement.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/DiagramEdgeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DiagramEdgeEquatable.cs
@@ -87,7 +87,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Bounds.OrderBy(x => x).SequenceEqual(other.Bounds.OrderBy(x => x))) return false;
 
-            if (!me.DepictedThing.HasValue && other.DepictedThing.HasValue) return false;
+            if (me.DepictedThing.HasValue != other.DepictedThing.HasValue) return false;
             if (!me.DepictedThing.Equals(other.DepictedThing)) return false;
 
             if (!me.DiagramElement.OrderBy(x => x).SequenceEqual(other.DiagramElement.OrderBy(x => x))) return false;
@@ -106,7 +106,7 @@ namespace CDP4Common.DTO.Equatable
             if (!me.Point.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.Point.OrderBy(x => x.K).Select(x => x.K))) return false;
             if (!me.Point.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.Point.OrderBy(x => x.K).Select(x => x.V))) return false;
 
-            if (!me.SharedStyle.HasValue && other.SharedStyle.HasValue) return false;
+            if (me.SharedStyle.HasValue != other.SharedStyle.HasValue) return false;
             if (!me.SharedStyle.Equals(other.SharedStyle)) return false;
 
             if (!me.Source.Equals(other.Source)) return false;

--- a/CDP4Common/AutoGenEquatable/DiagramEdgeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DiagramEdgeEquatable.cs
@@ -1,0 +1,126 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DiagramEdgeEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | bounds                               | Guid                         | 0..1        |  1.1.0  |
+ | 3     | depictedThing                        | Guid                         | 0..1        |  1.1.0  |
+ | 4     | diagramElement                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | localStyle                           | Guid                         | 0..1        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | name                                 | string                       | 1..1        |  1.1.0  |
+ | 10    | point                                | Guid                         | 0..*        |  1.1.0  |
+ | 11    | sharedStyle                          | Guid                         | 0..1        |  1.1.0  |
+ | 12    | source                               | Guid                         | 1..1        |  1.1.0  |
+ | 13    | target                               | Guid                         | 1..1        |  1.1.0  |
+ | 14    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="DiagramEdge"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class DiagramEdgeEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="DiagramEdge"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="DiagramEdge"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="DiagramEdge"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="DiagramEdge"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this DiagramEdge me, DiagramEdge other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Bounds.OrderBy(x => x).SequenceEqual(other.Bounds.OrderBy(x => x))) return false;
+
+            if (!me.DepictedThing.HasValue && other.DepictedThing.HasValue) return false;
+            if (!me.DepictedThing.Equals(other.DepictedThing)) return false;
+
+            if (!me.DiagramElement.OrderBy(x => x).SequenceEqual(other.DiagramElement.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.LocalStyle.OrderBy(x => x).SequenceEqual(other.LocalStyle.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Point.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.Point.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.Point.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.Point.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.SharedStyle.HasValue && other.SharedStyle.HasValue) return false;
+            if (!me.SharedStyle.Equals(other.SharedStyle)) return false;
+
+            if (!me.Source.Equals(other.Source)) return false;
+
+            if (!me.Target.Equals(other.Target)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/DiagramObjectEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DiagramObjectEquatable.cs
@@ -1,0 +1,123 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DiagramObjectEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | bounds                               | Guid                         | 0..1        |  1.1.0  |
+ | 3     | depictedThing                        | Guid                         | 0..1        |  1.1.0  |
+ | 4     | diagramElement                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | documentation                        | string                       | 1..1        |  1.1.0  |
+ | 6     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | localStyle                           | Guid                         | 0..1        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | name                                 | string                       | 1..1        |  1.1.0  |
+ | 11    | resolution                           | float                        | 1..1        |  1.1.0  |
+ | 12    | sharedStyle                          | Guid                         | 0..1        |  1.1.0  |
+ | 13    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="DiagramObject"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class DiagramObjectEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="DiagramObject"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="DiagramObject"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="DiagramObject"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="DiagramObject"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this DiagramObject me, DiagramObject other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Bounds.OrderBy(x => x).SequenceEqual(other.Bounds.OrderBy(x => x))) return false;
+
+            if (!me.DepictedThing.HasValue && other.DepictedThing.HasValue) return false;
+            if (!me.DepictedThing.Equals(other.DepictedThing)) return false;
+
+            if (!me.DiagramElement.OrderBy(x => x).SequenceEqual(other.DiagramElement.OrderBy(x => x))) return false;
+
+            if (me.Documentation == null && other.Documentation != null) return false;
+            if (me.Documentation != null && !me.Documentation.Equals(other.Documentation)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.LocalStyle.OrderBy(x => x).SequenceEqual(other.LocalStyle.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Resolution.Equals(other.Resolution)) return false;
+
+            if (!me.SharedStyle.HasValue && other.SharedStyle.HasValue) return false;
+            if (!me.SharedStyle.Equals(other.SharedStyle)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/DiagramObjectEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DiagramObjectEquatable.cs
@@ -86,7 +86,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Bounds.OrderBy(x => x).SequenceEqual(other.Bounds.OrderBy(x => x))) return false;
 
-            if (!me.DepictedThing.HasValue && other.DepictedThing.HasValue) return false;
+            if (me.DepictedThing.HasValue != other.DepictedThing.HasValue) return false;
             if (!me.DepictedThing.Equals(other.DepictedThing)) return false;
 
             if (!me.DiagramElement.OrderBy(x => x).SequenceEqual(other.DiagramElement.OrderBy(x => x))) return false;
@@ -107,7 +107,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Resolution.Equals(other.Resolution)) return false;
 
-            if (!me.SharedStyle.HasValue && other.SharedStyle.HasValue) return false;
+            if (me.SharedStyle.HasValue != other.SharedStyle.HasValue) return false;
             if (!me.SharedStyle.Equals(other.SharedStyle)) return false;
 
             if (me.ThingPreference == null && other.ThingPreference != null) return false;

--- a/CDP4Common/AutoGenEquatable/DomainFileStoreEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DomainFileStoreEquatable.cs
@@ -1,0 +1,114 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DomainFileStoreEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | createdOn                            | DateTime                     | 1..1        |  1.0.0  |
+ | 3     | file                                 | Guid                         | 0..*        |  1.0.0  |
+ | 4     | folder                               | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isHidden                             | bool                         | 1..1        |  1.0.0  |
+ | 6     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 7     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 8     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="DomainFileStore"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class DomainFileStoreEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="DomainFileStore"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="DomainFileStore"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="DomainFileStore"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="DomainFileStore"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this DomainFileStore me, DomainFileStore other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.File.OrderBy(x => x).SequenceEqual(other.File.OrderBy(x => x))) return false;
+
+            if (!me.Folder.OrderBy(x => x).SequenceEqual(other.Folder.OrderBy(x => x))) return false;
+
+            if (!me.IsHidden.Equals(other.IsHidden)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/DomainOfExpertiseEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DomainOfExpertiseEquatable.cs
@@ -1,0 +1,118 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DomainOfExpertiseEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="DomainOfExpertise"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class DomainOfExpertiseEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="DomainOfExpertise"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="DomainOfExpertise"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="DomainOfExpertise"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="DomainOfExpertise"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this DomainOfExpertise me, DomainOfExpertise other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/DomainOfExpertiseGroupEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/DomainOfExpertiseGroupEquatable.cs
@@ -1,0 +1,118 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DomainOfExpertiseGroupEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | domain                               | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="DomainOfExpertiseGroup"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class DomainOfExpertiseGroupEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="DomainOfExpertiseGroup"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="DomainOfExpertiseGroup"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="DomainOfExpertiseGroup"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="DomainOfExpertiseGroup"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this DomainOfExpertiseGroup me, DomainOfExpertiseGroup other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.Domain.OrderBy(x => x).SequenceEqual(other.Domain.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ElementDefinitionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ElementDefinitionEquatable.cs
@@ -1,0 +1,133 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ElementDefinitionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | containedElement                     | Guid                         | 0..*        |  1.0.0  |
+ | 5     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 6     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 9     | parameter                            | Guid                         | 0..*        |  1.0.0  |
+ | 10    | parameterGroup                       | Guid                         | 0..*        |  1.0.0  |
+ | 11    | referencedElement                    | Guid                         | 0..*        |  1.0.0  |
+ | 12    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 13    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 15    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 16    | organizationalParticipant            | Guid                         | 0..*        |  1.2.0  |
+ | 17    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ElementDefinition"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ElementDefinitionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ElementDefinition"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ElementDefinition"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ElementDefinition"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ElementDefinition"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ElementDefinition me, ElementDefinition other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.ContainedElement.OrderBy(x => x).SequenceEqual(other.ContainedElement.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.Parameter.OrderBy(x => x).SequenceEqual(other.Parameter.OrderBy(x => x))) return false;
+
+            if (!me.ParameterGroup.OrderBy(x => x).SequenceEqual(other.ParameterGroup.OrderBy(x => x))) return false;
+
+            if (!me.ReferencedElement.OrderBy(x => x).SequenceEqual(other.ReferencedElement.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.OrganizationalParticipant.OrderBy(x => x).SequenceEqual(other.OrganizationalParticipant.OrderBy(x => x))) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ElementUsageEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ElementUsageEquatable.cs
@@ -1,0 +1,130 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ElementUsageEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | elementDefinition                    | Guid                         | 1..1        |  1.0.0  |
+ | 6     | excludeOption                        | Guid                         | 0..*        |  1.0.0  |
+ | 7     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 8     | interfaceEnd                         | InterfaceEndKind             | 1..1        |  1.0.0  |
+ | 9     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 10    | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 11    | parameterOverride                    | Guid                         | 0..*        |  1.0.0  |
+ | 12    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 13    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 15    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 16    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ElementUsage"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ElementUsageEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ElementUsage"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ElementUsage"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ElementUsage"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ElementUsage"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ElementUsage me, ElementUsage other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.ElementDefinition.Equals(other.ElementDefinition)) return false;
+
+            if (!me.ExcludeOption.OrderBy(x => x).SequenceEqual(other.ExcludeOption.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.InterfaceEnd.Equals(other.InterfaceEnd)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.ParameterOverride.OrderBy(x => x).SequenceEqual(other.ParameterOverride.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/EmailAddressEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/EmailAddressEquatable.cs
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EmailAddressEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | value                                | string                       | 1..1        |  1.0.0  |
+ | 3     | vcardType                            | VcardEmailAddressKind        | 1..1        |  1.0.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="EmailAddress"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class EmailAddressEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="EmailAddress"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="EmailAddress"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="EmailAddress"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="EmailAddress"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this EmailAddress me, EmailAddress other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (me.Value == null && other.Value != null) return false;
+            if (me.Value != null && !me.Value.Equals(other.Value)) return false;
+
+            if (!me.VcardType.Equals(other.VcardType)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/EngineeringModelDataDiscussionItemEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/EngineeringModelDataDiscussionItemEquatable.cs
@@ -97,7 +97,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
 
-            if (!me.ReplyTo.HasValue && other.ReplyTo.HasValue) return false;
+            if (me.ReplyTo.HasValue != other.ReplyTo.HasValue) return false;
             if (!me.ReplyTo.Equals(other.ReplyTo)) return false;
 
             if (me.ThingPreference == null && other.ThingPreference != null) return false;

--- a/CDP4Common/AutoGenEquatable/EngineeringModelDataDiscussionItemEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/EngineeringModelDataDiscussionItemEquatable.cs
@@ -1,0 +1,113 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EngineeringModelDataDiscussionItemEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | author                               | Guid                         | 1..1        |  1.1.0  |
+ | 3     | content                              | string                       | 1..1        |  1.1.0  |
+ | 4     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | replyTo                              | Guid                         | 0..1        |  1.1.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="EngineeringModelDataDiscussionItem"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class EngineeringModelDataDiscussionItemEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="EngineeringModelDataDiscussionItem"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="EngineeringModelDataDiscussionItem"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="EngineeringModelDataDiscussionItem"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="EngineeringModelDataDiscussionItem"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this EngineeringModelDataDiscussionItem me, EngineeringModelDataDiscussionItem other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.ReplyTo.HasValue && other.ReplyTo.HasValue) return false;
+            if (!me.ReplyTo.Equals(other.ReplyTo)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/EngineeringModelDataNoteEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/EngineeringModelDataNoteEquatable.cs
@@ -101,7 +101,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
 
-            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (me.PrimaryAnnotatedThing.HasValue != other.PrimaryAnnotatedThing.HasValue) return false;
             if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
 
             if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/EngineeringModelDataNoteEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/EngineeringModelDataNoteEquatable.cs
@@ -1,0 +1,119 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EngineeringModelDataNoteEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | author                               | Guid                         | 1..1        |  1.1.0  |
+ | 3     | content                              | string                       | 1..1        |  1.1.0  |
+ | 4     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | discussion                           | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | primaryAnnotatedThing                | Guid                         | 0..1        |  1.1.0  |
+ | 11    | relatedThing                         | Guid                         | 0..*        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="EngineeringModelDataNote"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class EngineeringModelDataNoteEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="EngineeringModelDataNote"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="EngineeringModelDataNote"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="EngineeringModelDataNote"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="EngineeringModelDataNote"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this EngineeringModelDataNote me, EngineeringModelDataNote other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.Discussion.OrderBy(x => x).SequenceEqual(other.Discussion.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
+
+            if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/EngineeringModelEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/EngineeringModelEquatable.cs
@@ -1,0 +1,120 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EngineeringModelEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | commonFileStore                      | Guid                         | 0..1        |  1.0.0  |
+ | 3     | engineeringModelSetup                | Guid                         | 1..1        |  1.0.0  |
+ | 4     | iteration                            | Guid                         | 1..*        |  1.0.0  |
+ | 5     | lastModifiedOn                       | DateTime                     | 1..1        |  1.0.0  |
+ | 6     | logEntry                             | Guid                         | 0..*        |  1.0.0  |
+ | 7     | book                                 | Guid                         | 0..*        |  1.1.0  |
+ | 8     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | genericNote                          | Guid                         | 0..*        |  1.1.0  |
+ | 11    | modellingAnnotation                  | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="EngineeringModel"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class EngineeringModelEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="EngineeringModel"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="EngineeringModel"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="EngineeringModel"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="EngineeringModel"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this EngineeringModel me, EngineeringModel other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.CommonFileStore.OrderBy(x => x).SequenceEqual(other.CommonFileStore.OrderBy(x => x))) return false;
+
+            if (!me.EngineeringModelSetup.Equals(other.EngineeringModelSetup)) return false;
+
+            if (!me.Iteration.OrderBy(x => x).SequenceEqual(other.Iteration.OrderBy(x => x))) return false;
+
+            if (!me.LastModifiedOn.Equals(other.LastModifiedOn)) return false;
+
+            if (!me.LogEntry.OrderBy(x => x).SequenceEqual(other.LogEntry.OrderBy(x => x))) return false;
+
+            if (!me.Book.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.Book.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.Book.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.Book.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.GenericNote.OrderBy(x => x).SequenceEqual(other.GenericNote.OrderBy(x => x))) return false;
+
+            if (!me.ModellingAnnotation.OrderBy(x => x).SequenceEqual(other.ModellingAnnotation.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/EngineeringModelSetupEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/EngineeringModelSetupEquatable.cs
@@ -115,7 +115,7 @@ namespace CDP4Common.DTO.Equatable
             if (me.ShortName == null && other.ShortName != null) return false;
             if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
 
-            if (!me.SourceEngineeringModelSetupIid.HasValue && other.SourceEngineeringModelSetupIid.HasValue) return false;
+            if (me.SourceEngineeringModelSetupIid.HasValue != other.SourceEngineeringModelSetupIid.HasValue) return false;
             if (!me.SourceEngineeringModelSetupIid.Equals(other.SourceEngineeringModelSetupIid)) return false;
 
             if (!me.StudyPhase.Equals(other.StudyPhase)) return false;
@@ -126,7 +126,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
 
-            if (!me.DefaultOrganizationalParticipant.HasValue && other.DefaultOrganizationalParticipant.HasValue) return false;
+            if (me.DefaultOrganizationalParticipant.HasValue != other.DefaultOrganizationalParticipant.HasValue) return false;
             if (!me.DefaultOrganizationalParticipant.Equals(other.DefaultOrganizationalParticipant)) return false;
 
             if (!me.OrganizationalParticipant.OrderBy(x => x).SequenceEqual(other.OrganizationalParticipant.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/EngineeringModelSetupEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/EngineeringModelSetupEquatable.cs
@@ -1,0 +1,144 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EngineeringModelSetupEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | activeDomain                         | Guid                         | 1..*        |  1.0.0  |
+ | 3     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | engineeringModelIid                  | Guid                         | 1..1        |  1.0.0  |
+ | 6     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | iterationSetup                       | Guid                         | 1..*        |  1.0.0  |
+ | 8     | kind                                 | EngineeringModelKind         | 1..1        |  1.0.0  |
+ | 9     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 10    | participant                          | Guid                         | 1..*        |  1.0.0  |
+ | 11    | requiredRdl                          | Guid                         | 1..1        |  1.0.0  |
+ | 12    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 13    | sourceEngineeringModelSetupIid       | Guid                         | 0..1        |  1.0.0  |
+ | 14    | studyPhase                           | StudyPhaseKind               | 1..1        |  1.0.0  |
+ | 15    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 16    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 17    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 18    | defaultOrganizationalParticipant     | Guid                         | 0..1        |  1.2.0  |
+ | 19    | organizationalParticipant            | Guid                         | 0..*        |  1.2.0  |
+ | 20    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="EngineeringModelSetup"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class EngineeringModelSetupEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="EngineeringModelSetup"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="EngineeringModelSetup"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="EngineeringModelSetup"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="EngineeringModelSetup"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this EngineeringModelSetup me, EngineeringModelSetup other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ActiveDomain.OrderBy(x => x).SequenceEqual(other.ActiveDomain.OrderBy(x => x))) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.EngineeringModelIid.Equals(other.EngineeringModelIid)) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IterationSetup.OrderBy(x => x).SequenceEqual(other.IterationSetup.OrderBy(x => x))) return false;
+
+            if (!me.Kind.Equals(other.Kind)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Participant.OrderBy(x => x).SequenceEqual(other.Participant.OrderBy(x => x))) return false;
+
+            if (!me.RequiredRdl.OrderBy(x => x).SequenceEqual(other.RequiredRdl.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.SourceEngineeringModelSetupIid.HasValue && other.SourceEngineeringModelSetupIid.HasValue) return false;
+            if (!me.SourceEngineeringModelSetupIid.Equals(other.SourceEngineeringModelSetupIid)) return false;
+
+            if (!me.StudyPhase.Equals(other.StudyPhase)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.DefaultOrganizationalParticipant.HasValue && other.DefaultOrganizationalParticipant.HasValue) return false;
+            if (!me.DefaultOrganizationalParticipant.Equals(other.DefaultOrganizationalParticipant)) return false;
+
+            if (!me.OrganizationalParticipant.OrderBy(x => x).SequenceEqual(other.OrganizationalParticipant.OrderBy(x => x))) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/EnumerationParameterTypeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/EnumerationParameterTypeEquatable.cs
@@ -1,0 +1,129 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EnumerationParameterTypeEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | allowMultiSelect                     | bool                         | 1..1        |  1.0.0  |
+ | 4     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 5     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 6     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 8     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 9     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 10    | symbol                               | string                       | 1..1        |  1.0.0  |
+ | 11    | valueDefinition                      | Guid                         | 1..*        |  1.0.0  |
+ | 12    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 13    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 15    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="EnumerationParameterType"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class EnumerationParameterTypeEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="EnumerationParameterType"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="EnumerationParameterType"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="EnumerationParameterType"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="EnumerationParameterType"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this EnumerationParameterType me, EnumerationParameterType other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.AllowMultiSelect.Equals(other.AllowMultiSelect)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Symbol == null && other.Symbol != null) return false;
+            if (me.Symbol != null && !me.Symbol.Equals(other.Symbol)) return false;
+
+            if (!me.ValueDefinition.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.ValueDefinition.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.ValueDefinition.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.ValueDefinition.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/EnumerationValueDefinitionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/EnumerationValueDefinitionEquatable.cs
@@ -1,0 +1,112 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EnumerationValueDefinitionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 6     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 7     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="EnumerationValueDefinition"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class EnumerationValueDefinitionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="EnumerationValueDefinition"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="EnumerationValueDefinition"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="EnumerationValueDefinition"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="EnumerationValueDefinition"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this EnumerationValueDefinition me, EnumerationValueDefinition other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ExclusiveOrExpressionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ExclusiveOrExpressionEquatable.cs
@@ -1,0 +1,98 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ExclusiveOrExpressionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | term                                 | Guid                         | 2..2        |  1.0.0  |
+ | 3     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 6     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ExclusiveOrExpression"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ExclusiveOrExpressionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ExclusiveOrExpression"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ExclusiveOrExpression"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ExclusiveOrExpression"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ExclusiveOrExpression"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ExclusiveOrExpression me, ExclusiveOrExpression other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Term.OrderBy(x => x).SequenceEqual(other.Term.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ExternalIdentifierMapEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ExternalIdentifierMapEquatable.cs
@@ -85,7 +85,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Correspondence.OrderBy(x => x).SequenceEqual(other.Correspondence.OrderBy(x => x))) return false;
 
-            if (!me.ExternalFormat.HasValue && other.ExternalFormat.HasValue) return false;
+            if (me.ExternalFormat.HasValue != other.ExternalFormat.HasValue) return false;
             if (!me.ExternalFormat.Equals(other.ExternalFormat)) return false;
 
             if (me.ExternalModelName == null && other.ExternalModelName != null) return false;

--- a/CDP4Common/AutoGenEquatable/ExternalIdentifierMapEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ExternalIdentifierMapEquatable.cs
@@ -1,0 +1,121 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ExternalIdentifierMapEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | correspondence                       | Guid                         | 0..*        |  1.0.0  |
+ | 3     | externalFormat                       | Guid                         | 0..1        |  1.0.0  |
+ | 4     | externalModelName                    | string                       | 1..1        |  1.0.0  |
+ | 5     | externalToolName                     | string                       | 1..1        |  1.0.0  |
+ | 6     | externalToolVersion                  | string                       | 0..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ExternalIdentifierMap"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ExternalIdentifierMapEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ExternalIdentifierMap"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ExternalIdentifierMap"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ExternalIdentifierMap"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ExternalIdentifierMap"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ExternalIdentifierMap me, ExternalIdentifierMap other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Correspondence.OrderBy(x => x).SequenceEqual(other.Correspondence.OrderBy(x => x))) return false;
+
+            if (!me.ExternalFormat.HasValue && other.ExternalFormat.HasValue) return false;
+            if (!me.ExternalFormat.Equals(other.ExternalFormat)) return false;
+
+            if (me.ExternalModelName == null && other.ExternalModelName != null) return false;
+            if (me.ExternalModelName != null && !me.ExternalModelName.Equals(other.ExternalModelName)) return false;
+
+            if (me.ExternalToolName == null && other.ExternalToolName != null) return false;
+            if (me.ExternalToolName != null && !me.ExternalToolName.Equals(other.ExternalToolName)) return false;
+
+            if (me.ExternalToolVersion == null && other.ExternalToolVersion != null) return false;
+            if (me.ExternalToolVersion != null && !me.ExternalToolVersion.Equals(other.ExternalToolVersion)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/FileEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/FileEquatable.cs
@@ -84,7 +84,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.FileRevision.OrderBy(x => x).SequenceEqual(other.FileRevision.OrderBy(x => x))) return false;
 
-            if (!me.LockedBy.HasValue && other.LockedBy.HasValue) return false;
+            if (me.LockedBy.HasValue != other.LockedBy.HasValue) return false;
             if (!me.LockedBy.Equals(other.LockedBy)) return false;
 
             if (!me.Owner.Equals(other.Owner)) return false;

--- a/CDP4Common/AutoGenEquatable/FileEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/FileEquatable.cs
@@ -1,0 +1,108 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="FileEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 3     | fileRevision                         | Guid                         | 1..*        |  1.0.0  |
+ | 4     | lockedBy                             | Guid                         | 0..1        |  1.0.0  |
+ | 5     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 6     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="File"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class FileEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="File"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="File"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="File"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="File"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this File me, File other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.FileRevision.OrderBy(x => x).SequenceEqual(other.FileRevision.OrderBy(x => x))) return false;
+
+            if (!me.LockedBy.HasValue && other.LockedBy.HasValue) return false;
+            if (!me.LockedBy.Equals(other.LockedBy)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/FileRevisionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/FileRevisionEquatable.cs
@@ -82,7 +82,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
 
-            if (!me.ContainingFolder.HasValue && other.ContainingFolder.HasValue) return false;
+            if (me.ContainingFolder.HasValue != other.ContainingFolder.HasValue) return false;
             if (!me.ContainingFolder.Equals(other.ContainingFolder)) return false;
 
             if (me.ContentHash == null && other.ContentHash != null) return false;

--- a/CDP4Common/AutoGenEquatable/FileRevisionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/FileRevisionEquatable.cs
@@ -1,0 +1,117 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="FileRevisionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | containingFolder                     | Guid                         | 0..1        |  1.0.0  |
+ | 3     | contentHash                          | string                       | 1..1        |  1.0.0  |
+ | 4     | createdOn                            | DateTime                     | 1..1        |  1.0.0  |
+ | 5     | creator                              | Guid                         | 1..1        |  1.0.0  |
+ | 6     | fileType                             | Guid                         | 1..*        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="FileRevision"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class FileRevisionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="FileRevision"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="FileRevision"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="FileRevision"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="FileRevision"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this FileRevision me, FileRevision other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ContainingFolder.HasValue && other.ContainingFolder.HasValue) return false;
+            if (!me.ContainingFolder.Equals(other.ContainingFolder)) return false;
+
+            if (me.ContentHash == null && other.ContentHash != null) return false;
+            if (me.ContentHash != null && !me.ContentHash.Equals(other.ContentHash)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.Creator.Equals(other.Creator)) return false;
+
+            if (!me.FileType.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.FileType.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.FileType.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.FileType.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/FileTypeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/FileTypeEquatable.cs
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="FileTypeEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | extension                            | string                       | 1..1        |  1.0.0  |
+ | 6     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 8     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 9     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="FileType"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class FileTypeEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="FileType"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="FileType"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="FileType"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="FileType"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this FileType me, FileType other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (me.Extension == null && other.Extension != null) return false;
+            if (me.Extension != null && !me.Extension.Equals(other.Extension)) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/FolderEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/FolderEquatable.cs
@@ -1,0 +1,112 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="FolderEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | containingFolder                     | Guid                         | 0..1        |  1.0.0  |
+ | 3     | createdOn                            | DateTime                     | 1..1        |  1.0.0  |
+ | 4     | creator                              | Guid                         | 1..1        |  1.0.0  |
+ | 5     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 6     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 7     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Folder"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class FolderEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Folder"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Folder"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Folder"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Folder"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Folder me, Folder other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ContainingFolder.HasValue && other.ContainingFolder.HasValue) return false;
+            if (!me.ContainingFolder.Equals(other.ContainingFolder)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.Creator.Equals(other.Creator)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/FolderEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/FolderEquatable.cs
@@ -81,7 +81,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
 
-            if (!me.ContainingFolder.HasValue && other.ContainingFolder.HasValue) return false;
+            if (me.ContainingFolder.HasValue != other.ContainingFolder.HasValue) return false;
             if (!me.ContainingFolder.Equals(other.ContainingFolder)) return false;
 
             if (!me.CreatedOn.Equals(other.CreatedOn)) return false;

--- a/CDP4Common/AutoGenEquatable/GlossaryEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/GlossaryEquatable.cs
@@ -1,0 +1,121 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="GlossaryEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | term                                 | Guid                         | 0..*        |  1.0.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Glossary"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class GlossaryEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Glossary"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Glossary"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Glossary"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Glossary"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Glossary me, Glossary other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.Term.OrderBy(x => x).SequenceEqual(other.Term.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/GoalEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/GoalEquatable.cs
@@ -1,0 +1,115 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="GoalEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.1.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | hyperLink                            | Guid                         | 0..*        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | name                                 | string                       | 1..1        |  1.1.0  |
+ | 10    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Goal"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class GoalEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Goal"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Goal"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Goal"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Goal"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Goal me, Goal other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/HyperLinkEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/HyperLinkEquatable.cs
@@ -1,0 +1,107 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="HyperLinkEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | content                              | string                       | 1..1        |  1.0.0  |
+ | 3     | languageCode                         | string                       | 1..1        |  1.0.0  |
+ | 4     | uri                                  | string                       | 1..1        |  1.0.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="HyperLink"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class HyperLinkEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="HyperLink"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="HyperLink"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="HyperLink"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="HyperLink"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this HyperLink me, HyperLink other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (me.Uri == null && other.Uri != null) return false;
+            if (me.Uri != null && !me.Uri.Equals(other.Uri)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/IdCorrespondenceEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/IdCorrespondenceEquatable.cs
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IdCorrespondenceEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | externalId                           | string                       | 1..1        |  1.0.0  |
+ | 3     | internalThing                        | Guid                         | 1..1        |  1.0.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="IdCorrespondence"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class IdCorrespondenceEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="IdCorrespondence"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="IdCorrespondence"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="IdCorrespondence"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="IdCorrespondence"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this IdCorrespondence me, IdCorrespondence other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (me.ExternalId == null && other.ExternalId != null) return false;
+            if (me.ExternalId != null && !me.ExternalId.Equals(other.ExternalId)) return false;
+
+            if (!me.InternalThing.Equals(other.InternalThing)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/IndependentParameterTypeAssignmentEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/IndependentParameterTypeAssignmentEquatable.cs
@@ -84,7 +84,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
 
-            if (!me.MeasurementScale.HasValue && other.MeasurementScale.HasValue) return false;
+            if (me.MeasurementScale.HasValue != other.MeasurementScale.HasValue) return false;
             if (!me.MeasurementScale.Equals(other.MeasurementScale)) return false;
 
             if (!me.ParameterType.Equals(other.ParameterType)) return false;

--- a/CDP4Common/AutoGenEquatable/IndependentParameterTypeAssignmentEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/IndependentParameterTypeAssignmentEquatable.cs
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IndependentParameterTypeAssignmentEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | measurementScale                     | Guid                         | 0..1        |  1.2.0  |
+ | 6     | parameterType                        | Guid                         | 1..1        |  1.2.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="IndependentParameterTypeAssignment"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class IndependentParameterTypeAssignmentEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="IndependentParameterTypeAssignment"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="IndependentParameterTypeAssignment"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="IndependentParameterTypeAssignment"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="IndependentParameterTypeAssignment"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this IndependentParameterTypeAssignment me, IndependentParameterTypeAssignment other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.MeasurementScale.HasValue && other.MeasurementScale.HasValue) return false;
+            if (!me.MeasurementScale.Equals(other.MeasurementScale)) return false;
+
+            if (!me.ParameterType.Equals(other.ParameterType)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/IntervalScaleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/IntervalScaleEquatable.cs
@@ -1,0 +1,149 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IntervalScaleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 6     | isMaximumInclusive                   | bool                         | 1..1        |  1.0.0  |
+ | 7     | isMinimumInclusive                   | bool                         | 1..1        |  1.0.0  |
+ | 8     | mappingToReferenceScale              | Guid                         | 0..*        |  1.0.0  |
+ | 9     | maximumPermissibleValue              | string                       | 0..1        |  1.0.0  |
+ | 10    | minimumPermissibleValue              | string                       | 0..1        |  1.0.0  |
+ | 11    | name                                 | string                       | 1..1        |  1.0.0  |
+ | 12    | negativeValueConnotation             | string                       | 0..1        |  1.0.0  |
+ | 13    | numberSet                            | NumberSetKind                | 1..1        |  1.0.0  |
+ | 14    | positiveValueConnotation             | string                       | 0..1        |  1.0.0  |
+ | 15    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 16    | unit                                 | Guid                         | 1..1        |  1.0.0  |
+ | 17    | valueDefinition                      | Guid                         | 0..*        |  1.0.0  |
+ | 18    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 19    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 20    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 21    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="IntervalScale"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class IntervalScaleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="IntervalScale"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="IntervalScale"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="IntervalScale"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="IntervalScale"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this IntervalScale me, IntervalScale other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.IsMaximumInclusive.Equals(other.IsMaximumInclusive)) return false;
+
+            if (!me.IsMinimumInclusive.Equals(other.IsMinimumInclusive)) return false;
+
+            if (!me.MappingToReferenceScale.OrderBy(x => x).SequenceEqual(other.MappingToReferenceScale.OrderBy(x => x))) return false;
+
+            if (me.MaximumPermissibleValue == null && other.MaximumPermissibleValue != null) return false;
+            if (me.MaximumPermissibleValue != null && !me.MaximumPermissibleValue.Equals(other.MaximumPermissibleValue)) return false;
+
+            if (me.MinimumPermissibleValue == null && other.MinimumPermissibleValue != null) return false;
+            if (me.MinimumPermissibleValue != null && !me.MinimumPermissibleValue.Equals(other.MinimumPermissibleValue)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.NegativeValueConnotation == null && other.NegativeValueConnotation != null) return false;
+            if (me.NegativeValueConnotation != null && !me.NegativeValueConnotation.Equals(other.NegativeValueConnotation)) return false;
+
+            if (!me.NumberSet.Equals(other.NumberSet)) return false;
+
+            if (me.PositiveValueConnotation == null && other.PositiveValueConnotation != null) return false;
+            if (me.PositiveValueConnotation != null && !me.PositiveValueConnotation.Equals(other.PositiveValueConnotation)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.Unit.Equals(other.Unit)) return false;
+
+            if (!me.ValueDefinition.OrderBy(x => x).SequenceEqual(other.ValueDefinition.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/IterationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/IterationEquatable.cs
@@ -1,0 +1,162 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IterationEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | actualFiniteStateList                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | defaultOption                        | Guid                         | 0..1        |  1.0.0  |
+ | 4     | domainFileStore                      | Guid                         | 0..*        |  1.0.0  |
+ | 5     | element                              | Guid                         | 0..*        |  1.0.0  |
+ | 6     | externalIdentifierMap                | Guid                         | 0..*        |  1.0.0  |
+ | 7     | iterationSetup                       | Guid                         | 1..1        |  1.0.0  |
+ | 8     | option                               | Guid                         | 1..*        |  1.0.0  |
+ | 9     | possibleFiniteStateList              | Guid                         | 0..*        |  1.0.0  |
+ | 10    | publication                          | Guid                         | 0..*        |  1.0.0  |
+ | 11    | relationship                         | Guid                         | 0..*        |  1.0.0  |
+ | 12    | requirementsSpecification            | Guid                         | 0..*        |  1.0.0  |
+ | 13    | ruleVerificationList                 | Guid                         | 0..*        |  1.0.0  |
+ | 14    | sourceIterationIid                   | Guid                         | 0..1        |  1.0.0  |
+ | 15    | topElement                           | Guid                         | 0..1        |  1.0.0  |
+ | 16    | diagramCanvas                        | Guid                         | 0..*        |  1.1.0  |
+ | 17    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 18    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 19    | goal                                 | Guid                         | 0..*        |  1.1.0  |
+ | 20    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 21    | sharedDiagramStyle                   | Guid                         | 0..*        |  1.1.0  |
+ | 22    | stakeholder                          | Guid                         | 0..*        |  1.1.0  |
+ | 23    | stakeholderValue                     | Guid                         | 0..*        |  1.1.0  |
+ | 24    | stakeholderValueMap                  | Guid                         | 0..*        |  1.1.0  |
+ | 25    | valueGroup                           | Guid                         | 0..*        |  1.1.0  |
+ | 26    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Iteration"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class IterationEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Iteration"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Iteration"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Iteration"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Iteration"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Iteration me, Iteration other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ActualFiniteStateList.OrderBy(x => x).SequenceEqual(other.ActualFiniteStateList.OrderBy(x => x))) return false;
+
+            if (!me.DefaultOption.HasValue && other.DefaultOption.HasValue) return false;
+            if (!me.DefaultOption.Equals(other.DefaultOption)) return false;
+
+            if (!me.DomainFileStore.OrderBy(x => x).SequenceEqual(other.DomainFileStore.OrderBy(x => x))) return false;
+
+            if (!me.Element.OrderBy(x => x).SequenceEqual(other.Element.OrderBy(x => x))) return false;
+
+            if (!me.ExternalIdentifierMap.OrderBy(x => x).SequenceEqual(other.ExternalIdentifierMap.OrderBy(x => x))) return false;
+
+            if (!me.IterationSetup.Equals(other.IterationSetup)) return false;
+
+            if (!me.Option.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.Option.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.Option.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.Option.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.PossibleFiniteStateList.OrderBy(x => x).SequenceEqual(other.PossibleFiniteStateList.OrderBy(x => x))) return false;
+
+            if (!me.Publication.OrderBy(x => x).SequenceEqual(other.Publication.OrderBy(x => x))) return false;
+
+            if (!me.Relationship.OrderBy(x => x).SequenceEqual(other.Relationship.OrderBy(x => x))) return false;
+
+            if (!me.RequirementsSpecification.OrderBy(x => x).SequenceEqual(other.RequirementsSpecification.OrderBy(x => x))) return false;
+
+            if (!me.RuleVerificationList.OrderBy(x => x).SequenceEqual(other.RuleVerificationList.OrderBy(x => x))) return false;
+
+            if (!me.SourceIterationIid.HasValue && other.SourceIterationIid.HasValue) return false;
+            if (!me.SourceIterationIid.Equals(other.SourceIterationIid)) return false;
+
+            if (!me.TopElement.HasValue && other.TopElement.HasValue) return false;
+            if (!me.TopElement.Equals(other.TopElement)) return false;
+
+            if (!me.DiagramCanvas.OrderBy(x => x).SequenceEqual(other.DiagramCanvas.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.Goal.OrderBy(x => x).SequenceEqual(other.Goal.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.SharedDiagramStyle.OrderBy(x => x).SequenceEqual(other.SharedDiagramStyle.OrderBy(x => x))) return false;
+
+            if (!me.Stakeholder.OrderBy(x => x).SequenceEqual(other.Stakeholder.OrderBy(x => x))) return false;
+
+            if (!me.StakeholderValue.OrderBy(x => x).SequenceEqual(other.StakeholderValue.OrderBy(x => x))) return false;
+
+            if (!me.StakeholderValueMap.OrderBy(x => x).SequenceEqual(other.StakeholderValueMap.OrderBy(x => x))) return false;
+
+            if (!me.ValueGroup.OrderBy(x => x).SequenceEqual(other.ValueGroup.OrderBy(x => x))) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/IterationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/IterationEquatable.cs
@@ -99,7 +99,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ActualFiniteStateList.OrderBy(x => x).SequenceEqual(other.ActualFiniteStateList.OrderBy(x => x))) return false;
 
-            if (!me.DefaultOption.HasValue && other.DefaultOption.HasValue) return false;
+            if (me.DefaultOption.HasValue != other.DefaultOption.HasValue) return false;
             if (!me.DefaultOption.Equals(other.DefaultOption)) return false;
 
             if (!me.DomainFileStore.OrderBy(x => x).SequenceEqual(other.DomainFileStore.OrderBy(x => x))) return false;
@@ -123,10 +123,10 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.RuleVerificationList.OrderBy(x => x).SequenceEqual(other.RuleVerificationList.OrderBy(x => x))) return false;
 
-            if (!me.SourceIterationIid.HasValue && other.SourceIterationIid.HasValue) return false;
+            if (me.SourceIterationIid.HasValue != other.SourceIterationIid.HasValue) return false;
             if (!me.SourceIterationIid.Equals(other.SourceIterationIid)) return false;
 
-            if (!me.TopElement.HasValue && other.TopElement.HasValue) return false;
+            if (me.TopElement.HasValue != other.TopElement.HasValue) return false;
             if (!me.TopElement.Equals(other.TopElement)) return false;
 
             if (!me.DiagramCanvas.OrderBy(x => x).SequenceEqual(other.DiagramCanvas.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/IterationSetupEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/IterationSetupEquatable.cs
@@ -1,0 +1,119 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IterationSetupEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | createdOn                            | DateTime                     | 1..1        |  1.0.0  |
+ | 3     | description                          | string                       | 1..1        |  1.0.0  |
+ | 4     | frozenOn                             | DateTime                     | 0..1        |  1.0.0  |
+ | 5     | isDeleted                            | bool                         | 1..1        |  1.0.0  |
+ | 6     | iterationIid                         | Guid                         | 1..1        |  1.0.0  |
+ | 7     | iterationNumber                      | int                          | 1..1        |  1.0.0  |
+ | 8     | sourceIterationSetup                 | Guid                         | 0..1        |  1.0.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="IterationSetup"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class IterationSetupEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="IterationSetup"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="IterationSetup"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="IterationSetup"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="IterationSetup"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this IterationSetup me, IterationSetup other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (me.Description == null && other.Description != null) return false;
+            if (me.Description != null && !me.Description.Equals(other.Description)) return false;
+
+            if (!me.FrozenOn.HasValue && other.FrozenOn.HasValue) return false;
+            if (!me.FrozenOn.Equals(other.FrozenOn)) return false;
+
+            if (!me.IsDeleted.Equals(other.IsDeleted)) return false;
+
+            if (!me.IterationIid.Equals(other.IterationIid)) return false;
+
+            if (!me.IterationNumber.Equals(other.IterationNumber)) return false;
+
+            if (!me.SourceIterationSetup.HasValue && other.SourceIterationSetup.HasValue) return false;
+            if (!me.SourceIterationSetup.Equals(other.SourceIterationSetup)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/IterationSetupEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/IterationSetupEquatable.cs
@@ -88,7 +88,7 @@ namespace CDP4Common.DTO.Equatable
             if (me.Description == null && other.Description != null) return false;
             if (me.Description != null && !me.Description.Equals(other.Description)) return false;
 
-            if (!me.FrozenOn.HasValue && other.FrozenOn.HasValue) return false;
+            if (me.FrozenOn.HasValue != other.FrozenOn.HasValue) return false;
             if (!me.FrozenOn.Equals(other.FrozenOn)) return false;
 
             if (!me.IsDeleted.Equals(other.IsDeleted)) return false;
@@ -97,7 +97,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.IterationNumber.Equals(other.IterationNumber)) return false;
 
-            if (!me.SourceIterationSetup.HasValue && other.SourceIterationSetup.HasValue) return false;
+            if (me.SourceIterationSetup.HasValue != other.SourceIterationSetup.HasValue) return false;
             if (!me.SourceIterationSetup.Equals(other.SourceIterationSetup)) return false;
 
             if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/LinearConversionUnitEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/LinearConversionUnitEquatable.cs
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="LinearConversionUnitEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | conversionFactor                     | string                       | 1..1        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | referenceUnit                        | Guid                         | 1..1        |  1.0.0  |
+ | 9     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="LinearConversionUnit"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class LinearConversionUnitEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="LinearConversionUnit"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="LinearConversionUnit"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="LinearConversionUnit"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="LinearConversionUnit"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this LinearConversionUnit me, LinearConversionUnit other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (me.ConversionFactor == null && other.ConversionFactor != null) return false;
+            if (me.ConversionFactor != null && !me.ConversionFactor.Equals(other.ConversionFactor)) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.ReferenceUnit.Equals(other.ReferenceUnit)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/LogEntryChangelogItemEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/LogEntryChangelogItemEquatable.cs
@@ -1,0 +1,108 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="LogEntryChangelogItemEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | affectedItemIid                      | Guid                         | 1..1        |  1.2.0  |
+ | 6     | affectedReferenceIid                 | Guid                         | 0..*        |  1.2.0  |
+ | 7     | changeDescription                    | string                       | 0..1        |  1.2.0  |
+ | 8     | changelogKind                        | LogEntryChangelogItemKind    | 1..1        |  1.2.0  |
+ | 9     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="LogEntryChangelogItem"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class LogEntryChangelogItemEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="LogEntryChangelogItem"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="LogEntryChangelogItem"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="LogEntryChangelogItem"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="LogEntryChangelogItem"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this LogEntryChangelogItem me, LogEntryChangelogItem other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.AffectedItemIid.Equals(other.AffectedItemIid)) return false;
+
+            if (!me.AffectedReferenceIid.Equals(other.AffectedReferenceIid)) return false;
+
+            if (me.ChangeDescription == null && other.ChangeDescription != null) return false;
+            if (me.ChangeDescription != null && !me.ChangeDescription.Equals(other.ChangeDescription)) return false;
+
+            if (!me.ChangelogKind.Equals(other.ChangelogKind)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/LogarithmicScaleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/LogarithmicScaleEquatable.cs
@@ -1,0 +1,166 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="LogarithmicScaleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | exponent                             | string                       | 1..1        |  1.0.0  |
+ | 5     | factor                               | string                       | 1..1        |  1.0.0  |
+ | 6     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 8     | isMaximumInclusive                   | bool                         | 1..1        |  1.0.0  |
+ | 9     | isMinimumInclusive                   | bool                         | 1..1        |  1.0.0  |
+ | 10    | logarithmBase                        | LogarithmBaseKind            | 1..1        |  1.0.0  |
+ | 11    | mappingToReferenceScale              | Guid                         | 0..*        |  1.0.0  |
+ | 12    | maximumPermissibleValue              | string                       | 0..1        |  1.0.0  |
+ | 13    | minimumPermissibleValue              | string                       | 0..1        |  1.0.0  |
+ | 14    | name                                 | string                       | 1..1        |  1.0.0  |
+ | 15    | negativeValueConnotation             | string                       | 0..1        |  1.0.0  |
+ | 16    | numberSet                            | NumberSetKind                | 1..1        |  1.0.0  |
+ | 17    | positiveValueConnotation             | string                       | 0..1        |  1.0.0  |
+ | 18    | referenceQuantityKind                | Guid                         | 1..1        |  1.0.0  |
+ | 19    | referenceQuantityValue               | Guid                         | 0..1        |  1.0.0  |
+ | 20    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 21    | unit                                 | Guid                         | 1..1        |  1.0.0  |
+ | 22    | valueDefinition                      | Guid                         | 0..*        |  1.0.0  |
+ | 23    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 24    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 25    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 26    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="LogarithmicScale"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class LogarithmicScaleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="LogarithmicScale"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="LogarithmicScale"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="LogarithmicScale"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="LogarithmicScale"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this LogarithmicScale me, LogarithmicScale other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (me.Exponent == null && other.Exponent != null) return false;
+            if (me.Exponent != null && !me.Exponent.Equals(other.Exponent)) return false;
+
+            if (me.Factor == null && other.Factor != null) return false;
+            if (me.Factor != null && !me.Factor.Equals(other.Factor)) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.IsMaximumInclusive.Equals(other.IsMaximumInclusive)) return false;
+
+            if (!me.IsMinimumInclusive.Equals(other.IsMinimumInclusive)) return false;
+
+            if (!me.LogarithmBase.Equals(other.LogarithmBase)) return false;
+
+            if (!me.MappingToReferenceScale.OrderBy(x => x).SequenceEqual(other.MappingToReferenceScale.OrderBy(x => x))) return false;
+
+            if (me.MaximumPermissibleValue == null && other.MaximumPermissibleValue != null) return false;
+            if (me.MaximumPermissibleValue != null && !me.MaximumPermissibleValue.Equals(other.MaximumPermissibleValue)) return false;
+
+            if (me.MinimumPermissibleValue == null && other.MinimumPermissibleValue != null) return false;
+            if (me.MinimumPermissibleValue != null && !me.MinimumPermissibleValue.Equals(other.MinimumPermissibleValue)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.NegativeValueConnotation == null && other.NegativeValueConnotation != null) return false;
+            if (me.NegativeValueConnotation != null && !me.NegativeValueConnotation.Equals(other.NegativeValueConnotation)) return false;
+
+            if (!me.NumberSet.Equals(other.NumberSet)) return false;
+
+            if (me.PositiveValueConnotation == null && other.PositiveValueConnotation != null) return false;
+            if (me.PositiveValueConnotation != null && !me.PositiveValueConnotation.Equals(other.PositiveValueConnotation)) return false;
+
+            if (!me.ReferenceQuantityKind.Equals(other.ReferenceQuantityKind)) return false;
+
+            if (!me.ReferenceQuantityValue.OrderBy(x => x).SequenceEqual(other.ReferenceQuantityValue.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.Unit.Equals(other.Unit)) return false;
+
+            if (!me.ValueDefinition.OrderBy(x => x).SequenceEqual(other.ValueDefinition.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/MappingToReferenceScaleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/MappingToReferenceScaleEquatable.cs
@@ -1,0 +1,101 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="MappingToReferenceScaleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | dependentScaleValue                  | Guid                         | 1..1        |  1.0.0  |
+ | 3     | referenceScaleValue                  | Guid                         | 1..1        |  1.0.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="MappingToReferenceScale"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class MappingToReferenceScaleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="MappingToReferenceScale"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="MappingToReferenceScale"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="MappingToReferenceScale"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="MappingToReferenceScale"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this MappingToReferenceScale me, MappingToReferenceScale other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.DependentScaleValue.Equals(other.DependentScaleValue)) return false;
+
+            if (!me.ReferenceScaleValue.Equals(other.ReferenceScaleValue)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ModelLogEntryEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ModelLogEntryEquatable.cs
@@ -89,7 +89,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.AffectedItemIid.Equals(other.AffectedItemIid)) return false;
 
-            if (!me.Author.HasValue && other.Author.HasValue) return false;
+            if (me.Author.HasValue != other.Author.HasValue) return false;
             if (!me.Author.Equals(other.Author)) return false;
 
             if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/ModelLogEntryEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ModelLogEntryEquatable.cs
@@ -1,0 +1,125 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ModelLogEntryEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | affectedDomainIid                    | Guid                         | 0..*        |  1.0.0  |
+ | 3     | affectedItemIid                      | Guid                         | 0..*        |  1.0.0  |
+ | 4     | author                               | Guid                         | 0..1        |  1.0.0  |
+ | 5     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 6     | content                              | string                       | 1..1        |  1.0.0  |
+ | 7     | createdOn                            | DateTime                     | 1..1        |  1.0.0  |
+ | 8     | languageCode                         | string                       | 1..1        |  1.0.0  |
+ | 9     | level                                | LogLevelKind                 | 1..1        |  1.0.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | logEntryChangelogItem                | Guid                         | 0..*        |  1.2.0  |
+ | 14    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ModelLogEntry"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ModelLogEntryEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ModelLogEntry"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ModelLogEntry"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ModelLogEntry"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ModelLogEntry"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ModelLogEntry me, ModelLogEntry other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.AffectedDomainIid.Equals(other.AffectedDomainIid)) return false;
+
+            if (!me.AffectedItemIid.Equals(other.AffectedItemIid)) return false;
+
+            if (!me.Author.HasValue && other.Author.HasValue) return false;
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.Level.Equals(other.Level)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.LogEntryChangelogItem.OrderBy(x => x).SequenceEqual(other.LogEntryChangelogItem.OrderBy(x => x))) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ModelReferenceDataLibraryEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ModelReferenceDataLibraryEquatable.cs
@@ -120,7 +120,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ReferenceSource.OrderBy(x => x).SequenceEqual(other.ReferenceSource.OrderBy(x => x))) return false;
 
-            if (!me.RequiredRdl.HasValue && other.RequiredRdl.HasValue) return false;
+            if (me.RequiredRdl.HasValue != other.RequiredRdl.HasValue) return false;
             if (!me.RequiredRdl.Equals(other.RequiredRdl)) return false;
 
             if (!me.Rule.OrderBy(x => x).SequenceEqual(other.Rule.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/ModelReferenceDataLibraryEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ModelReferenceDataLibraryEquatable.cs
@@ -1,0 +1,153 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ModelReferenceDataLibraryEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | baseQuantityKind                     | Guid                         | 0..*        |  1.0.0  |
+ | 4     | baseUnit                             | Guid                         | 0..*        |  1.0.0  |
+ | 5     | constant                             | Guid                         | 0..*        |  1.0.0  |
+ | 6     | definedCategory                      | Guid                         | 0..*        |  1.0.0  |
+ | 7     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 8     | fileType                             | Guid                         | 0..*        |  1.0.0  |
+ | 9     | glossary                             | Guid                         | 0..*        |  1.0.0  |
+ | 10    | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 11    | name                                 | string                       | 1..1        |  1.0.0  |
+ | 12    | parameterType                        | Guid                         | 0..*        |  1.0.0  |
+ | 13    | referenceSource                      | Guid                         | 0..*        |  1.0.0  |
+ | 14    | requiredRdl                          | Guid                         | 0..1        |  1.0.0  |
+ | 15    | rule                                 | Guid                         | 0..*        |  1.0.0  |
+ | 16    | scale                                | Guid                         | 0..*        |  1.0.0  |
+ | 17    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 18    | unit                                 | Guid                         | 0..*        |  1.0.0  |
+ | 19    | unitPrefix                           | Guid                         | 0..*        |  1.0.0  |
+ | 20    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 21    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 22    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 23    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ModelReferenceDataLibrary"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ModelReferenceDataLibraryEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ModelReferenceDataLibrary"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ModelReferenceDataLibrary"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ModelReferenceDataLibrary"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ModelReferenceDataLibrary"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ModelReferenceDataLibrary me, ModelReferenceDataLibrary other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.BaseQuantityKind.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.BaseQuantityKind.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.BaseQuantityKind.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.BaseQuantityKind.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.BaseUnit.OrderBy(x => x).SequenceEqual(other.BaseUnit.OrderBy(x => x))) return false;
+
+            if (!me.Constant.OrderBy(x => x).SequenceEqual(other.Constant.OrderBy(x => x))) return false;
+
+            if (!me.DefinedCategory.OrderBy(x => x).SequenceEqual(other.DefinedCategory.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.FileType.OrderBy(x => x).SequenceEqual(other.FileType.OrderBy(x => x))) return false;
+
+            if (!me.Glossary.OrderBy(x => x).SequenceEqual(other.Glossary.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.ParameterType.OrderBy(x => x).SequenceEqual(other.ParameterType.OrderBy(x => x))) return false;
+
+            if (!me.ReferenceSource.OrderBy(x => x).SequenceEqual(other.ReferenceSource.OrderBy(x => x))) return false;
+
+            if (!me.RequiredRdl.HasValue && other.RequiredRdl.HasValue) return false;
+            if (!me.RequiredRdl.Equals(other.RequiredRdl)) return false;
+
+            if (!me.Rule.OrderBy(x => x).SequenceEqual(other.Rule.OrderBy(x => x))) return false;
+
+            if (!me.Scale.OrderBy(x => x).SequenceEqual(other.Scale.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.Unit.OrderBy(x => x).SequenceEqual(other.Unit.OrderBy(x => x))) return false;
+
+            if (!me.UnitPrefix.OrderBy(x => x).SequenceEqual(other.UnitPrefix.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ModellingThingReferenceEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ModellingThingReferenceEquatable.cs
@@ -1,0 +1,101 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ModellingThingReferenceEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | referencedRevisionNumber             | int                          | 1..1        |  1.1.0  |
+ | 6     | referencedThing                      | Guid                         | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ModellingThingReference"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ModellingThingReferenceEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ModellingThingReference"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ModellingThingReference"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ModellingThingReference"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ModellingThingReference"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ModellingThingReference me, ModellingThingReference other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.ReferencedRevisionNumber.Equals(other.ReferencedRevisionNumber)) return false;
+
+            if (!me.ReferencedThing.Equals(other.ReferencedThing)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/MultiRelationshipEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/MultiRelationshipEquatable.cs
@@ -1,0 +1,111 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="MultiRelationshipEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 3     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 4     | relatedThing                         | Guid                         | 0..*        |  1.0.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | parameterValue                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | name                                 | string                       | 0..1        |  1.2.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="MultiRelationship"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class MultiRelationshipEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="MultiRelationship"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="MultiRelationship"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="MultiRelationship"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="MultiRelationship"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this MultiRelationship me, MultiRelationship other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.ParameterValue.OrderBy(x => x).SequenceEqual(other.ParameterValue.OrderBy(x => x))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/MultiRelationshipRuleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/MultiRelationshipRuleEquatable.cs
@@ -1,0 +1,127 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="MultiRelationshipRuleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 6     | maxRelated                           | int                          | 1..1        |  1.0.0  |
+ | 7     | minRelated                           | int                          | 1..1        |  1.0.0  |
+ | 8     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 9     | relatedCategory                      | Guid                         | 1..*        |  1.0.0  |
+ | 10    | relationshipCategory                 | Guid                         | 1..1        |  1.0.0  |
+ | 11    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 12    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 13    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 15    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="MultiRelationshipRule"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class MultiRelationshipRuleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="MultiRelationshipRule"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="MultiRelationshipRule"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="MultiRelationshipRule"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="MultiRelationshipRule"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this MultiRelationshipRule me, MultiRelationshipRule other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.MaxRelated.Equals(other.MaxRelated)) return false;
+
+            if (!me.MinRelated.Equals(other.MinRelated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.RelatedCategory.OrderBy(x => x).SequenceEqual(other.RelatedCategory.OrderBy(x => x))) return false;
+
+            if (!me.RelationshipCategory.Equals(other.RelationshipCategory)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/NaturalLanguageEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/NaturalLanguageEquatable.cs
@@ -1,0 +1,107 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="NaturalLanguageEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | languageCode                         | string                       | 1..1        |  1.0.0  |
+ | 3     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 4     | nativeName                           | string                       | 1..1        |  1.0.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="NaturalLanguage"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class NaturalLanguageEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="NaturalLanguage"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="NaturalLanguage"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="NaturalLanguage"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="NaturalLanguage"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this NaturalLanguage me, NaturalLanguage other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.NativeName == null && other.NativeName != null) return false;
+            if (me.NativeName != null && !me.NativeName.Equals(other.NativeName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/NestedElementEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/NestedElementEquatable.cs
@@ -1,0 +1,108 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="NestedElementEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | elementUsage                         | Guid                         | 1..*        |  1.0.0  |
+ | 3     | isVolatile                           | bool                         | 1..1        |  1.0.0  |
+ | 4     | nestedParameter                      | Guid                         | 0..*        |  1.0.0  |
+ | 5     | rootElement                          | Guid                         | 1..1        |  1.0.0  |
+ | 6     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="NestedElement"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class NestedElementEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="NestedElement"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="NestedElement"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="NestedElement"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="NestedElement"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this NestedElement me, NestedElement other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ElementUsage.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.ElementUsage.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.ElementUsage.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.ElementUsage.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.IsVolatile.Equals(other.IsVolatile)) return false;
+
+            if (!me.NestedParameter.OrderBy(x => x).SequenceEqual(other.NestedParameter.OrderBy(x => x))) return false;
+
+            if (!me.RootElement.Equals(other.RootElement)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/NestedParameterEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/NestedParameterEquatable.cs
@@ -82,7 +82,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
 
-            if (!me.ActualState.HasValue && other.ActualState.HasValue) return false;
+            if (me.ActualState.HasValue != other.ActualState.HasValue) return false;
             if (!me.ActualState.Equals(other.ActualState)) return false;
 
             if (me.ActualValue == null && other.ActualValue != null) return false;

--- a/CDP4Common/AutoGenEquatable/NestedParameterEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/NestedParameterEquatable.cs
@@ -1,0 +1,116 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="NestedParameterEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | actualState                          | Guid                         | 0..1        |  1.0.0  |
+ | 3     | actualValue                          | string                       | 1..1        |  1.0.0  |
+ | 4     | associatedParameter                  | Guid                         | 1..1        |  1.0.0  |
+ | 5     | formula                              | string                       | 1..1        |  1.0.0  |
+ | 6     | isVolatile                           | bool                         | 1..1        |  1.0.0  |
+ | 7     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 8     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="NestedParameter"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class NestedParameterEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="NestedParameter"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="NestedParameter"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="NestedParameter"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="NestedParameter"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this NestedParameter me, NestedParameter other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ActualState.HasValue && other.ActualState.HasValue) return false;
+            if (!me.ActualState.Equals(other.ActualState)) return false;
+
+            if (me.ActualValue == null && other.ActualValue != null) return false;
+            if (me.ActualValue != null && !me.ActualValue.Equals(other.ActualValue)) return false;
+
+            if (!me.AssociatedParameter.Equals(other.AssociatedParameter)) return false;
+
+            if (me.Formula == null && other.Formula != null) return false;
+            if (me.Formula != null && !me.Formula.Equals(other.Formula)) return false;
+
+            if (!me.IsVolatile.Equals(other.IsVolatile)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/NotExpressionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/NotExpressionEquatable.cs
@@ -1,0 +1,98 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="NotExpressionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | term                                 | Guid                         | 1..1        |  1.0.0  |
+ | 3     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 6     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="NotExpression"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class NotExpressionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="NotExpression"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="NotExpression"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="NotExpression"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="NotExpression"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this NotExpression me, NotExpression other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Term.Equals(other.Term)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/OptionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/OptionEquatable.cs
@@ -1,0 +1,118 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="OptionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 7     | nestedElement                        | Guid                         | 0..*        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Option"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class OptionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Option"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Option"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Option"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Option"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Option me, Option other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.NestedElement.OrderBy(x => x).SequenceEqual(other.NestedElement.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/OrExpressionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/OrExpressionEquatable.cs
@@ -1,0 +1,98 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="OrExpressionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | term                                 | Guid                         | 2..*        |  1.0.0  |
+ | 3     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 6     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="OrExpression"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class OrExpressionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="OrExpression"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="OrExpression"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="OrExpression"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="OrExpression"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this OrExpression me, OrExpression other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Term.OrderBy(x => x).SequenceEqual(other.Term.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/OrdinalScaleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/OrdinalScaleEquatable.cs
@@ -1,0 +1,152 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="OrdinalScaleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 6     | isMaximumInclusive                   | bool                         | 1..1        |  1.0.0  |
+ | 7     | isMinimumInclusive                   | bool                         | 1..1        |  1.0.0  |
+ | 8     | mappingToReferenceScale              | Guid                         | 0..*        |  1.0.0  |
+ | 9     | maximumPermissibleValue              | string                       | 0..1        |  1.0.0  |
+ | 10    | minimumPermissibleValue              | string                       | 0..1        |  1.0.0  |
+ | 11    | name                                 | string                       | 1..1        |  1.0.0  |
+ | 12    | negativeValueConnotation             | string                       | 0..1        |  1.0.0  |
+ | 13    | numberSet                            | NumberSetKind                | 1..1        |  1.0.0  |
+ | 14    | positiveValueConnotation             | string                       | 0..1        |  1.0.0  |
+ | 15    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 16    | unit                                 | Guid                         | 1..1        |  1.0.0  |
+ | 17    | useShortNameValues                   | bool                         | 1..1        |  1.0.0  |
+ | 18    | valueDefinition                      | Guid                         | 0..*        |  1.0.0  |
+ | 19    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 20    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 21    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 22    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="OrdinalScale"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class OrdinalScaleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="OrdinalScale"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="OrdinalScale"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="OrdinalScale"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="OrdinalScale"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this OrdinalScale me, OrdinalScale other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.IsMaximumInclusive.Equals(other.IsMaximumInclusive)) return false;
+
+            if (!me.IsMinimumInclusive.Equals(other.IsMinimumInclusive)) return false;
+
+            if (!me.MappingToReferenceScale.OrderBy(x => x).SequenceEqual(other.MappingToReferenceScale.OrderBy(x => x))) return false;
+
+            if (me.MaximumPermissibleValue == null && other.MaximumPermissibleValue != null) return false;
+            if (me.MaximumPermissibleValue != null && !me.MaximumPermissibleValue.Equals(other.MaximumPermissibleValue)) return false;
+
+            if (me.MinimumPermissibleValue == null && other.MinimumPermissibleValue != null) return false;
+            if (me.MinimumPermissibleValue != null && !me.MinimumPermissibleValue.Equals(other.MinimumPermissibleValue)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.NegativeValueConnotation == null && other.NegativeValueConnotation != null) return false;
+            if (me.NegativeValueConnotation != null && !me.NegativeValueConnotation.Equals(other.NegativeValueConnotation)) return false;
+
+            if (!me.NumberSet.Equals(other.NumberSet)) return false;
+
+            if (me.PositiveValueConnotation == null && other.PositiveValueConnotation != null) return false;
+            if (me.PositiveValueConnotation != null && !me.PositiveValueConnotation.Equals(other.PositiveValueConnotation)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.Unit.Equals(other.Unit)) return false;
+
+            if (!me.UseShortNameValues.Equals(other.UseShortNameValues)) return false;
+
+            if (!me.ValueDefinition.OrderBy(x => x).SequenceEqual(other.ValueDefinition.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/OrganizationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/OrganizationEquatable.cs
@@ -1,0 +1,106 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="OrganizationEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 3     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 4     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Organization"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class OrganizationEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Organization"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Organization"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Organization"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Organization"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Organization me, Organization other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/OrganizationalParticipantEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/OrganizationalParticipantEquatable.cs
@@ -1,0 +1,98 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="OrganizationalParticipantEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | organization                         | Guid                         | 1..1        |  1.2.0  |
+ | 6     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="OrganizationalParticipant"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class OrganizationalParticipantEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="OrganizationalParticipant"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="OrganizationalParticipant"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="OrganizationalParticipant"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="OrganizationalParticipant"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this OrganizationalParticipant me, OrganizationalParticipant other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.Organization.Equals(other.Organization)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/OwnedStyleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/OwnedStyleEquatable.cs
@@ -94,31 +94,31 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
 
-            if (!me.FillColor.HasValue && other.FillColor.HasValue) return false;
+            if (me.FillColor.HasValue != other.FillColor.HasValue) return false;
             if (!me.FillColor.Equals(other.FillColor)) return false;
 
-            if (!me.FillOpacity.HasValue && other.FillOpacity.HasValue) return false;
+            if (me.FillOpacity.HasValue != other.FillOpacity.HasValue) return false;
             if (!me.FillOpacity.Equals(other.FillOpacity)) return false;
 
-            if (!me.FontBold.HasValue && other.FontBold.HasValue) return false;
+            if (me.FontBold.HasValue != other.FontBold.HasValue) return false;
             if (!me.FontBold.Equals(other.FontBold)) return false;
 
-            if (!me.FontColor.HasValue && other.FontColor.HasValue) return false;
+            if (me.FontColor.HasValue != other.FontColor.HasValue) return false;
             if (!me.FontColor.Equals(other.FontColor)) return false;
 
-            if (!me.FontItalic.HasValue && other.FontItalic.HasValue) return false;
+            if (me.FontItalic.HasValue != other.FontItalic.HasValue) return false;
             if (!me.FontItalic.Equals(other.FontItalic)) return false;
 
             if (me.FontName == null && other.FontName != null) return false;
             if (me.FontName != null && !me.FontName.Equals(other.FontName)) return false;
 
-            if (!me.FontSize.HasValue && other.FontSize.HasValue) return false;
+            if (me.FontSize.HasValue != other.FontSize.HasValue) return false;
             if (!me.FontSize.Equals(other.FontSize)) return false;
 
-            if (!me.FontStrokeThrough.HasValue && other.FontStrokeThrough.HasValue) return false;
+            if (me.FontStrokeThrough.HasValue != other.FontStrokeThrough.HasValue) return false;
             if (!me.FontStrokeThrough.Equals(other.FontStrokeThrough)) return false;
 
-            if (!me.FontUnderline.HasValue && other.FontUnderline.HasValue) return false;
+            if (me.FontUnderline.HasValue != other.FontUnderline.HasValue) return false;
             if (!me.FontUnderline.Equals(other.FontUnderline)) return false;
 
             if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
@@ -126,13 +126,13 @@ namespace CDP4Common.DTO.Equatable
             if (me.Name == null && other.Name != null) return false;
             if (me.Name != null && !me.Name.Equals(other.Name)) return false;
 
-            if (!me.StrokeColor.HasValue && other.StrokeColor.HasValue) return false;
+            if (me.StrokeColor.HasValue != other.StrokeColor.HasValue) return false;
             if (!me.StrokeColor.Equals(other.StrokeColor)) return false;
 
-            if (!me.StrokeOpacity.HasValue && other.StrokeOpacity.HasValue) return false;
+            if (me.StrokeOpacity.HasValue != other.StrokeOpacity.HasValue) return false;
             if (!me.StrokeOpacity.Equals(other.StrokeOpacity)) return false;
 
-            if (!me.StrokeWidth.HasValue && other.StrokeWidth.HasValue) return false;
+            if (me.StrokeWidth.HasValue != other.StrokeWidth.HasValue) return false;
             if (!me.StrokeWidth.Equals(other.StrokeWidth)) return false;
 
             if (!me.UsedColor.OrderBy(x => x).SequenceEqual(other.UsedColor.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/OwnedStyleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/OwnedStyleEquatable.cs
@@ -1,0 +1,150 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="OwnedStyleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | fillColor                            | Guid                         | 0..1        |  1.1.0  |
+ | 5     | fillOpacity                          | float                        | 0..1        |  1.1.0  |
+ | 6     | fontBold                             | bool                         | 0..1        |  1.1.0  |
+ | 7     | fontColor                            | Guid                         | 0..1        |  1.1.0  |
+ | 8     | fontItalic                           | bool                         | 0..1        |  1.1.0  |
+ | 9     | fontName                             | string                       | 0..1        |  1.1.0  |
+ | 10    | fontSize                             | float                        | 0..1        |  1.1.0  |
+ | 11    | fontStrokeThrough                    | bool                         | 0..1        |  1.1.0  |
+ | 12    | fontUnderline                        | bool                         | 0..1        |  1.1.0  |
+ | 13    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 14    | name                                 | string                       | 1..1        |  1.1.0  |
+ | 15    | strokeColor                          | Guid                         | 0..1        |  1.1.0  |
+ | 16    | strokeOpacity                        | float                        | 0..1        |  1.1.0  |
+ | 17    | strokeWidth                          | float                        | 0..1        |  1.1.0  |
+ | 18    | usedColor                            | Guid                         | 0..*        |  1.1.0  |
+ | 19    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="OwnedStyle"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class OwnedStyleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="OwnedStyle"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="OwnedStyle"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="OwnedStyle"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="OwnedStyle"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this OwnedStyle me, OwnedStyle other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.FillColor.HasValue && other.FillColor.HasValue) return false;
+            if (!me.FillColor.Equals(other.FillColor)) return false;
+
+            if (!me.FillOpacity.HasValue && other.FillOpacity.HasValue) return false;
+            if (!me.FillOpacity.Equals(other.FillOpacity)) return false;
+
+            if (!me.FontBold.HasValue && other.FontBold.HasValue) return false;
+            if (!me.FontBold.Equals(other.FontBold)) return false;
+
+            if (!me.FontColor.HasValue && other.FontColor.HasValue) return false;
+            if (!me.FontColor.Equals(other.FontColor)) return false;
+
+            if (!me.FontItalic.HasValue && other.FontItalic.HasValue) return false;
+            if (!me.FontItalic.Equals(other.FontItalic)) return false;
+
+            if (me.FontName == null && other.FontName != null) return false;
+            if (me.FontName != null && !me.FontName.Equals(other.FontName)) return false;
+
+            if (!me.FontSize.HasValue && other.FontSize.HasValue) return false;
+            if (!me.FontSize.Equals(other.FontSize)) return false;
+
+            if (!me.FontStrokeThrough.HasValue && other.FontStrokeThrough.HasValue) return false;
+            if (!me.FontStrokeThrough.Equals(other.FontStrokeThrough)) return false;
+
+            if (!me.FontUnderline.HasValue && other.FontUnderline.HasValue) return false;
+            if (!me.FontUnderline.Equals(other.FontUnderline)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.StrokeColor.HasValue && other.StrokeColor.HasValue) return false;
+            if (!me.StrokeColor.Equals(other.StrokeColor)) return false;
+
+            if (!me.StrokeOpacity.HasValue && other.StrokeOpacity.HasValue) return false;
+            if (!me.StrokeOpacity.Equals(other.StrokeOpacity)) return false;
+
+            if (!me.StrokeWidth.HasValue && other.StrokeWidth.HasValue) return false;
+            if (!me.StrokeWidth.Equals(other.StrokeWidth)) return false;
+
+            if (!me.UsedColor.OrderBy(x => x).SequenceEqual(other.UsedColor.OrderBy(x => x))) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/PageEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/PageEquatable.cs
@@ -1,0 +1,116 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PageEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 3     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.1.0  |
+ | 8     | note                                 | Guid                         | 0..*        |  1.1.0  |
+ | 9     | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 10    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Page"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class PageEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Page"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Page"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Page"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Page"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Page me, Page other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Note.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.Note.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.Note.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.Note.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ParameterEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParameterEquatable.cs
@@ -91,7 +91,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ExpectsOverride.Equals(other.ExpectsOverride)) return false;
 
-            if (!me.Group.HasValue && other.Group.HasValue) return false;
+            if (me.Group.HasValue != other.Group.HasValue) return false;
             if (!me.Group.Equals(other.Group)) return false;
 
             if (!me.IsOptionDependent.Equals(other.IsOptionDependent)) return false;
@@ -102,13 +102,13 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ParameterType.Equals(other.ParameterType)) return false;
 
-            if (!me.RequestedBy.HasValue && other.RequestedBy.HasValue) return false;
+            if (me.RequestedBy.HasValue != other.RequestedBy.HasValue) return false;
             if (!me.RequestedBy.Equals(other.RequestedBy)) return false;
 
-            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (me.Scale.HasValue != other.Scale.HasValue) return false;
             if (!me.Scale.Equals(other.Scale)) return false;
 
-            if (!me.StateDependence.HasValue && other.StateDependence.HasValue) return false;
+            if (me.StateDependence.HasValue != other.StateDependence.HasValue) return false;
             if (!me.StateDependence.Equals(other.StateDependence)) return false;
 
             if (!me.ValueSet.OrderBy(x => x).SequenceEqual(other.ValueSet.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/ParameterEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParameterEquatable.cs
@@ -1,0 +1,132 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | allowDifferentOwnerOfOverride        | bool                         | 1..1        |  1.0.0  |
+ | 3     | expectsOverride                      | bool                         | 1..1        |  1.0.0  |
+ | 4     | group                                | Guid                         | 0..1        |  1.0.0  |
+ | 5     | isOptionDependent                    | bool                         | 1..1        |  1.0.0  |
+ | 6     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 7     | parameterSubscription                | Guid                         | 0..*        |  1.0.0  |
+ | 8     | parameterType                        | Guid                         | 1..1        |  1.0.0  |
+ | 9     | requestedBy                          | Guid                         | 0..1        |  1.0.0  |
+ | 10    | scale                                | Guid                         | 0..1        |  1.0.0  |
+ | 11    | stateDependence                      | Guid                         | 0..1        |  1.0.0  |
+ | 12    | valueSet                             | Guid                         | 1..*        |  1.0.0  |
+ | 13    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 15    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 16    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Parameter"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ParameterEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Parameter"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Parameter"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Parameter"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Parameter"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Parameter me, Parameter other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.AllowDifferentOwnerOfOverride.Equals(other.AllowDifferentOwnerOfOverride)) return false;
+
+            if (!me.ExpectsOverride.Equals(other.ExpectsOverride)) return false;
+
+            if (!me.Group.HasValue && other.Group.HasValue) return false;
+            if (!me.Group.Equals(other.Group)) return false;
+
+            if (!me.IsOptionDependent.Equals(other.IsOptionDependent)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.ParameterSubscription.OrderBy(x => x).SequenceEqual(other.ParameterSubscription.OrderBy(x => x))) return false;
+
+            if (!me.ParameterType.Equals(other.ParameterType)) return false;
+
+            if (!me.RequestedBy.HasValue && other.RequestedBy.HasValue) return false;
+            if (!me.RequestedBy.Equals(other.RequestedBy)) return false;
+
+            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (!me.Scale.Equals(other.Scale)) return false;
+
+            if (!me.StateDependence.HasValue && other.StateDependence.HasValue) return false;
+            if (!me.StateDependence.Equals(other.StateDependence)) return false;
+
+            if (!me.ValueSet.OrderBy(x => x).SequenceEqual(other.ValueSet.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ParameterGroupEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParameterGroupEquatable.cs
@@ -78,7 +78,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
 
-            if (!me.ContainingGroup.HasValue && other.ContainingGroup.HasValue) return false;
+            if (me.ContainingGroup.HasValue != other.ContainingGroup.HasValue) return false;
             if (!me.ContainingGroup.Equals(other.ContainingGroup)) return false;
 
             if (me.Name == null && other.Name != null) return false;

--- a/CDP4Common/AutoGenEquatable/ParameterGroupEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParameterGroupEquatable.cs
@@ -1,0 +1,103 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterGroupEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | containingGroup                      | Guid                         | 0..1        |  1.0.0  |
+ | 3     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ParameterGroup"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ParameterGroupEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ParameterGroup"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ParameterGroup"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ParameterGroup"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ParameterGroup"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ParameterGroup me, ParameterGroup other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ContainingGroup.HasValue && other.ContainingGroup.HasValue) return false;
+            if (!me.ContainingGroup.Equals(other.ContainingGroup)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ParameterOverrideEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParameterOverrideEquatable.cs
@@ -1,0 +1,107 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterOverrideEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 3     | parameter                            | Guid                         | 1..1        |  1.0.0  |
+ | 4     | parameterSubscription                | Guid                         | 0..*        |  1.0.0  |
+ | 5     | valueSet                             | Guid                         | 1..*        |  1.0.0  |
+ | 6     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ParameterOverride"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ParameterOverrideEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ParameterOverride"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ParameterOverride"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ParameterOverride"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ParameterOverride"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ParameterOverride me, ParameterOverride other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.Parameter.Equals(other.Parameter)) return false;
+
+            if (!me.ParameterSubscription.OrderBy(x => x).SequenceEqual(other.ParameterSubscription.OrderBy(x => x))) return false;
+
+            if (!me.ValueSet.OrderBy(x => x).SequenceEqual(other.ValueSet.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ParameterOverrideValueSetEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParameterOverrideValueSetEquatable.cs
@@ -1,0 +1,116 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterOverrideValueSetEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | computed                             | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 3     | formula                              | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 4     | manual                               | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 5     | parameterValueSet                    | Guid                         | 1..1        |  1.0.0  |
+ | 6     | published                            | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 7     | reference                            | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 8     | valueSwitch                          | ParameterSwitchKind          | 1..1        |  1.0.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ParameterOverrideValueSet"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ParameterOverrideValueSetEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ParameterOverrideValueSet"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ParameterOverrideValueSet"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ParameterOverrideValueSet"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ParameterOverrideValueSet"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ParameterOverrideValueSet me, ParameterOverrideValueSet other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Computed.SequenceEqual(other.Computed)) return false;
+
+            if (!me.Formula.SequenceEqual(other.Formula)) return false;
+
+            if (!me.Manual.SequenceEqual(other.Manual)) return false;
+
+            if (!me.ParameterValueSet.Equals(other.ParameterValueSet)) return false;
+
+            if (!me.Published.SequenceEqual(other.Published)) return false;
+
+            if (!me.Reference.SequenceEqual(other.Reference)) return false;
+
+            if (!me.ValueSwitch.Equals(other.ValueSwitch)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ParameterSubscriptionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParameterSubscriptionEquatable.cs
@@ -1,0 +1,101 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterSubscriptionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 3     | valueSet                             | Guid                         | 1..*        |  1.0.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ParameterSubscription"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ParameterSubscriptionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ParameterSubscription"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ParameterSubscription"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ParameterSubscription"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ParameterSubscription"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ParameterSubscription me, ParameterSubscription other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.ValueSet.OrderBy(x => x).SequenceEqual(other.ValueSet.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ParameterSubscriptionValueSetEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParameterSubscriptionValueSetEquatable.cs
@@ -1,0 +1,104 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterSubscriptionValueSetEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | manual                               | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 3     | subscribedValueSet                   | Guid                         | 1..1        |  1.0.0  |
+ | 4     | valueSwitch                          | ParameterSwitchKind          | 1..1        |  1.0.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ParameterSubscriptionValueSet"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ParameterSubscriptionValueSetEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ParameterSubscriptionValueSet"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ParameterSubscriptionValueSet"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ParameterSubscriptionValueSet"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ParameterSubscriptionValueSet"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ParameterSubscriptionValueSet me, ParameterSubscriptionValueSet other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Manual.SequenceEqual(other.Manual)) return false;
+
+            if (!me.SubscribedValueSet.Equals(other.SubscribedValueSet)) return false;
+
+            if (!me.ValueSwitch.Equals(other.ValueSwitch)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ParameterTypeComponentEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParameterTypeComponentEquatable.cs
@@ -81,7 +81,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ParameterType.Equals(other.ParameterType)) return false;
 
-            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (me.Scale.HasValue != other.Scale.HasValue) return false;
             if (!me.Scale.Equals(other.Scale)) return false;
 
             if (me.ShortName == null && other.ShortName != null) return false;

--- a/CDP4Common/AutoGenEquatable/ParameterTypeComponentEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParameterTypeComponentEquatable.cs
@@ -1,0 +1,106 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterTypeComponentEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | parameterType                        | Guid                         | 1..1        |  1.0.0  |
+ | 3     | scale                                | Guid                         | 0..1        |  1.0.0  |
+ | 4     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ParameterTypeComponent"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ParameterTypeComponentEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ParameterTypeComponent"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ParameterTypeComponent"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ParameterTypeComponent"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ParameterTypeComponent"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ParameterTypeComponent me, ParameterTypeComponent other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ParameterType.Equals(other.ParameterType)) return false;
+
+            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (!me.Scale.Equals(other.Scale)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ParameterValueSetEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParameterValueSetEquatable.cs
@@ -84,10 +84,10 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
 
-            if (!me.ActualOption.HasValue && other.ActualOption.HasValue) return false;
+            if (me.ActualOption.HasValue != other.ActualOption.HasValue) return false;
             if (!me.ActualOption.Equals(other.ActualOption)) return false;
 
-            if (!me.ActualState.HasValue && other.ActualState.HasValue) return false;
+            if (me.ActualState.HasValue != other.ActualState.HasValue) return false;
             if (!me.ActualState.Equals(other.ActualState)) return false;
 
             if (!me.Computed.SequenceEqual(other.Computed)) return false;

--- a/CDP4Common/AutoGenEquatable/ParameterValueSetEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParameterValueSetEquatable.cs
@@ -1,0 +1,121 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterValueSetEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | actualOption                         | Guid                         | 0..1        |  1.0.0  |
+ | 3     | actualState                          | Guid                         | 0..1        |  1.0.0  |
+ | 4     | computed                             | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 5     | formula                              | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 6     | manual                               | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 7     | published                            | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 8     | reference                            | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 9     | valueSwitch                          | ParameterSwitchKind          | 1..1        |  1.0.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ParameterValueSet"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ParameterValueSetEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ParameterValueSet"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ParameterValueSet"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ParameterValueSet"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ParameterValueSet"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ParameterValueSet me, ParameterValueSet other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ActualOption.HasValue && other.ActualOption.HasValue) return false;
+            if (!me.ActualOption.Equals(other.ActualOption)) return false;
+
+            if (!me.ActualState.HasValue && other.ActualState.HasValue) return false;
+            if (!me.ActualState.Equals(other.ActualState)) return false;
+
+            if (!me.Computed.SequenceEqual(other.Computed)) return false;
+
+            if (!me.Formula.SequenceEqual(other.Formula)) return false;
+
+            if (!me.Manual.SequenceEqual(other.Manual)) return false;
+
+            if (!me.Published.SequenceEqual(other.Published)) return false;
+
+            if (!me.Reference.SequenceEqual(other.Reference)) return false;
+
+            if (!me.ValueSwitch.Equals(other.ValueSwitch)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ParameterizedCategoryRuleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParameterizedCategoryRuleEquatable.cs
@@ -1,0 +1,121 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterizedCategoryRuleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 1..1        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | parameterType                        | Guid                         | 1..*        |  1.0.0  |
+ | 9     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ParameterizedCategoryRule"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ParameterizedCategoryRuleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ParameterizedCategoryRule"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ParameterizedCategoryRule"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ParameterizedCategoryRule"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ParameterizedCategoryRule"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ParameterizedCategoryRule me, ParameterizedCategoryRule other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.Equals(other.Category)) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.ParameterType.OrderBy(x => x).SequenceEqual(other.ParameterType.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ParametricConstraintEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParametricConstraintEquatable.cs
@@ -80,7 +80,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Expression.OrderBy(x => x).SequenceEqual(other.Expression.OrderBy(x => x))) return false;
 
-            if (!me.TopExpression.HasValue && other.TopExpression.HasValue) return false;
+            if (me.TopExpression.HasValue != other.TopExpression.HasValue) return false;
             if (!me.TopExpression.Equals(other.TopExpression)) return false;
 
             if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/ParametricConstraintEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParametricConstraintEquatable.cs
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParametricConstraintEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | expression                           | Guid                         | 1..*        |  1.0.0  |
+ | 3     | topExpression                        | Guid                         | 0..1        |  1.0.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ParametricConstraint"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ParametricConstraintEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ParametricConstraint"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ParametricConstraint"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ParametricConstraint"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ParametricConstraint"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ParametricConstraint me, ParametricConstraint other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Expression.OrderBy(x => x).SequenceEqual(other.Expression.OrderBy(x => x))) return false;
+
+            if (!me.TopExpression.HasValue && other.TopExpression.HasValue) return false;
+            if (!me.TopExpression.Equals(other.TopExpression)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ParticipantEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParticipantEquatable.cs
@@ -1,0 +1,110 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParticipantEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | domain                               | Guid                         | 1..*        |  1.0.0  |
+ | 3     | isActive                             | bool                         | 1..1        |  1.0.0  |
+ | 4     | person                               | Guid                         | 1..1        |  1.0.0  |
+ | 5     | role                                 | Guid                         | 1..1        |  1.0.0  |
+ | 6     | selectedDomain                       | Guid                         | 1..1        |  1.0.0  |
+ | 7     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Participant"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ParticipantEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Participant"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Participant"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Participant"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Participant"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Participant me, Participant other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Domain.OrderBy(x => x).SequenceEqual(other.Domain.OrderBy(x => x))) return false;
+
+            if (!me.IsActive.Equals(other.IsActive)) return false;
+
+            if (!me.Person.Equals(other.Person)) return false;
+
+            if (!me.Role.Equals(other.Role)) return false;
+
+            if (!me.SelectedDomain.Equals(other.SelectedDomain)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ParticipantPermissionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParticipantPermissionEquatable.cs
@@ -1,0 +1,104 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParticipantPermissionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | accessRight                          | ParticipantAccessRightKind   | 1..1        |  1.0.0  |
+ | 3     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 4     | objectClass                          | ClassKind                    | 1..1        |  1.0.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ParticipantPermission"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ParticipantPermissionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ParticipantPermission"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ParticipantPermission"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ParticipantPermission"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ParticipantPermission"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ParticipantPermission me, ParticipantPermission other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.AccessRight.Equals(other.AccessRight)) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.ObjectClass.Equals(other.ObjectClass)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ParticipantRoleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ParticipantRoleEquatable.cs
@@ -1,0 +1,118 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParticipantRoleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 6     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 7     | participantPermission                | Guid                         | 0..*        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ParticipantRole"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ParticipantRoleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ParticipantRole"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ParticipantRole"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ParticipantRole"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ParticipantRole"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ParticipantRole me, ParticipantRole other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.ParticipantPermission.OrderBy(x => x).SequenceEqual(other.ParticipantPermission.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/PersonEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/PersonEquatable.cs
@@ -1,0 +1,150 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PersonEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | defaultDomain                        | Guid                         | 0..1        |  1.0.0  |
+ | 3     | defaultEmailAddress                  | Guid                         | 0..1        |  1.0.0  |
+ | 4     | defaultTelephoneNumber               | Guid                         | 0..1        |  1.0.0  |
+ | 5     | emailAddress                         | Guid                         | 0..*        |  1.0.0  |
+ | 6     | givenName                            | string                       | 1..1        |  1.0.0  |
+ | 7     | isActive                             | bool                         | 1..1        |  1.0.0  |
+ | 8     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 9     | organization                         | Guid                         | 0..1        |  1.0.0  |
+ | 10    | organizationalUnit                   | string                       | 0..1        |  1.0.0  |
+ | 11    | password                             | string                       | 0..1        |  1.0.0  |
+ | 12    | role                                 | Guid                         | 0..1        |  1.0.0  |
+ | 13    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 14    | surname                              | string                       | 1..1        |  1.0.0  |
+ | 15    | telephoneNumber                      | Guid                         | 0..*        |  1.0.0  |
+ | 16    | userPreference                       | Guid                         | 0..*        |  1.0.0  |
+ | 17    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 18    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 19    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 20    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Person"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class PersonEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Person"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Person"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Person"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Person"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Person me, Person other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.DefaultDomain.HasValue && other.DefaultDomain.HasValue) return false;
+            if (!me.DefaultDomain.Equals(other.DefaultDomain)) return false;
+
+            if (!me.DefaultEmailAddress.HasValue && other.DefaultEmailAddress.HasValue) return false;
+            if (!me.DefaultEmailAddress.Equals(other.DefaultEmailAddress)) return false;
+
+            if (!me.DefaultTelephoneNumber.HasValue && other.DefaultTelephoneNumber.HasValue) return false;
+            if (!me.DefaultTelephoneNumber.Equals(other.DefaultTelephoneNumber)) return false;
+
+            if (!me.EmailAddress.OrderBy(x => x).SequenceEqual(other.EmailAddress.OrderBy(x => x))) return false;
+
+            if (me.GivenName == null && other.GivenName != null) return false;
+            if (me.GivenName != null && !me.GivenName.Equals(other.GivenName)) return false;
+
+            if (!me.IsActive.Equals(other.IsActive)) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.Organization.HasValue && other.Organization.HasValue) return false;
+            if (!me.Organization.Equals(other.Organization)) return false;
+
+            if (me.OrganizationalUnit == null && other.OrganizationalUnit != null) return false;
+            if (me.OrganizationalUnit != null && !me.OrganizationalUnit.Equals(other.OrganizationalUnit)) return false;
+
+            if (me.Password == null && other.Password != null) return false;
+            if (me.Password != null && !me.Password.Equals(other.Password)) return false;
+
+            if (!me.Role.HasValue && other.Role.HasValue) return false;
+            if (!me.Role.Equals(other.Role)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Surname == null && other.Surname != null) return false;
+            if (me.Surname != null && !me.Surname.Equals(other.Surname)) return false;
+
+            if (!me.TelephoneNumber.OrderBy(x => x).SequenceEqual(other.TelephoneNumber.OrderBy(x => x))) return false;
+
+            if (!me.UserPreference.OrderBy(x => x).SequenceEqual(other.UserPreference.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/PersonEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/PersonEquatable.cs
@@ -91,13 +91,13 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
 
-            if (!me.DefaultDomain.HasValue && other.DefaultDomain.HasValue) return false;
+            if (me.DefaultDomain.HasValue != other.DefaultDomain.HasValue) return false;
             if (!me.DefaultDomain.Equals(other.DefaultDomain)) return false;
 
-            if (!me.DefaultEmailAddress.HasValue && other.DefaultEmailAddress.HasValue) return false;
+            if (me.DefaultEmailAddress.HasValue != other.DefaultEmailAddress.HasValue) return false;
             if (!me.DefaultEmailAddress.Equals(other.DefaultEmailAddress)) return false;
 
-            if (!me.DefaultTelephoneNumber.HasValue && other.DefaultTelephoneNumber.HasValue) return false;
+            if (me.DefaultTelephoneNumber.HasValue != other.DefaultTelephoneNumber.HasValue) return false;
             if (!me.DefaultTelephoneNumber.Equals(other.DefaultTelephoneNumber)) return false;
 
             if (!me.EmailAddress.OrderBy(x => x).SequenceEqual(other.EmailAddress.OrderBy(x => x))) return false;
@@ -109,7 +109,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
 
-            if (!me.Organization.HasValue && other.Organization.HasValue) return false;
+            if (me.Organization.HasValue != other.Organization.HasValue) return false;
             if (!me.Organization.Equals(other.Organization)) return false;
 
             if (me.OrganizationalUnit == null && other.OrganizationalUnit != null) return false;
@@ -118,7 +118,7 @@ namespace CDP4Common.DTO.Equatable
             if (me.Password == null && other.Password != null) return false;
             if (me.Password != null && !me.Password.Equals(other.Password)) return false;
 
-            if (!me.Role.HasValue && other.Role.HasValue) return false;
+            if (me.Role.HasValue != other.Role.HasValue) return false;
             if (!me.Role.Equals(other.Role)) return false;
 
             if (me.ShortName == null && other.ShortName != null) return false;

--- a/CDP4Common/AutoGenEquatable/PersonPermissionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/PersonPermissionEquatable.cs
@@ -1,0 +1,104 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PersonPermissionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | accessRight                          | PersonAccessRightKind        | 1..1        |  1.0.0  |
+ | 3     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 4     | objectClass                          | ClassKind                    | 1..1        |  1.0.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="PersonPermission"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class PersonPermissionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="PersonPermission"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="PersonPermission"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="PersonPermission"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="PersonPermission"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this PersonPermission me, PersonPermission other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.AccessRight.Equals(other.AccessRight)) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.ObjectClass.Equals(other.ObjectClass)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/PersonRoleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/PersonRoleEquatable.cs
@@ -1,0 +1,118 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PersonRoleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 6     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 7     | personPermission                     | Guid                         | 0..*        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="PersonRole"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class PersonRoleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="PersonRole"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="PersonRole"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="PersonRole"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="PersonRole"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this PersonRole me, PersonRole other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.PersonPermission.OrderBy(x => x).SequenceEqual(other.PersonPermission.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/PointEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/PointEquatable.cs
@@ -1,0 +1,105 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PointEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | name                                 | string                       | 1..1        |  1.1.0  |
+ | 6     | x                                    | float                        | 1..1        |  1.1.0  |
+ | 7     | y                                    | float                        | 1..1        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Point"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class PointEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Point"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Point"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Point"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Point"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Point me, Point other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.X.Equals(other.X)) return false;
+
+            if (!me.Y.Equals(other.Y)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/PossibleFiniteStateEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/PossibleFiniteStateEquatable.cs
@@ -1,0 +1,112 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PossibleFiniteStateEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 6     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 7     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="PossibleFiniteState"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class PossibleFiniteStateEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="PossibleFiniteState"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="PossibleFiniteState"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="PossibleFiniteState"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="PossibleFiniteState"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this PossibleFiniteState me, PossibleFiniteState other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/PossibleFiniteStateListEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/PossibleFiniteStateListEquatable.cs
@@ -89,7 +89,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
 
-            if (!me.DefaultState.HasValue && other.DefaultState.HasValue) return false;
+            if (me.DefaultState.HasValue != other.DefaultState.HasValue) return false;
             if (!me.DefaultState.Equals(other.DefaultState)) return false;
 
             if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/PossibleFiniteStateListEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/PossibleFiniteStateListEquatable.cs
@@ -1,0 +1,126 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PossibleFiniteStateListEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | defaultState                         | Guid                         | 0..1        |  1.0.0  |
+ | 5     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 6     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 9     | possibleState                        | Guid                         | 1..*        |  1.0.0  |
+ | 10    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 11    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 13    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 14    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="PossibleFiniteStateList"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class PossibleFiniteStateListEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="PossibleFiniteStateList"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="PossibleFiniteStateList"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="PossibleFiniteStateList"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="PossibleFiniteStateList"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this PossibleFiniteStateList me, PossibleFiniteStateList other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.DefaultState.HasValue && other.DefaultState.HasValue) return false;
+            if (!me.DefaultState.Equals(other.DefaultState)) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.PossibleState.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.PossibleState.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.PossibleState.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.PossibleState.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/PrefixedUnitEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/PrefixedUnitEquatable.cs
@@ -1,0 +1,113 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PrefixedUnitEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 6     | prefix                               | Guid                         | 1..1        |  1.0.0  |
+ | 7     | referenceUnit                        | Guid                         | 1..1        |  1.0.0  |
+ | 8     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="PrefixedUnit"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class PrefixedUnitEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="PrefixedUnit"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="PrefixedUnit"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="PrefixedUnit"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="PrefixedUnit"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this PrefixedUnit me, PrefixedUnit other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.Prefix.Equals(other.Prefix)) return false;
+
+            if (!me.ReferenceUnit.Equals(other.ReferenceUnit)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/PublicationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/PublicationEquatable.cs
@@ -1,0 +1,104 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PublicationEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | createdOn                            | DateTime                     | 1..1        |  1.0.0  |
+ | 3     | domain                               | Guid                         | 0..*        |  1.0.0  |
+ | 4     | publishedParameter                   | Guid                         | 0..*        |  1.0.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Publication"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class PublicationEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Publication"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Publication"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Publication"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Publication"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Publication me, Publication other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.Domain.OrderBy(x => x).SequenceEqual(other.Domain.OrderBy(x => x))) return false;
+
+            if (!me.PublishedParameter.OrderBy(x => x).SequenceEqual(other.PublishedParameter.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/QuantityKindFactorEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/QuantityKindFactorEquatable.cs
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="QuantityKindFactorEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | exponent                             | string                       | 1..1        |  1.0.0  |
+ | 3     | quantityKind                         | Guid                         | 1..1        |  1.0.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="QuantityKindFactor"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class QuantityKindFactorEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="QuantityKindFactor"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="QuantityKindFactor"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="QuantityKindFactor"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="QuantityKindFactor"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this QuantityKindFactor me, QuantityKindFactor other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (me.Exponent == null && other.Exponent != null) return false;
+            if (me.Exponent != null && !me.Exponent.Equals(other.Exponent)) return false;
+
+            if (!me.QuantityKind.Equals(other.QuantityKind)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/RatioScaleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RatioScaleEquatable.cs
@@ -1,0 +1,149 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RatioScaleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 6     | isMaximumInclusive                   | bool                         | 1..1        |  1.0.0  |
+ | 7     | isMinimumInclusive                   | bool                         | 1..1        |  1.0.0  |
+ | 8     | mappingToReferenceScale              | Guid                         | 0..*        |  1.0.0  |
+ | 9     | maximumPermissibleValue              | string                       | 0..1        |  1.0.0  |
+ | 10    | minimumPermissibleValue              | string                       | 0..1        |  1.0.0  |
+ | 11    | name                                 | string                       | 1..1        |  1.0.0  |
+ | 12    | negativeValueConnotation             | string                       | 0..1        |  1.0.0  |
+ | 13    | numberSet                            | NumberSetKind                | 1..1        |  1.0.0  |
+ | 14    | positiveValueConnotation             | string                       | 0..1        |  1.0.0  |
+ | 15    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 16    | unit                                 | Guid                         | 1..1        |  1.0.0  |
+ | 17    | valueDefinition                      | Guid                         | 0..*        |  1.0.0  |
+ | 18    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 19    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 20    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 21    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="RatioScale"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class RatioScaleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="RatioScale"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="RatioScale"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="RatioScale"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="RatioScale"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this RatioScale me, RatioScale other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.IsMaximumInclusive.Equals(other.IsMaximumInclusive)) return false;
+
+            if (!me.IsMinimumInclusive.Equals(other.IsMinimumInclusive)) return false;
+
+            if (!me.MappingToReferenceScale.OrderBy(x => x).SequenceEqual(other.MappingToReferenceScale.OrderBy(x => x))) return false;
+
+            if (me.MaximumPermissibleValue == null && other.MaximumPermissibleValue != null) return false;
+            if (me.MaximumPermissibleValue != null && !me.MaximumPermissibleValue.Equals(other.MaximumPermissibleValue)) return false;
+
+            if (me.MinimumPermissibleValue == null && other.MinimumPermissibleValue != null) return false;
+            if (me.MinimumPermissibleValue != null && !me.MinimumPermissibleValue.Equals(other.MinimumPermissibleValue)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.NegativeValueConnotation == null && other.NegativeValueConnotation != null) return false;
+            if (me.NegativeValueConnotation != null && !me.NegativeValueConnotation.Equals(other.NegativeValueConnotation)) return false;
+
+            if (!me.NumberSet.Equals(other.NumberSet)) return false;
+
+            if (me.PositiveValueConnotation == null && other.PositiveValueConnotation != null) return false;
+            if (me.PositiveValueConnotation != null && !me.PositiveValueConnotation.Equals(other.PositiveValueConnotation)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.Unit.Equals(other.Unit)) return false;
+
+            if (!me.ValueDefinition.OrderBy(x => x).SequenceEqual(other.ValueDefinition.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ReferenceSourceEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ReferenceSourceEquatable.cs
@@ -109,19 +109,19 @@ namespace CDP4Common.DTO.Equatable
             if (me.Name == null && other.Name != null) return false;
             if (me.Name != null && !me.Name.Equals(other.Name)) return false;
 
-            if (!me.PublicationYear.HasValue && other.PublicationYear.HasValue) return false;
+            if (me.PublicationYear.HasValue != other.PublicationYear.HasValue) return false;
             if (!me.PublicationYear.Equals(other.PublicationYear)) return false;
 
-            if (!me.PublishedIn.HasValue && other.PublishedIn.HasValue) return false;
+            if (me.PublishedIn.HasValue != other.PublishedIn.HasValue) return false;
             if (!me.PublishedIn.Equals(other.PublishedIn)) return false;
 
-            if (!me.Publisher.HasValue && other.Publisher.HasValue) return false;
+            if (me.Publisher.HasValue != other.Publisher.HasValue) return false;
             if (!me.Publisher.Equals(other.Publisher)) return false;
 
             if (me.ShortName == null && other.ShortName != null) return false;
             if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
 
-            if (!me.VersionDate.HasValue && other.VersionDate.HasValue) return false;
+            if (me.VersionDate.HasValue != other.VersionDate.HasValue) return false;
             if (!me.VersionDate.Equals(other.VersionDate)) return false;
 
             if (me.VersionIdentifier == null && other.VersionIdentifier != null) return false;

--- a/CDP4Common/AutoGenEquatable/ReferenceSourceEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ReferenceSourceEquatable.cs
@@ -1,0 +1,146 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ReferenceSourceEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | author                               | string                       | 0..1        |  1.0.0  |
+ | 4     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 5     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 6     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 8     | language                             | string                       | 0..1        |  1.0.0  |
+ | 9     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 10    | publicationYear                      | int                          | 0..1        |  1.0.0  |
+ | 11    | publishedIn                          | Guid                         | 0..1        |  1.0.0  |
+ | 12    | publisher                            | Guid                         | 0..1        |  1.0.0  |
+ | 13    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 14    | versionDate                          | DateTime                     | 0..1        |  1.0.0  |
+ | 15    | versionIdentifier                    | string                       | 0..1        |  1.0.0  |
+ | 16    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 17    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 18    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 19    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ReferenceSource"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ReferenceSourceEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ReferenceSource"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ReferenceSource"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ReferenceSource"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ReferenceSource"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ReferenceSource me, ReferenceSource other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (me.Author == null && other.Author != null) return false;
+            if (me.Author != null && !me.Author.Equals(other.Author)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Language == null && other.Language != null) return false;
+            if (me.Language != null && !me.Language.Equals(other.Language)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.PublicationYear.HasValue && other.PublicationYear.HasValue) return false;
+            if (!me.PublicationYear.Equals(other.PublicationYear)) return false;
+
+            if (!me.PublishedIn.HasValue && other.PublishedIn.HasValue) return false;
+            if (!me.PublishedIn.Equals(other.PublishedIn)) return false;
+
+            if (!me.Publisher.HasValue && other.Publisher.HasValue) return false;
+            if (!me.Publisher.Equals(other.Publisher)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.VersionDate.HasValue && other.VersionDate.HasValue) return false;
+            if (!me.VersionDate.Equals(other.VersionDate)) return false;
+
+            if (me.VersionIdentifier == null && other.VersionIdentifier != null) return false;
+            if (me.VersionIdentifier != null && !me.VersionIdentifier.Equals(other.VersionIdentifier)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ReferencerRuleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ReferencerRuleEquatable.cs
@@ -1,0 +1,127 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ReferencerRuleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 6     | maxReferenced                        | int                          | 1..1        |  1.0.0  |
+ | 7     | minReferenced                        | int                          | 1..1        |  1.0.0  |
+ | 8     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 9     | referencedCategory                   | Guid                         | 1..*        |  1.0.0  |
+ | 10    | referencingCategory                  | Guid                         | 1..1        |  1.0.0  |
+ | 11    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 12    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 13    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 15    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ReferencerRule"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ReferencerRuleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ReferencerRule"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ReferencerRule"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ReferencerRule"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ReferencerRule"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ReferencerRule me, ReferencerRule other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (!me.MaxReferenced.Equals(other.MaxReferenced)) return false;
+
+            if (!me.MinReferenced.Equals(other.MinReferenced)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.ReferencedCategory.OrderBy(x => x).SequenceEqual(other.ReferencedCategory.OrderBy(x => x))) return false;
+
+            if (!me.ReferencingCategory.Equals(other.ReferencingCategory)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/RelationalExpressionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RelationalExpressionEquatable.cs
@@ -1,0 +1,108 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RelationalExpressionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | parameterType                        | Guid                         | 1..1        |  1.0.0  |
+ | 3     | relationalOperator                   | RelationalOperatorKind       | 1..1        |  1.0.0  |
+ | 4     | scale                                | Guid                         | 0..1        |  1.0.0  |
+ | 5     | value                                | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 6     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="RelationalExpression"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class RelationalExpressionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="RelationalExpression"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="RelationalExpression"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="RelationalExpression"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="RelationalExpression"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this RelationalExpression me, RelationalExpression other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ParameterType.Equals(other.ParameterType)) return false;
+
+            if (!me.RelationalOperator.Equals(other.RelationalOperator)) return false;
+
+            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (!me.Scale.Equals(other.Scale)) return false;
+
+            if (!me.Value.SequenceEqual(other.Value)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/RelationalExpressionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RelationalExpressionEquatable.cs
@@ -84,7 +84,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.RelationalOperator.Equals(other.RelationalOperator)) return false;
 
-            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (me.Scale.HasValue != other.Scale.HasValue) return false;
             if (!me.Scale.Equals(other.Scale)) return false;
 
             if (!me.Value.SequenceEqual(other.Value)) return false;

--- a/CDP4Common/AutoGenEquatable/RelationshipParameterValueEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RelationshipParameterValueEquatable.cs
@@ -1,0 +1,105 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipParameterValueEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | parameterType                        | Guid                         | 1..1        |  1.1.0  |
+ | 6     | scale                                | Guid                         | 0..1        |  1.1.0  |
+ | 7     | value                                | ValueArray<string>           | 1..*        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="RelationshipParameterValue"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class RelationshipParameterValueEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="RelationshipParameterValue"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="RelationshipParameterValue"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="RelationshipParameterValue"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="RelationshipParameterValue"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this RelationshipParameterValue me, RelationshipParameterValue other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.ParameterType.Equals(other.ParameterType)) return false;
+
+            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (!me.Scale.Equals(other.Scale)) return false;
+
+            if (!me.Value.SequenceEqual(other.Value)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/RelationshipParameterValueEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RelationshipParameterValueEquatable.cs
@@ -87,7 +87,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ParameterType.Equals(other.ParameterType)) return false;
 
-            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (me.Scale.HasValue != other.Scale.HasValue) return false;
             if (!me.Scale.Equals(other.Scale)) return false;
 
             if (!me.Value.SequenceEqual(other.Value)) return false;

--- a/CDP4Common/AutoGenEquatable/RequestForDeviationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RequestForDeviationEquatable.cs
@@ -117,7 +117,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Owner.Equals(other.Owner)) return false;
 
-            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (me.PrimaryAnnotatedThing.HasValue != other.PrimaryAnnotatedThing.HasValue) return false;
             if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
 
             if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/RequestForDeviationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RequestForDeviationEquatable.cs
@@ -1,0 +1,145 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RequestForDeviationEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | approvedBy                           | Guid                         | 0..*        |  1.1.0  |
+ | 3     | author                               | Guid                         | 1..1        |  1.1.0  |
+ | 4     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 5     | classification                       | AnnotationClassificationKind | 1..1        |  1.1.0  |
+ | 6     | content                              | string                       | 1..1        |  1.1.0  |
+ | 7     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | discussion                           | Guid                         | 0..*        |  1.1.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 14    | primaryAnnotatedThing                | Guid                         | 0..1        |  1.1.0  |
+ | 15    | relatedThing                         | Guid                         | 0..*        |  1.1.0  |
+ | 16    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 17    | sourceAnnotation                     | Guid                         | 0..*        |  1.1.0  |
+ | 18    | status                               | AnnotationStatusKind         | 1..1        |  1.1.0  |
+ | 19    | title                                | string                       | 1..1        |  1.1.0  |
+ | 20    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="RequestForDeviation"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class RequestForDeviationEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="RequestForDeviation"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="RequestForDeviation"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="RequestForDeviation"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="RequestForDeviation"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this RequestForDeviation me, RequestForDeviation other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ApprovedBy.OrderBy(x => x).SequenceEqual(other.ApprovedBy.OrderBy(x => x))) return false;
+
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Classification.Equals(other.Classification)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.Discussion.OrderBy(x => x).SequenceEqual(other.Discussion.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
+
+            if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.SourceAnnotation.OrderBy(x => x).SequenceEqual(other.SourceAnnotation.OrderBy(x => x))) return false;
+
+            if (!me.Status.Equals(other.Status)) return false;
+
+            if (me.Title == null && other.Title != null) return false;
+            if (me.Title != null && !me.Title.Equals(other.Title)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/RequestForWaiverEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RequestForWaiverEquatable.cs
@@ -117,7 +117,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Owner.Equals(other.Owner)) return false;
 
-            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (me.PrimaryAnnotatedThing.HasValue != other.PrimaryAnnotatedThing.HasValue) return false;
             if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
 
             if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/RequestForWaiverEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RequestForWaiverEquatable.cs
@@ -1,0 +1,145 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RequestForWaiverEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | approvedBy                           | Guid                         | 0..*        |  1.1.0  |
+ | 3     | author                               | Guid                         | 1..1        |  1.1.0  |
+ | 4     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 5     | classification                       | AnnotationClassificationKind | 1..1        |  1.1.0  |
+ | 6     | content                              | string                       | 1..1        |  1.1.0  |
+ | 7     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | discussion                           | Guid                         | 0..*        |  1.1.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 14    | primaryAnnotatedThing                | Guid                         | 0..1        |  1.1.0  |
+ | 15    | relatedThing                         | Guid                         | 0..*        |  1.1.0  |
+ | 16    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 17    | sourceAnnotation                     | Guid                         | 0..*        |  1.1.0  |
+ | 18    | status                               | AnnotationStatusKind         | 1..1        |  1.1.0  |
+ | 19    | title                                | string                       | 1..1        |  1.1.0  |
+ | 20    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="RequestForWaiver"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class RequestForWaiverEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="RequestForWaiver"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="RequestForWaiver"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="RequestForWaiver"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="RequestForWaiver"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this RequestForWaiver me, RequestForWaiver other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ApprovedBy.OrderBy(x => x).SequenceEqual(other.ApprovedBy.OrderBy(x => x))) return false;
+
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Classification.Equals(other.Classification)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.Discussion.OrderBy(x => x).SequenceEqual(other.Discussion.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
+
+            if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.SourceAnnotation.OrderBy(x => x).SequenceEqual(other.SourceAnnotation.OrderBy(x => x))) return false;
+
+            if (!me.Status.Equals(other.Status)) return false;
+
+            if (me.Title == null && other.Title != null) return false;
+            if (me.Title != null && !me.Title.Equals(other.Title)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/RequirementEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RequirementEquatable.cs
@@ -1,0 +1,132 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RequirementEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | group                                | Guid                         | 0..1        |  1.0.0  |
+ | 6     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 8     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 9     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 10    | parameterValue                       | Guid                         | 0..*        |  1.0.0  |
+ | 11    | parametricConstraint                 | Guid                         | 0..*        |  1.0.0  |
+ | 12    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 13    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 15    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 16    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Requirement"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class RequirementEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Requirement"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Requirement"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Requirement"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Requirement"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Requirement me, Requirement other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.Group.HasValue && other.Group.HasValue) return false;
+            if (!me.Group.Equals(other.Group)) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.ParameterValue.OrderBy(x => x).SequenceEqual(other.ParameterValue.OrderBy(x => x))) return false;
+
+            if (!me.ParametricConstraint.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.ParametricConstraint.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.ParametricConstraint.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.ParametricConstraint.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/RequirementEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RequirementEquatable.cs
@@ -93,7 +93,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
 
-            if (!me.Group.HasValue && other.Group.HasValue) return false;
+            if (me.Group.HasValue != other.Group.HasValue) return false;
             if (!me.Group.Equals(other.Group)) return false;
 
             if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/RequirementsContainerParameterValueEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RequirementsContainerParameterValueEquatable.cs
@@ -1,0 +1,105 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RequirementsContainerParameterValueEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | parameterType                        | Guid                         | 1..1        |  1.1.0  |
+ | 6     | scale                                | Guid                         | 0..1        |  1.1.0  |
+ | 7     | value                                | ValueArray<string>           | 1..*        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="RequirementsContainerParameterValue"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class RequirementsContainerParameterValueEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="RequirementsContainerParameterValue"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="RequirementsContainerParameterValue"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="RequirementsContainerParameterValue"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="RequirementsContainerParameterValue"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this RequirementsContainerParameterValue me, RequirementsContainerParameterValue other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.ParameterType.Equals(other.ParameterType)) return false;
+
+            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (!me.Scale.Equals(other.Scale)) return false;
+
+            if (!me.Value.SequenceEqual(other.Value)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/RequirementsContainerParameterValueEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RequirementsContainerParameterValueEquatable.cs
@@ -87,7 +87,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ParameterType.Equals(other.ParameterType)) return false;
 
-            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (me.Scale.HasValue != other.Scale.HasValue) return false;
             if (!me.Scale.Equals(other.Scale)) return false;
 
             if (!me.Value.SequenceEqual(other.Value)) return false;

--- a/CDP4Common/AutoGenEquatable/RequirementsGroupEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RequirementsGroupEquatable.cs
@@ -1,0 +1,124 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RequirementsGroupEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | group                                | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 7     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | parameterValue                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="RequirementsGroup"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class RequirementsGroupEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="RequirementsGroup"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="RequirementsGroup"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="RequirementsGroup"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="RequirementsGroup"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this RequirementsGroup me, RequirementsGroup other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.Group.OrderBy(x => x).SequenceEqual(other.Group.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.ParameterValue.OrderBy(x => x).SequenceEqual(other.ParameterValue.OrderBy(x => x))) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/RequirementsSpecificationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RequirementsSpecificationEquatable.cs
@@ -1,0 +1,130 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RequirementsSpecificationEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | group                                | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 9     | requirement                          | Guid                         | 0..*        |  1.0.0  |
+ | 10    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 11    | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 12    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 13    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 15    | parameterValue                       | Guid                         | 0..*        |  1.1.0  |
+ | 16    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="RequirementsSpecification"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class RequirementsSpecificationEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="RequirementsSpecification"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="RequirementsSpecification"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="RequirementsSpecification"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="RequirementsSpecification"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this RequirementsSpecification me, RequirementsSpecification other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.Group.OrderBy(x => x).SequenceEqual(other.Group.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.Requirement.OrderBy(x => x).SequenceEqual(other.Requirement.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.ParameterValue.OrderBy(x => x).SequenceEqual(other.ParameterValue.OrderBy(x => x))) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ReviewItemDiscrepancyEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ReviewItemDiscrepancyEquatable.cs
@@ -118,7 +118,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Owner.Equals(other.Owner)) return false;
 
-            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (me.PrimaryAnnotatedThing.HasValue != other.PrimaryAnnotatedThing.HasValue) return false;
             if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
 
             if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/ReviewItemDiscrepancyEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ReviewItemDiscrepancyEquatable.cs
@@ -1,0 +1,148 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ReviewItemDiscrepancyEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | approvedBy                           | Guid                         | 0..*        |  1.1.0  |
+ | 3     | author                               | Guid                         | 1..1        |  1.1.0  |
+ | 4     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 5     | classification                       | AnnotationClassificationKind | 1..1        |  1.1.0  |
+ | 6     | content                              | string                       | 1..1        |  1.1.0  |
+ | 7     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | discussion                           | Guid                         | 0..*        |  1.1.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 14    | primaryAnnotatedThing                | Guid                         | 0..1        |  1.1.0  |
+ | 15    | relatedThing                         | Guid                         | 0..*        |  1.1.0  |
+ | 16    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 17    | solution                             | Guid                         | 0..1        |  1.1.0  |
+ | 18    | sourceAnnotation                     | Guid                         | 0..*        |  1.1.0  |
+ | 19    | status                               | AnnotationStatusKind         | 1..1        |  1.1.0  |
+ | 20    | title                                | string                       | 1..1        |  1.1.0  |
+ | 21    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ReviewItemDiscrepancy"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ReviewItemDiscrepancyEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ReviewItemDiscrepancy"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ReviewItemDiscrepancy"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ReviewItemDiscrepancy"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ReviewItemDiscrepancy"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ReviewItemDiscrepancy me, ReviewItemDiscrepancy other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ApprovedBy.OrderBy(x => x).SequenceEqual(other.ApprovedBy.OrderBy(x => x))) return false;
+
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Classification.Equals(other.Classification)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.Discussion.OrderBy(x => x).SequenceEqual(other.Discussion.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.PrimaryAnnotatedThing.HasValue && other.PrimaryAnnotatedThing.HasValue) return false;
+            if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
+
+            if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.Solution.OrderBy(x => x).SequenceEqual(other.Solution.OrderBy(x => x))) return false;
+
+            if (!me.SourceAnnotation.OrderBy(x => x).SequenceEqual(other.SourceAnnotation.OrderBy(x => x))) return false;
+
+            if (!me.Status.Equals(other.Status)) return false;
+
+            if (me.Title == null && other.Title != null) return false;
+            if (me.Title != null && !me.Title.Equals(other.Title)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/RuleVerificationListEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RuleVerificationListEquatable.cs
@@ -1,0 +1,119 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RuleVerificationListEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 6     | owner                                | Guid                         | 1..1        |  1.0.0  |
+ | 7     | ruleVerification                     | Guid                         | 0..*        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="RuleVerificationList"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class RuleVerificationListEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="RuleVerificationList"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="RuleVerificationList"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="RuleVerificationList"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="RuleVerificationList"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this RuleVerificationList me, RuleVerificationList other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.RuleVerification.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.RuleVerification.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.RuleVerification.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.RuleVerification.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/RuleViolationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/RuleViolationEquatable.cs
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RuleViolationEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | description                          | string                       | 1..1        |  1.0.0  |
+ | 3     | violatingThing                       | Guid                         | 0..*        |  1.0.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="RuleViolation"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class RuleViolationEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="RuleViolation"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="RuleViolation"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="RuleViolation"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="RuleViolation"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this RuleViolation me, RuleViolation other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (me.Description == null && other.Description != null) return false;
+            if (me.Description != null && !me.Description.Equals(other.Description)) return false;
+
+            if (!me.ViolatingThing.Equals(other.ViolatingThing)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SampledFunctionParameterTypeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SampledFunctionParameterTypeEquatable.cs
@@ -1,0 +1,137 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SampledFunctionParameterTypeEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | alias                                | Guid                         | 0..*        |  1.2.0  |
+ | 6     | category                             | Guid                         | 0..*        |  1.2.0  |
+ | 7     | definition                           | Guid                         | 0..*        |  1.2.0  |
+ | 8     | degreeOfInterpolation                | int                          | 0..1        |  1.2.0  |
+ | 9     | dependentParameterType               | Guid                         | 1..*        |  1.2.0  |
+ | 10    | hyperLink                            | Guid                         | 0..*        |  1.2.0  |
+ | 11    | independentParameterType             | Guid                         | 1..*        |  1.2.0  |
+ | 12    | interpolationPeriod                  | ValueArray<string>           | 1..*        |  1.2.0  |
+ | 13    | isDeprecated                         | bool                         | 1..1        |  1.2.0  |
+ | 14    | name                                 | string                       | 1..1        |  1.2.0  |
+ | 15    | shortName                            | string                       | 1..1        |  1.2.0  |
+ | 16    | symbol                               | string                       | 1..1        |  1.2.0  |
+ | 17    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="SampledFunctionParameterType"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SampledFunctionParameterTypeEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="SampledFunctionParameterType"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="SampledFunctionParameterType"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="SampledFunctionParameterType"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="SampledFunctionParameterType"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this SampledFunctionParameterType me, SampledFunctionParameterType other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.DegreeOfInterpolation.HasValue && other.DegreeOfInterpolation.HasValue) return false;
+            if (!me.DegreeOfInterpolation.Equals(other.DegreeOfInterpolation)) return false;
+
+            if (!me.DependentParameterType.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.DependentParameterType.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.DependentParameterType.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.DependentParameterType.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IndependentParameterType.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.IndependentParameterType.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.IndependentParameterType.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.IndependentParameterType.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.InterpolationPeriod.SequenceEqual(other.InterpolationPeriod)) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Symbol == null && other.Symbol != null) return false;
+            if (me.Symbol != null && !me.Symbol.Equals(other.Symbol)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SampledFunctionParameterTypeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SampledFunctionParameterTypeEquatable.cs
@@ -100,7 +100,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
 
-            if (!me.DegreeOfInterpolation.HasValue && other.DegreeOfInterpolation.HasValue) return false;
+            if (me.DegreeOfInterpolation.HasValue != other.DegreeOfInterpolation.HasValue) return false;
             if (!me.DegreeOfInterpolation.Equals(other.DegreeOfInterpolation)) return false;
 
             if (!me.DependentParameterType.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.DependentParameterType.OrderBy(x => x.K).Select(x => x.K))) return false;

--- a/CDP4Common/AutoGenEquatable/ScaleReferenceQuantityValueEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ScaleReferenceQuantityValueEquatable.cs
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ScaleReferenceQuantityValueEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | scale                                | Guid                         | 1..1        |  1.0.0  |
+ | 3     | value                                | string                       | 1..1        |  1.0.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ScaleReferenceQuantityValue"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ScaleReferenceQuantityValueEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ScaleReferenceQuantityValue"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ScaleReferenceQuantityValue"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ScaleReferenceQuantityValue"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ScaleReferenceQuantityValue"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ScaleReferenceQuantityValue me, ScaleReferenceQuantityValue other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Scale.Equals(other.Scale)) return false;
+
+            if (me.Value == null && other.Value != null) return false;
+            if (me.Value != null && !me.Value.Equals(other.Value)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ScaleValueDefinitionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ScaleValueDefinitionEquatable.cs
@@ -1,0 +1,116 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ScaleValueDefinitionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 6     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 7     | value                                | string                       | 1..1        |  1.0.0  |
+ | 8     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ScaleValueDefinition"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ScaleValueDefinitionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ScaleValueDefinition"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ScaleValueDefinition"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ScaleValueDefinition"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ScaleValueDefinition"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ScaleValueDefinition me, ScaleValueDefinition other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Value == null && other.Value != null) return false;
+            if (me.Value != null && !me.Value.Equals(other.Value)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SectionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SectionEquatable.cs
@@ -1,0 +1,116 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SectionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 3     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.1.0  |
+ | 8     | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 9     | page                                 | Guid                         | 0..*        |  1.1.0  |
+ | 10    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Section"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SectionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Section"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Section"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Section"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Section"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Section me, Section other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (!me.Page.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.Page.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.Page.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.Page.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SharedStyleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SharedStyleEquatable.cs
@@ -94,31 +94,31 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
 
-            if (!me.FillColor.HasValue && other.FillColor.HasValue) return false;
+            if (me.FillColor.HasValue != other.FillColor.HasValue) return false;
             if (!me.FillColor.Equals(other.FillColor)) return false;
 
-            if (!me.FillOpacity.HasValue && other.FillOpacity.HasValue) return false;
+            if (me.FillOpacity.HasValue != other.FillOpacity.HasValue) return false;
             if (!me.FillOpacity.Equals(other.FillOpacity)) return false;
 
-            if (!me.FontBold.HasValue && other.FontBold.HasValue) return false;
+            if (me.FontBold.HasValue != other.FontBold.HasValue) return false;
             if (!me.FontBold.Equals(other.FontBold)) return false;
 
-            if (!me.FontColor.HasValue && other.FontColor.HasValue) return false;
+            if (me.FontColor.HasValue != other.FontColor.HasValue) return false;
             if (!me.FontColor.Equals(other.FontColor)) return false;
 
-            if (!me.FontItalic.HasValue && other.FontItalic.HasValue) return false;
+            if (me.FontItalic.HasValue != other.FontItalic.HasValue) return false;
             if (!me.FontItalic.Equals(other.FontItalic)) return false;
 
             if (me.FontName == null && other.FontName != null) return false;
             if (me.FontName != null && !me.FontName.Equals(other.FontName)) return false;
 
-            if (!me.FontSize.HasValue && other.FontSize.HasValue) return false;
+            if (me.FontSize.HasValue != other.FontSize.HasValue) return false;
             if (!me.FontSize.Equals(other.FontSize)) return false;
 
-            if (!me.FontStrokeThrough.HasValue && other.FontStrokeThrough.HasValue) return false;
+            if (me.FontStrokeThrough.HasValue != other.FontStrokeThrough.HasValue) return false;
             if (!me.FontStrokeThrough.Equals(other.FontStrokeThrough)) return false;
 
-            if (!me.FontUnderline.HasValue && other.FontUnderline.HasValue) return false;
+            if (me.FontUnderline.HasValue != other.FontUnderline.HasValue) return false;
             if (!me.FontUnderline.Equals(other.FontUnderline)) return false;
 
             if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
@@ -126,13 +126,13 @@ namespace CDP4Common.DTO.Equatable
             if (me.Name == null && other.Name != null) return false;
             if (me.Name != null && !me.Name.Equals(other.Name)) return false;
 
-            if (!me.StrokeColor.HasValue && other.StrokeColor.HasValue) return false;
+            if (me.StrokeColor.HasValue != other.StrokeColor.HasValue) return false;
             if (!me.StrokeColor.Equals(other.StrokeColor)) return false;
 
-            if (!me.StrokeOpacity.HasValue && other.StrokeOpacity.HasValue) return false;
+            if (me.StrokeOpacity.HasValue != other.StrokeOpacity.HasValue) return false;
             if (!me.StrokeOpacity.Equals(other.StrokeOpacity)) return false;
 
-            if (!me.StrokeWidth.HasValue && other.StrokeWidth.HasValue) return false;
+            if (me.StrokeWidth.HasValue != other.StrokeWidth.HasValue) return false;
             if (!me.StrokeWidth.Equals(other.StrokeWidth)) return false;
 
             if (!me.UsedColor.OrderBy(x => x).SequenceEqual(other.UsedColor.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/SharedStyleEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SharedStyleEquatable.cs
@@ -1,0 +1,150 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SharedStyleEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | fillColor                            | Guid                         | 0..1        |  1.1.0  |
+ | 5     | fillOpacity                          | float                        | 0..1        |  1.1.0  |
+ | 6     | fontBold                             | bool                         | 0..1        |  1.1.0  |
+ | 7     | fontColor                            | Guid                         | 0..1        |  1.1.0  |
+ | 8     | fontItalic                           | bool                         | 0..1        |  1.1.0  |
+ | 9     | fontName                             | string                       | 0..1        |  1.1.0  |
+ | 10    | fontSize                             | float                        | 0..1        |  1.1.0  |
+ | 11    | fontStrokeThrough                    | bool                         | 0..1        |  1.1.0  |
+ | 12    | fontUnderline                        | bool                         | 0..1        |  1.1.0  |
+ | 13    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 14    | name                                 | string                       | 1..1        |  1.1.0  |
+ | 15    | strokeColor                          | Guid                         | 0..1        |  1.1.0  |
+ | 16    | strokeOpacity                        | float                        | 0..1        |  1.1.0  |
+ | 17    | strokeWidth                          | float                        | 0..1        |  1.1.0  |
+ | 18    | usedColor                            | Guid                         | 0..*        |  1.1.0  |
+ | 19    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="SharedStyle"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SharedStyleEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="SharedStyle"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="SharedStyle"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="SharedStyle"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="SharedStyle"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this SharedStyle me, SharedStyle other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.FillColor.HasValue && other.FillColor.HasValue) return false;
+            if (!me.FillColor.Equals(other.FillColor)) return false;
+
+            if (!me.FillOpacity.HasValue && other.FillOpacity.HasValue) return false;
+            if (!me.FillOpacity.Equals(other.FillOpacity)) return false;
+
+            if (!me.FontBold.HasValue && other.FontBold.HasValue) return false;
+            if (!me.FontBold.Equals(other.FontBold)) return false;
+
+            if (!me.FontColor.HasValue && other.FontColor.HasValue) return false;
+            if (!me.FontColor.Equals(other.FontColor)) return false;
+
+            if (!me.FontItalic.HasValue && other.FontItalic.HasValue) return false;
+            if (!me.FontItalic.Equals(other.FontItalic)) return false;
+
+            if (me.FontName == null && other.FontName != null) return false;
+            if (me.FontName != null && !me.FontName.Equals(other.FontName)) return false;
+
+            if (!me.FontSize.HasValue && other.FontSize.HasValue) return false;
+            if (!me.FontSize.Equals(other.FontSize)) return false;
+
+            if (!me.FontStrokeThrough.HasValue && other.FontStrokeThrough.HasValue) return false;
+            if (!me.FontStrokeThrough.Equals(other.FontStrokeThrough)) return false;
+
+            if (!me.FontUnderline.HasValue && other.FontUnderline.HasValue) return false;
+            if (!me.FontUnderline.Equals(other.FontUnderline)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.StrokeColor.HasValue && other.StrokeColor.HasValue) return false;
+            if (!me.StrokeColor.Equals(other.StrokeColor)) return false;
+
+            if (!me.StrokeOpacity.HasValue && other.StrokeOpacity.HasValue) return false;
+            if (!me.StrokeOpacity.Equals(other.StrokeOpacity)) return false;
+
+            if (!me.StrokeWidth.HasValue && other.StrokeWidth.HasValue) return false;
+            if (!me.StrokeWidth.Equals(other.StrokeWidth)) return false;
+
+            if (!me.UsedColor.OrderBy(x => x).SequenceEqual(other.UsedColor.OrderBy(x => x))) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SimpleParameterValueEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SimpleParameterValueEquatable.cs
@@ -1,0 +1,105 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SimpleParameterValueEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | parameterType                        | Guid                         | 1..1        |  1.0.0  |
+ | 3     | scale                                | Guid                         | 0..1        |  1.0.0  |
+ | 4     | value                                | ValueArray<string>           | 1..*        |  1.0.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="SimpleParameterValue"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SimpleParameterValueEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="SimpleParameterValue"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="SimpleParameterValue"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="SimpleParameterValue"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="SimpleParameterValue"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this SimpleParameterValue me, SimpleParameterValue other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ParameterType.Equals(other.ParameterType)) return false;
+
+            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (!me.Scale.Equals(other.Scale)) return false;
+
+            if (!me.Value.SequenceEqual(other.Value)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SimpleParameterValueEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SimpleParameterValueEquatable.cs
@@ -81,7 +81,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ParameterType.Equals(other.ParameterType)) return false;
 
-            if (!me.Scale.HasValue && other.Scale.HasValue) return false;
+            if (me.Scale.HasValue != other.Scale.HasValue) return false;
             if (!me.Scale.Equals(other.Scale)) return false;
 
             if (!me.Value.SequenceEqual(other.Value)) return false;

--- a/CDP4Common/AutoGenEquatable/SimpleQuantityKindEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SimpleQuantityKindEquatable.cs
@@ -1,0 +1,132 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SimpleQuantityKindEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | defaultScale                         | Guid                         | 1..1        |  1.0.0  |
+ | 5     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 6     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 8     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 9     | possibleScale                        | Guid                         | 0..*        |  1.0.0  |
+ | 10    | quantityDimensionSymbol              | string                       | 0..1        |  1.0.0  |
+ | 11    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 12    | symbol                               | string                       | 1..1        |  1.0.0  |
+ | 13    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 14    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 15    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 16    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="SimpleQuantityKind"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SimpleQuantityKindEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="SimpleQuantityKind"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="SimpleQuantityKind"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="SimpleQuantityKind"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="SimpleQuantityKind"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this SimpleQuantityKind me, SimpleQuantityKind other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.DefaultScale.Equals(other.DefaultScale)) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.PossibleScale.OrderBy(x => x).SequenceEqual(other.PossibleScale.OrderBy(x => x))) return false;
+
+            if (me.QuantityDimensionSymbol == null && other.QuantityDimensionSymbol != null) return false;
+            if (me.QuantityDimensionSymbol != null && !me.QuantityDimensionSymbol.Equals(other.QuantityDimensionSymbol)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Symbol == null && other.Symbol != null) return false;
+            if (me.Symbol != null && !me.Symbol.Equals(other.Symbol)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SimpleUnitEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SimpleUnitEquatable.cs
@@ -1,0 +1,115 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SimpleUnitEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 6     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 7     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 8     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="SimpleUnit"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SimpleUnitEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="SimpleUnit"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="SimpleUnit"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="SimpleUnit"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="SimpleUnit"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this SimpleUnit me, SimpleUnit other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SiteDirectoryDataAnnotationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SiteDirectoryDataAnnotationEquatable.cs
@@ -1,0 +1,118 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SiteDirectoryDataAnnotationEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | author                               | Guid                         | 1..1        |  1.1.0  |
+ | 3     | content                              | string                       | 1..1        |  1.1.0  |
+ | 4     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | discussion                           | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | primaryAnnotatedThing                | Guid                         | 1..1        |  1.1.0  |
+ | 11    | relatedThing                         | Guid                         | 1..*        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="SiteDirectoryDataAnnotation"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SiteDirectoryDataAnnotationEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="SiteDirectoryDataAnnotation"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="SiteDirectoryDataAnnotation"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="SiteDirectoryDataAnnotation"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="SiteDirectoryDataAnnotation"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this SiteDirectoryDataAnnotation me, SiteDirectoryDataAnnotation other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.Discussion.OrderBy(x => x).SequenceEqual(other.Discussion.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.PrimaryAnnotatedThing.Equals(other.PrimaryAnnotatedThing)) return false;
+
+            if (!me.RelatedThing.OrderBy(x => x).SequenceEqual(other.RelatedThing.OrderBy(x => x))) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SiteDirectoryDataDiscussionItemEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SiteDirectoryDataDiscussionItemEquatable.cs
@@ -97,7 +97,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
 
-            if (!me.ReplyTo.HasValue && other.ReplyTo.HasValue) return false;
+            if (me.ReplyTo.HasValue != other.ReplyTo.HasValue) return false;
             if (!me.ReplyTo.Equals(other.ReplyTo)) return false;
 
             if (me.ThingPreference == null && other.ThingPreference != null) return false;

--- a/CDP4Common/AutoGenEquatable/SiteDirectoryDataDiscussionItemEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SiteDirectoryDataDiscussionItemEquatable.cs
@@ -1,0 +1,113 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SiteDirectoryDataDiscussionItemEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | author                               | Guid                         | 1..1        |  1.1.0  |
+ | 3     | content                              | string                       | 1..1        |  1.1.0  |
+ | 4     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | replyTo                              | Guid                         | 0..1        |  1.1.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="SiteDirectoryDataDiscussionItem"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SiteDirectoryDataDiscussionItemEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="SiteDirectoryDataDiscussionItem"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="SiteDirectoryDataDiscussionItem"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="SiteDirectoryDataDiscussionItem"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="SiteDirectoryDataDiscussionItem"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this SiteDirectoryDataDiscussionItem me, SiteDirectoryDataDiscussionItem other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.ReplyTo.HasValue && other.ReplyTo.HasValue) return false;
+            if (!me.ReplyTo.Equals(other.ReplyTo)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SiteDirectoryEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SiteDirectoryEquatable.cs
@@ -1,0 +1,150 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SiteDirectoryEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | createdOn                            | DateTime                     | 1..1        |  1.0.0  |
+ | 3     | defaultParticipantRole               | Guid                         | 0..1        |  1.0.0  |
+ | 4     | defaultPersonRole                    | Guid                         | 0..1        |  1.0.0  |
+ | 5     | domain                               | Guid                         | 0..*        |  1.0.0  |
+ | 6     | domainGroup                          | Guid                         | 0..*        |  1.0.0  |
+ | 7     | lastModifiedOn                       | DateTime                     | 1..1        |  1.0.0  |
+ | 8     | logEntry                             | Guid                         | 0..*        |  1.0.0  |
+ | 9     | model                                | Guid                         | 0..*        |  1.0.0  |
+ | 10    | name                                 | string                       | 1..1        |  1.0.0  |
+ | 11    | naturalLanguage                      | Guid                         | 0..*        |  1.0.0  |
+ | 12    | organization                         | Guid                         | 0..*        |  1.0.0  |
+ | 13    | participantRole                      | Guid                         | 0..*        |  1.0.0  |
+ | 14    | person                               | Guid                         | 0..*        |  1.0.0  |
+ | 15    | personRole                           | Guid                         | 0..*        |  1.0.0  |
+ | 16    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 17    | siteReferenceDataLibrary             | Guid                         | 0..*        |  1.0.0  |
+ | 18    | annotation                           | Guid                         | 0..*        |  1.1.0  |
+ | 19    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 20    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 21    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 22    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="SiteDirectory"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SiteDirectoryEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="SiteDirectory"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="SiteDirectory"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="SiteDirectory"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="SiteDirectory"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this SiteDirectory me, SiteDirectory other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.DefaultParticipantRole.HasValue && other.DefaultParticipantRole.HasValue) return false;
+            if (!me.DefaultParticipantRole.Equals(other.DefaultParticipantRole)) return false;
+
+            if (!me.DefaultPersonRole.HasValue && other.DefaultPersonRole.HasValue) return false;
+            if (!me.DefaultPersonRole.Equals(other.DefaultPersonRole)) return false;
+
+            if (!me.Domain.OrderBy(x => x).SequenceEqual(other.Domain.OrderBy(x => x))) return false;
+
+            if (!me.DomainGroup.OrderBy(x => x).SequenceEqual(other.DomainGroup.OrderBy(x => x))) return false;
+
+            if (!me.LastModifiedOn.Equals(other.LastModifiedOn)) return false;
+
+            if (!me.LogEntry.OrderBy(x => x).SequenceEqual(other.LogEntry.OrderBy(x => x))) return false;
+
+            if (!me.Model.OrderBy(x => x).SequenceEqual(other.Model.OrderBy(x => x))) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.NaturalLanguage.OrderBy(x => x).SequenceEqual(other.NaturalLanguage.OrderBy(x => x))) return false;
+
+            if (!me.Organization.OrderBy(x => x).SequenceEqual(other.Organization.OrderBy(x => x))) return false;
+
+            if (!me.ParticipantRole.OrderBy(x => x).SequenceEqual(other.ParticipantRole.OrderBy(x => x))) return false;
+
+            if (!me.Person.OrderBy(x => x).SequenceEqual(other.Person.OrderBy(x => x))) return false;
+
+            if (!me.PersonRole.OrderBy(x => x).SequenceEqual(other.PersonRole.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.SiteReferenceDataLibrary.OrderBy(x => x).SequenceEqual(other.SiteReferenceDataLibrary.OrderBy(x => x))) return false;
+
+            if (!me.Annotation.OrderBy(x => x).SequenceEqual(other.Annotation.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SiteDirectoryEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SiteDirectoryEquatable.cs
@@ -95,10 +95,10 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
 
-            if (!me.DefaultParticipantRole.HasValue && other.DefaultParticipantRole.HasValue) return false;
+            if (me.DefaultParticipantRole.HasValue != other.DefaultParticipantRole.HasValue) return false;
             if (!me.DefaultParticipantRole.Equals(other.DefaultParticipantRole)) return false;
 
-            if (!me.DefaultPersonRole.HasValue && other.DefaultPersonRole.HasValue) return false;
+            if (me.DefaultPersonRole.HasValue != other.DefaultPersonRole.HasValue) return false;
             if (!me.DefaultPersonRole.Equals(other.DefaultPersonRole)) return false;
 
             if (!me.Domain.OrderBy(x => x).SequenceEqual(other.Domain.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/SiteDirectoryThingReferenceEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SiteDirectoryThingReferenceEquatable.cs
@@ -1,0 +1,101 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SiteDirectoryThingReferenceEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | referencedRevisionNumber             | int                          | 1..1        |  1.1.0  |
+ | 6     | referencedThing                      | Guid                         | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="SiteDirectoryThingReference"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SiteDirectoryThingReferenceEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="SiteDirectoryThingReference"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="SiteDirectoryThingReference"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="SiteDirectoryThingReference"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="SiteDirectoryThingReference"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this SiteDirectoryThingReference me, SiteDirectoryThingReference other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.ReferencedRevisionNumber.Equals(other.ReferencedRevisionNumber)) return false;
+
+            if (!me.ReferencedThing.Equals(other.ReferencedThing)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SiteLogEntryEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SiteLogEntryEquatable.cs
@@ -89,7 +89,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.AffectedItemIid.Equals(other.AffectedItemIid)) return false;
 
-            if (!me.Author.HasValue && other.Author.HasValue) return false;
+            if (me.Author.HasValue != other.Author.HasValue) return false;
             if (!me.Author.Equals(other.Author)) return false;
 
             if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/SiteLogEntryEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SiteLogEntryEquatable.cs
@@ -1,0 +1,125 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SiteLogEntryEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | affectedDomainIid                    | Guid                         | 0..*        |  1.0.0  |
+ | 3     | affectedItemIid                      | Guid                         | 0..*        |  1.0.0  |
+ | 4     | author                               | Guid                         | 0..1        |  1.0.0  |
+ | 5     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 6     | content                              | string                       | 1..1        |  1.0.0  |
+ | 7     | createdOn                            | DateTime                     | 1..1        |  1.0.0  |
+ | 8     | languageCode                         | string                       | 1..1        |  1.0.0  |
+ | 9     | level                                | LogLevelKind                 | 1..1        |  1.0.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | logEntryChangelogItem                | Guid                         | 0..*        |  1.2.0  |
+ | 14    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="SiteLogEntry"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SiteLogEntryEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="SiteLogEntry"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="SiteLogEntry"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="SiteLogEntry"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="SiteLogEntry"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this SiteLogEntry me, SiteLogEntry other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.AffectedDomainIid.Equals(other.AffectedDomainIid)) return false;
+
+            if (!me.AffectedItemIid.Equals(other.AffectedItemIid)) return false;
+
+            if (!me.Author.HasValue && other.Author.HasValue) return false;
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.Level.Equals(other.Level)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.LogEntryChangelogItem.OrderBy(x => x).SequenceEqual(other.LogEntryChangelogItem.OrderBy(x => x))) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SiteReferenceDataLibraryEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SiteReferenceDataLibraryEquatable.cs
@@ -1,0 +1,156 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SiteReferenceDataLibraryEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | baseQuantityKind                     | Guid                         | 0..*        |  1.0.0  |
+ | 4     | baseUnit                             | Guid                         | 0..*        |  1.0.0  |
+ | 5     | constant                             | Guid                         | 0..*        |  1.0.0  |
+ | 6     | definedCategory                      | Guid                         | 0..*        |  1.0.0  |
+ | 7     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 8     | fileType                             | Guid                         | 0..*        |  1.0.0  |
+ | 9     | glossary                             | Guid                         | 0..*        |  1.0.0  |
+ | 10    | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 11    | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 12    | name                                 | string                       | 1..1        |  1.0.0  |
+ | 13    | parameterType                        | Guid                         | 0..*        |  1.0.0  |
+ | 14    | referenceSource                      | Guid                         | 0..*        |  1.0.0  |
+ | 15    | requiredRdl                          | Guid                         | 0..1        |  1.0.0  |
+ | 16    | rule                                 | Guid                         | 0..*        |  1.0.0  |
+ | 17    | scale                                | Guid                         | 0..*        |  1.0.0  |
+ | 18    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 19    | unit                                 | Guid                         | 0..*        |  1.0.0  |
+ | 20    | unitPrefix                           | Guid                         | 0..*        |  1.0.0  |
+ | 21    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 22    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 23    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 24    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="SiteReferenceDataLibrary"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SiteReferenceDataLibraryEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="SiteReferenceDataLibrary"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="SiteReferenceDataLibrary"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="SiteReferenceDataLibrary"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="SiteReferenceDataLibrary"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this SiteReferenceDataLibrary me, SiteReferenceDataLibrary other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.BaseQuantityKind.OrderBy(x => x.K).Select(x => x.K).SequenceEqual(other.BaseQuantityKind.OrderBy(x => x.K).Select(x => x.K))) return false;
+            if (!me.BaseQuantityKind.OrderBy(x => x.K).Select(x => x.V).SequenceEqual(other.BaseQuantityKind.OrderBy(x => x.K).Select(x => x.V))) return false;
+
+            if (!me.BaseUnit.OrderBy(x => x).SequenceEqual(other.BaseUnit.OrderBy(x => x))) return false;
+
+            if (!me.Constant.OrderBy(x => x).SequenceEqual(other.Constant.OrderBy(x => x))) return false;
+
+            if (!me.DefinedCategory.OrderBy(x => x).SequenceEqual(other.DefinedCategory.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.FileType.OrderBy(x => x).SequenceEqual(other.FileType.OrderBy(x => x))) return false;
+
+            if (!me.Glossary.OrderBy(x => x).SequenceEqual(other.Glossary.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.ParameterType.OrderBy(x => x).SequenceEqual(other.ParameterType.OrderBy(x => x))) return false;
+
+            if (!me.ReferenceSource.OrderBy(x => x).SequenceEqual(other.ReferenceSource.OrderBy(x => x))) return false;
+
+            if (!me.RequiredRdl.HasValue && other.RequiredRdl.HasValue) return false;
+            if (!me.RequiredRdl.Equals(other.RequiredRdl)) return false;
+
+            if (!me.Rule.OrderBy(x => x).SequenceEqual(other.Rule.OrderBy(x => x))) return false;
+
+            if (!me.Scale.OrderBy(x => x).SequenceEqual(other.Scale.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.Unit.OrderBy(x => x).SequenceEqual(other.Unit.OrderBy(x => x))) return false;
+
+            if (!me.UnitPrefix.OrderBy(x => x).SequenceEqual(other.UnitPrefix.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SiteReferenceDataLibraryEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SiteReferenceDataLibraryEquatable.cs
@@ -123,7 +123,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ReferenceSource.OrderBy(x => x).SequenceEqual(other.ReferenceSource.OrderBy(x => x))) return false;
 
-            if (!me.RequiredRdl.HasValue && other.RequiredRdl.HasValue) return false;
+            if (me.RequiredRdl.HasValue != other.RequiredRdl.HasValue) return false;
             if (!me.RequiredRdl.Equals(other.RequiredRdl)) return false;
 
             if (!me.Rule.OrderBy(x => x).SequenceEqual(other.Rule.OrderBy(x => x))) return false;

--- a/CDP4Common/AutoGenEquatable/SolutionEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SolutionEquatable.cs
@@ -1,0 +1,112 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SolutionEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | author                               | Guid                         | 1..1        |  1.1.0  |
+ | 3     | content                              | string                       | 1..1        |  1.1.0  |
+ | 4     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Solution"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SolutionEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Solution"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Solution"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Solution"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Solution"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Solution me, Solution other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Author.Equals(other.Author)) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/SpecializedQuantityKindEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/SpecializedQuantityKindEquatable.cs
@@ -1,0 +1,135 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SpecializedQuantityKindEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | defaultScale                         | Guid                         | 1..1        |  1.0.0  |
+ | 5     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 6     | general                              | Guid                         | 1..1        |  1.0.0  |
+ | 7     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 8     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 9     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 10    | possibleScale                        | Guid                         | 0..*        |  1.0.0  |
+ | 11    | quantityDimensionSymbol              | string                       | 0..1        |  1.0.0  |
+ | 12    | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 13    | symbol                               | string                       | 1..1        |  1.0.0  |
+ | 14    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 15    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 16    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 17    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="SpecializedQuantityKind"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class SpecializedQuantityKindEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="SpecializedQuantityKind"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="SpecializedQuantityKind"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="SpecializedQuantityKind"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="SpecializedQuantityKind"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this SpecializedQuantityKind me, SpecializedQuantityKind other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.DefaultScale.Equals(other.DefaultScale)) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.General.Equals(other.General)) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.PossibleScale.OrderBy(x => x).SequenceEqual(other.PossibleScale.OrderBy(x => x))) return false;
+
+            if (me.QuantityDimensionSymbol == null && other.QuantityDimensionSymbol != null) return false;
+            if (me.QuantityDimensionSymbol != null && !me.QuantityDimensionSymbol.Equals(other.QuantityDimensionSymbol)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Symbol == null && other.Symbol != null) return false;
+            if (me.Symbol != null && !me.Symbol.Equals(other.Symbol)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/StakeHolderValueMapEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/StakeHolderValueMapEquatable.cs
@@ -1,0 +1,130 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="StakeHolderValueMapEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.1.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | goal                                 | Guid                         | 0..*        |  1.1.0  |
+ | 8     | hyperLink                            | Guid                         | 0..*        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | name                                 | string                       | 1..1        |  1.1.0  |
+ | 11    | requirement                          | Guid                         | 0..*        |  1.1.0  |
+ | 12    | settings                             | Guid                         | 1..1        |  1.1.0  |
+ | 13    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 14    | stakeholderValue                     | Guid                         | 0..*        |  1.1.0  |
+ | 15    | valueGroup                           | Guid                         | 0..*        |  1.1.0  |
+ | 16    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="StakeHolderValueMap"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class StakeHolderValueMapEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="StakeHolderValueMap"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="StakeHolderValueMap"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="StakeHolderValueMap"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="StakeHolderValueMap"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this StakeHolderValueMap me, StakeHolderValueMap other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.Goal.OrderBy(x => x).SequenceEqual(other.Goal.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Requirement.OrderBy(x => x).SequenceEqual(other.Requirement.OrderBy(x => x))) return false;
+
+            if (!me.Settings.OrderBy(x => x).SequenceEqual(other.Settings.OrderBy(x => x))) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.StakeholderValue.OrderBy(x => x).SequenceEqual(other.StakeholderValue.OrderBy(x => x))) return false;
+
+            if (!me.ValueGroup.OrderBy(x => x).SequenceEqual(other.ValueGroup.OrderBy(x => x))) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/StakeHolderValueMapSettingsEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/StakeHolderValueMapSettingsEquatable.cs
@@ -83,15 +83,15 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
 
-            if (!me.GoalToValueGroupRelationship.HasValue && other.GoalToValueGroupRelationship.HasValue) return false;
+            if (me.GoalToValueGroupRelationship.HasValue != other.GoalToValueGroupRelationship.HasValue) return false;
             if (!me.GoalToValueGroupRelationship.Equals(other.GoalToValueGroupRelationship)) return false;
 
             if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
 
-            if (!me.StakeholderValueToRequirementRelationship.HasValue && other.StakeholderValueToRequirementRelationship.HasValue) return false;
+            if (me.StakeholderValueToRequirementRelationship.HasValue != other.StakeholderValueToRequirementRelationship.HasValue) return false;
             if (!me.StakeholderValueToRequirementRelationship.Equals(other.StakeholderValueToRequirementRelationship)) return false;
 
-            if (!me.ValueGroupToStakeholderValueRelationship.HasValue && other.ValueGroupToStakeholderValueRelationship.HasValue) return false;
+            if (me.ValueGroupToStakeholderValueRelationship.HasValue != other.ValueGroupToStakeholderValueRelationship.HasValue) return false;
             if (!me.ValueGroupToStakeholderValueRelationship.Equals(other.ValueGroupToStakeholderValueRelationship)) return false;
 
             if (me.ThingPreference == null && other.ThingPreference != null) return false;

--- a/CDP4Common/AutoGenEquatable/StakeHolderValueMapSettingsEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/StakeHolderValueMapSettingsEquatable.cs
@@ -1,0 +1,107 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="StakeHolderValueMapSettingsEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 3     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 4     | goalToValueGroupRelationship         | Guid                         | 0..1        |  1.1.0  |
+ | 5     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 6     | stakeholderValueToRequirementRelationship | Guid                         | 0..1        |  1.1.0  |
+ | 7     | valueGroupToStakeholderValueRelationship | Guid                         | 0..1        |  1.1.0  |
+ | 8     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="StakeHolderValueMapSettings"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class StakeHolderValueMapSettingsEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="StakeHolderValueMapSettings"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="StakeHolderValueMapSettings"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="StakeHolderValueMapSettings"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="StakeHolderValueMapSettings"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this StakeHolderValueMapSettings me, StakeHolderValueMapSettings other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.GoalToValueGroupRelationship.HasValue && other.GoalToValueGroupRelationship.HasValue) return false;
+            if (!me.GoalToValueGroupRelationship.Equals(other.GoalToValueGroupRelationship)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (!me.StakeholderValueToRequirementRelationship.HasValue && other.StakeholderValueToRequirementRelationship.HasValue) return false;
+            if (!me.StakeholderValueToRequirementRelationship.Equals(other.StakeholderValueToRequirementRelationship)) return false;
+
+            if (!me.ValueGroupToStakeholderValueRelationship.HasValue && other.ValueGroupToStakeholderValueRelationship.HasValue) return false;
+            if (!me.ValueGroupToStakeholderValueRelationship.Equals(other.ValueGroupToStakeholderValueRelationship)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/StakeholderEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/StakeholderEquatable.cs
@@ -1,0 +1,118 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="StakeholderEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.1.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | hyperLink                            | Guid                         | 0..*        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | name                                 | string                       | 1..1        |  1.1.0  |
+ | 10    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 11    | stakeholderValue                     | Guid                         | 0..*        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Stakeholder"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class StakeholderEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Stakeholder"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Stakeholder"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Stakeholder"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Stakeholder"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Stakeholder me, Stakeholder other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.StakeholderValue.OrderBy(x => x).SequenceEqual(other.StakeholderValue.OrderBy(x => x))) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/StakeholderValueEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/StakeholderValueEquatable.cs
@@ -1,0 +1,115 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="StakeholderValueEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.1.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | hyperLink                            | Guid                         | 0..*        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | name                                 | string                       | 1..1        |  1.1.0  |
+ | 10    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="StakeholderValue"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class StakeholderValueEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="StakeholderValue"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="StakeholderValue"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="StakeholderValue"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="StakeholderValue"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this StakeholderValue me, StakeholderValue other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/TelephoneNumberEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/TelephoneNumberEquatable.cs
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="TelephoneNumberEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | value                                | string                       | 1..1        |  1.0.0  |
+ | 3     | vcardType                            | VcardTelephoneNumberKind     | 0..*        |  1.0.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="TelephoneNumber"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class TelephoneNumberEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="TelephoneNumber"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="TelephoneNumber"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="TelephoneNumber"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="TelephoneNumber"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this TelephoneNumber me, TelephoneNumber other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (me.Value == null && other.Value != null) return false;
+            if (me.Value != null && !me.Value.Equals(other.Value)) return false;
+
+            if (!me.VcardType.OrderBy(x => x).SequenceEqual(other.VcardType.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/TermEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/TermEquatable.cs
@@ -1,0 +1,115 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="TermEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 4     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 5     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 6     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 7     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 8     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="Term"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class TermEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Term"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Term"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Term"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Term"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this Term me, Term other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/TextParameterTypeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/TextParameterTypeEquatable.cs
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="TextParameterTypeEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | symbol                               | string                       | 1..1        |  1.0.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="TextParameterType"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class TextParameterTypeEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="TextParameterType"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="TextParameterType"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="TextParameterType"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="TextParameterType"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this TextParameterType me, TextParameterType other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Symbol == null && other.Symbol != null) return false;
+            if (me.Symbol != null && !me.Symbol.Equals(other.Symbol)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/TextualNoteEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/TextualNoteEquatable.cs
@@ -1,0 +1,120 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="TextualNoteEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 3     | content                              | string                       | 1..1        |  1.1.0  |
+ | 4     | createdOn                            | DateTime                     | 1..1        |  1.1.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | languageCode                         | string                       | 1..1        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | name                                 | string                       | 1..1        |  1.1.0  |
+ | 10    | owner                                | Guid                         | 1..1        |  1.1.0  |
+ | 11    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="TextualNote"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class TextualNoteEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="TextualNote"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="TextualNote"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="TextualNote"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="TextualNote"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this TextualNote me, TextualNote other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (me.Content == null && other.Content != null) return false;
+            if (me.Content != null && !me.Content.Equals(other.Content)) return false;
+
+            if (!me.CreatedOn.Equals(other.CreatedOn)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (me.LanguageCode == null && other.LanguageCode != null) return false;
+            if (me.LanguageCode != null && !me.LanguageCode.Equals(other.LanguageCode)) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (!me.Owner.Equals(other.Owner)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/ThingEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ThingEquatable.cs
@@ -1,0 +1,522 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ThingEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+    /* ------------------------------------------- | ------- *
+     | index | property name                       | version |
+     | ------------------------------------------- | ------- |
+     |  0    | Created                             |  0.0.0  |
+     | ------------------------------------------- | ------- |
+     | 1     | ActualFiniteState                   |  1.0.0  |
+     | 2     | ActualFiniteStateList               |  1.0.0  |
+     | 3     | Alias                               |  1.0.0  |
+     | 4     | AndExpression                       |  1.0.0  |
+     | 5     | ArrayParameterType                  |  1.0.0  |
+     | 6     | BinaryRelationship                  |  1.0.0  |
+     | 7     | BinaryRelationshipRule              |  1.0.0  |
+     | 8     | BooleanParameterType                |  1.0.0  |
+     | 9     | BuiltInRuleVerification             |  1.0.0  |
+     | 10    | Category                            |  1.0.0  |
+     | 11    | Citation                            |  1.0.0  |
+     | 12    | Color                               |  1.0.0  |
+     | 13    | CommonFileStore                     |  1.0.0  |
+     | 14    | CompoundParameterType               |  1.0.0  |
+     | 15    | Constant                            |  1.0.0  |
+     | 16    | CyclicRatioScale                    |  1.0.0  |
+     | 17    | DateParameterType                   |  1.0.0  |
+     | 18    | DateTimeParameterType               |  1.0.0  |
+     | 19    | DecompositionRule                   |  1.0.0  |
+     | 20    | Definition                          |  1.0.0  |
+     | 21    | DerivedQuantityKind                 |  1.0.0  |
+     | 22    | DerivedUnit                         |  1.0.0  |
+     | 23    | DomainFileStore                     |  1.0.0  |
+     | 24    | DomainOfExpertise                   |  1.0.0  |
+     | 25    | DomainOfExpertiseGroup              |  1.0.0  |
+     | 26    | ElementDefinition                   |  1.0.0  |
+     | 27    | ElementUsage                        |  1.0.0  |
+     | 28    | EmailAddress                        |  1.0.0  |
+     | 29    | EngineeringModel                    |  1.0.0  |
+     | 30    | EngineeringModelSetup               |  1.0.0  |
+     | 31    | EnumerationParameterType            |  1.0.0  |
+     | 32    | EnumerationValueDefinition          |  1.0.0  |
+     | 33    | ExclusiveOrExpression               |  1.0.0  |
+     | 34    | ExternalIdentifierMap               |  1.0.0  |
+     | 35    | File                                |  1.0.0  |
+     | 36    | FileRevision                        |  1.0.0  |
+     | 37    | FileType                            |  1.0.0  |
+     | 38    | Folder                              |  1.0.0  |
+     | 39    | Glossary                            |  1.0.0  |
+     | 40    | HyperLink                           |  1.0.0  |
+     | 41    | IdCorrespondence                    |  1.0.0  |
+     | 42    | IntervalScale                       |  1.0.0  |
+     | 43    | Iteration                           |  1.0.0  |
+     | 44    | IterationSetup                      |  1.0.0  |
+     | 45    | LinearConversionUnit                |  1.0.0  |
+     | 46    | LogarithmicScale                    |  1.0.0  |
+     | 47    | MappingToReferenceScale             |  1.0.0  |
+     | 48    | ModelLogEntry                       |  1.0.0  |
+     | 49    | ModelReferenceDataLibrary           |  1.0.0  |
+     | 50    | MultiRelationship                   |  1.0.0  |
+     | 51    | MultiRelationshipRule               |  1.0.0  |
+     | 52    | NaturalLanguage                     |  1.0.0  |
+     | 53    | NestedElement                       |  1.0.0  |
+     | 54    | NestedParameter                     |  1.0.0  |
+     | 55    | NotExpression                       |  1.0.0  |
+     | 56    | Option                              |  1.0.0  |
+     | 57    | OrdinalScale                        |  1.0.0  |
+     | 58    | OrExpression                        |  1.0.0  |
+     | 59    | Organization                        |  1.0.0  |
+     | 60    | Parameter                           |  1.0.0  |
+     | 61    | ParameterGroup                      |  1.0.0  |
+     | 62    | ParameterizedCategoryRule           |  1.0.0  |
+     | 63    | ParameterOverride                   |  1.0.0  |
+     | 64    | ParameterOverrideValueSet           |  1.0.0  |
+     | 65    | ParameterSubscription               |  1.0.0  |
+     | 66    | ParameterSubscriptionValueSet       |  1.0.0  |
+     | 67    | ParameterTypeComponent              |  1.0.0  |
+     | 68    | ParameterValueSet                   |  1.0.0  |
+     | 69    | ParametricConstraint                |  1.0.0  |
+     | 70    | Participant                         |  1.0.0  |
+     | 71    | ParticipantPermission               |  1.0.0  |
+     | 72    | ParticipantRole                     |  1.0.0  |
+     | 73    | Person                              |  1.0.0  |
+     | 74    | PersonPermission                    |  1.0.0  |
+     | 75    | PersonRole                          |  1.0.0  |
+     | 76    | PossibleFiniteState                 |  1.0.0  |
+     | 77    | PossibleFiniteStateList             |  1.0.0  |
+     | 78    | PrefixedUnit                        |  1.0.0  |
+     | 79    | Publication                         |  1.0.0  |
+     | 80    | QuantityKindFactor                  |  1.0.0  |
+     | 81    | RatioScale                          |  1.0.0  |
+     | 82    | ReferencerRule                      |  1.0.0  |
+     | 83    | ReferenceSource                     |  1.0.0  |
+     | 84    | RelationalExpression                |  1.0.0  |
+     | 85    | Requirement                         |  1.0.0  |
+     | 86    | RequirementsGroup                   |  1.0.0  |
+     | 87    | RequirementsSpecification           |  1.0.0  |
+     | 88    | RuleVerificationList                |  1.0.0  |
+     | 89    | RuleViolation                       |  1.0.0  |
+     | 90    | ScaleReferenceQuantityValue         |  1.0.0  |
+     | 91    | ScaleValueDefinition                |  1.0.0  |
+     | 92    | SimpleParameterValue                |  1.0.0  |
+     | 93    | SimpleQuantityKind                  |  1.0.0  |
+     | 94    | SimpleUnit                          |  1.0.0  |
+     | 95    | SiteDirectory                       |  1.0.0  |
+     | 96    | SiteLogEntry                        |  1.0.0  |
+     | 97    | SiteReferenceDataLibrary            |  1.0.0  |
+     | 98    | SpecializedQuantityKind             |  1.0.0  |
+     | 99    | TelephoneNumber                     |  1.0.0  |
+     | 100   | Term                                |  1.0.0  |
+     | 101   | TextParameterType                   |  1.0.0  |
+     | 102   | TimeOfDayParameterType              |  1.0.0  |
+     | 103   | UnitFactor                          |  1.0.0  |
+     | 104   | UnitPrefix                          |  1.0.0  |
+     | 105   | UserPreference                      |  1.0.0  |
+     | 106   | UserRuleVerification                |  1.0.0  |
+     | 107   | ActionItem                          |  1.1.0  |
+     | 108   | Approval                            |  1.1.0  |
+     | 109   | BinaryNote                          |  1.1.0  |
+     | 110   | Book                                |  1.1.0  |
+     | 111   | Bounds                              |  1.1.0  |
+     | 112   | ChangeProposal                      |  1.1.0  |
+     | 113   | ChangeRequest                       |  1.1.0  |
+     | 114   | ContractChangeNotice                |  1.1.0  |
+     | 115   | DiagramCanvas                       |  1.1.0  |
+     | 116   | DiagramEdge                         |  1.1.0  |
+     | 117   | DiagramObject                       |  1.1.0  |
+     | 118   | EngineeringModelDataDiscussionItem  |  1.1.0  |
+     | 119   | EngineeringModelDataNote            |  1.1.0  |
+     | 120   | Goal                                |  1.1.0  |
+     | 121   | ModellingThingReference             |  1.1.0  |
+     | 122   | OwnedStyle                          |  1.1.0  |
+     | 123   | Page                                |  1.1.0  |
+     | 124   | Point                               |  1.1.0  |
+     | 125   | RelationshipParameterValue          |  1.1.0  |
+     | 126   | RequestForDeviation                 |  1.1.0  |
+     | 127   | RequestForWaiver                    |  1.1.0  |
+     | 128   | RequirementsContainerParameterValue |  1.1.0  |
+     | 129   | ReviewItemDiscrepancy               |  1.1.0  |
+     | 130   | Section                             |  1.1.0  |
+     | 131   | SharedStyle                         |  1.1.0  |
+     | 132   | SiteDirectoryDataAnnotation         |  1.1.0  |
+     | 133   | SiteDirectoryDataDiscussionItem     |  1.1.0  |
+     | 134   | SiteDirectoryThingReference         |  1.1.0  |
+     | 135   | Solution                            |  1.1.0  |
+     | 136   | Stakeholder                         |  1.1.0  |
+     | 137   | StakeholderValue                    |  1.1.0  |
+     | 138   | StakeHolderValueMap                 |  1.1.0  |
+     | 139   | StakeHolderValueMapSettings         |  1.1.0  |
+     | 140   | TextualNote                         |  1.1.0  |
+     | 141   | ValueGroup                          |  1.1.0  |
+     | 142   | DependentParameterTypeAssignment    |  1.2.0  |
+     | 143   | IndependentParameterTypeAssignment  |  1.2.0  |
+     | 144   | LogEntryChangelogItem               |  1.2.0  |
+     | 145   | OrganizationalParticipant           |  1.2.0  |
+     | 146   | SampledFunctionParameterType        |  1.2.0  |
+     * ------------------------------------------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An utility class for the <see cref="Thing"/> class to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ThingEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="Thing"/> objects are the same
+        /// by comparing all the properties, including <see cref="CDP4Common.CommonData.ClassKind"/>
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="Thing"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="Thing"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="Thing"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(Thing me, Thing other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.ClassKind.Equals(other.ClassKind)) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            switch (me)
+            {
+                case ActualFiniteState actualFiniteState:
+                    return actualFiniteState.ArePropertiesEqual((ActualFiniteState)other);
+                case ActualFiniteStateList actualFiniteStateList:
+                    return actualFiniteStateList.ArePropertiesEqual((ActualFiniteStateList)other);
+                case Alias alias:
+                    return alias.ArePropertiesEqual((Alias)other);
+                case AndExpression andExpression:
+                    return andExpression.ArePropertiesEqual((AndExpression)other);
+                case ArrayParameterType arrayParameterType:
+                    return arrayParameterType.ArePropertiesEqual((ArrayParameterType)other);
+                case BinaryRelationship binaryRelationship:
+                    return binaryRelationship.ArePropertiesEqual((BinaryRelationship)other);
+                case BinaryRelationshipRule binaryRelationshipRule:
+                    return binaryRelationshipRule.ArePropertiesEqual((BinaryRelationshipRule)other);
+                case BooleanParameterType booleanParameterType:
+                    return booleanParameterType.ArePropertiesEqual((BooleanParameterType)other);
+                case BuiltInRuleVerification builtInRuleVerification:
+                    return builtInRuleVerification.ArePropertiesEqual((BuiltInRuleVerification)other);
+                case Category category:
+                    return category.ArePropertiesEqual((Category)other);
+                case Citation citation:
+                    return citation.ArePropertiesEqual((Citation)other);
+                case Color color:
+                    return color.ArePropertiesEqual((Color)other);
+                case CommonFileStore commonFileStore:
+                    return commonFileStore.ArePropertiesEqual((CommonFileStore)other);
+                case CompoundParameterType compoundParameterType:
+                    return compoundParameterType.ArePropertiesEqual((CompoundParameterType)other);
+                case Constant constant:
+                    return constant.ArePropertiesEqual((Constant)other);
+                case CyclicRatioScale cyclicRatioScale:
+                    return cyclicRatioScale.ArePropertiesEqual((CyclicRatioScale)other);
+                case DateParameterType dateParameterType:
+                    return dateParameterType.ArePropertiesEqual((DateParameterType)other);
+                case DateTimeParameterType dateTimeParameterType:
+                    return dateTimeParameterType.ArePropertiesEqual((DateTimeParameterType)other);
+                case DecompositionRule decompositionRule:
+                    return decompositionRule.ArePropertiesEqual((DecompositionRule)other);
+                case Definition definition:
+                    return definition.ArePropertiesEqual((Definition)other);
+                case DerivedQuantityKind derivedQuantityKind:
+                    return derivedQuantityKind.ArePropertiesEqual((DerivedQuantityKind)other);
+                case DerivedUnit derivedUnit:
+                    return derivedUnit.ArePropertiesEqual((DerivedUnit)other);
+                case DomainFileStore domainFileStore:
+                    return domainFileStore.ArePropertiesEqual((DomainFileStore)other);
+                case DomainOfExpertise domainOfExpertise:
+                    return domainOfExpertise.ArePropertiesEqual((DomainOfExpertise)other);
+                case DomainOfExpertiseGroup domainOfExpertiseGroup:
+                    return domainOfExpertiseGroup.ArePropertiesEqual((DomainOfExpertiseGroup)other);
+                case ElementDefinition elementDefinition:
+                    return elementDefinition.ArePropertiesEqual((ElementDefinition)other);
+                case ElementUsage elementUsage:
+                    return elementUsage.ArePropertiesEqual((ElementUsage)other);
+                case EmailAddress emailAddress:
+                    return emailAddress.ArePropertiesEqual((EmailAddress)other);
+                case EngineeringModel engineeringModel:
+                    return engineeringModel.ArePropertiesEqual((EngineeringModel)other);
+                case EngineeringModelSetup engineeringModelSetup:
+                    return engineeringModelSetup.ArePropertiesEqual((EngineeringModelSetup)other);
+                case EnumerationParameterType enumerationParameterType:
+                    return enumerationParameterType.ArePropertiesEqual((EnumerationParameterType)other);
+                case EnumerationValueDefinition enumerationValueDefinition:
+                    return enumerationValueDefinition.ArePropertiesEqual((EnumerationValueDefinition)other);
+                case ExclusiveOrExpression exclusiveOrExpression:
+                    return exclusiveOrExpression.ArePropertiesEqual((ExclusiveOrExpression)other);
+                case ExternalIdentifierMap externalIdentifierMap:
+                    return externalIdentifierMap.ArePropertiesEqual((ExternalIdentifierMap)other);
+                case File file:
+                    return file.ArePropertiesEqual((File)other);
+                case FileRevision fileRevision:
+                    return fileRevision.ArePropertiesEqual((FileRevision)other);
+                case FileType fileType:
+                    return fileType.ArePropertiesEqual((FileType)other);
+                case Folder folder:
+                    return folder.ArePropertiesEqual((Folder)other);
+                case Glossary glossary:
+                    return glossary.ArePropertiesEqual((Glossary)other);
+                case HyperLink hyperLink:
+                    return hyperLink.ArePropertiesEqual((HyperLink)other);
+                case IdCorrespondence idCorrespondence:
+                    return idCorrespondence.ArePropertiesEqual((IdCorrespondence)other);
+                case IntervalScale intervalScale:
+                    return intervalScale.ArePropertiesEqual((IntervalScale)other);
+                case Iteration iteration:
+                    return iteration.ArePropertiesEqual((Iteration)other);
+                case IterationSetup iterationSetup:
+                    return iterationSetup.ArePropertiesEqual((IterationSetup)other);
+                case LinearConversionUnit linearConversionUnit:
+                    return linearConversionUnit.ArePropertiesEqual((LinearConversionUnit)other);
+                case LogarithmicScale logarithmicScale:
+                    return logarithmicScale.ArePropertiesEqual((LogarithmicScale)other);
+                case MappingToReferenceScale mappingToReferenceScale:
+                    return mappingToReferenceScale.ArePropertiesEqual((MappingToReferenceScale)other);
+                case ModelLogEntry modelLogEntry:
+                    return modelLogEntry.ArePropertiesEqual((ModelLogEntry)other);
+                case ModelReferenceDataLibrary modelReferenceDataLibrary:
+                    return modelReferenceDataLibrary.ArePropertiesEqual((ModelReferenceDataLibrary)other);
+                case MultiRelationship multiRelationship:
+                    return multiRelationship.ArePropertiesEqual((MultiRelationship)other);
+                case MultiRelationshipRule multiRelationshipRule:
+                    return multiRelationshipRule.ArePropertiesEqual((MultiRelationshipRule)other);
+                case NaturalLanguage naturalLanguage:
+                    return naturalLanguage.ArePropertiesEqual((NaturalLanguage)other);
+                case NestedElement nestedElement:
+                    return nestedElement.ArePropertiesEqual((NestedElement)other);
+                case NestedParameter nestedParameter:
+                    return nestedParameter.ArePropertiesEqual((NestedParameter)other);
+                case NotExpression notExpression:
+                    return notExpression.ArePropertiesEqual((NotExpression)other);
+                case Option option:
+                    return option.ArePropertiesEqual((Option)other);
+                case OrdinalScale ordinalScale:
+                    return ordinalScale.ArePropertiesEqual((OrdinalScale)other);
+                case OrExpression orExpression:
+                    return orExpression.ArePropertiesEqual((OrExpression)other);
+                case Organization organization:
+                    return organization.ArePropertiesEqual((Organization)other);
+                case Parameter parameter:
+                    return parameter.ArePropertiesEqual((Parameter)other);
+                case ParameterGroup parameterGroup:
+                    return parameterGroup.ArePropertiesEqual((ParameterGroup)other);
+                case ParameterizedCategoryRule parameterizedCategoryRule:
+                    return parameterizedCategoryRule.ArePropertiesEqual((ParameterizedCategoryRule)other);
+                case ParameterOverride parameterOverride:
+                    return parameterOverride.ArePropertiesEqual((ParameterOverride)other);
+                case ParameterOverrideValueSet parameterOverrideValueSet:
+                    return parameterOverrideValueSet.ArePropertiesEqual((ParameterOverrideValueSet)other);
+                case ParameterSubscription parameterSubscription:
+                    return parameterSubscription.ArePropertiesEqual((ParameterSubscription)other);
+                case ParameterSubscriptionValueSet parameterSubscriptionValueSet:
+                    return parameterSubscriptionValueSet.ArePropertiesEqual((ParameterSubscriptionValueSet)other);
+                case ParameterTypeComponent parameterTypeComponent:
+                    return parameterTypeComponent.ArePropertiesEqual((ParameterTypeComponent)other);
+                case ParameterValueSet parameterValueSet:
+                    return parameterValueSet.ArePropertiesEqual((ParameterValueSet)other);
+                case ParametricConstraint parametricConstraint:
+                    return parametricConstraint.ArePropertiesEqual((ParametricConstraint)other);
+                case Participant participant:
+                    return participant.ArePropertiesEqual((Participant)other);
+                case ParticipantPermission participantPermission:
+                    return participantPermission.ArePropertiesEqual((ParticipantPermission)other);
+                case ParticipantRole participantRole:
+                    return participantRole.ArePropertiesEqual((ParticipantRole)other);
+                case Person person:
+                    return person.ArePropertiesEqual((Person)other);
+                case PersonPermission personPermission:
+                    return personPermission.ArePropertiesEqual((PersonPermission)other);
+                case PersonRole personRole:
+                    return personRole.ArePropertiesEqual((PersonRole)other);
+                case PossibleFiniteState possibleFiniteState:
+                    return possibleFiniteState.ArePropertiesEqual((PossibleFiniteState)other);
+                case PossibleFiniteStateList possibleFiniteStateList:
+                    return possibleFiniteStateList.ArePropertiesEqual((PossibleFiniteStateList)other);
+                case PrefixedUnit prefixedUnit:
+                    return prefixedUnit.ArePropertiesEqual((PrefixedUnit)other);
+                case Publication publication:
+                    return publication.ArePropertiesEqual((Publication)other);
+                case QuantityKindFactor quantityKindFactor:
+                    return quantityKindFactor.ArePropertiesEqual((QuantityKindFactor)other);
+                case RatioScale ratioScale:
+                    return ratioScale.ArePropertiesEqual((RatioScale)other);
+                case ReferencerRule referencerRule:
+                    return referencerRule.ArePropertiesEqual((ReferencerRule)other);
+                case ReferenceSource referenceSource:
+                    return referenceSource.ArePropertiesEqual((ReferenceSource)other);
+                case RelationalExpression relationalExpression:
+                    return relationalExpression.ArePropertiesEqual((RelationalExpression)other);
+                case Requirement requirement:
+                    return requirement.ArePropertiesEqual((Requirement)other);
+                case RequirementsGroup requirementsGroup:
+                    return requirementsGroup.ArePropertiesEqual((RequirementsGroup)other);
+                case RequirementsSpecification requirementsSpecification:
+                    return requirementsSpecification.ArePropertiesEqual((RequirementsSpecification)other);
+                case RuleVerificationList ruleVerificationList:
+                    return ruleVerificationList.ArePropertiesEqual((RuleVerificationList)other);
+                case RuleViolation ruleViolation:
+                    return ruleViolation.ArePropertiesEqual((RuleViolation)other);
+                case ScaleReferenceQuantityValue scaleReferenceQuantityValue:
+                    return scaleReferenceQuantityValue.ArePropertiesEqual((ScaleReferenceQuantityValue)other);
+                case ScaleValueDefinition scaleValueDefinition:
+                    return scaleValueDefinition.ArePropertiesEqual((ScaleValueDefinition)other);
+                case SimpleParameterValue simpleParameterValue:
+                    return simpleParameterValue.ArePropertiesEqual((SimpleParameterValue)other);
+                case SimpleQuantityKind simpleQuantityKind:
+                    return simpleQuantityKind.ArePropertiesEqual((SimpleQuantityKind)other);
+                case SimpleUnit simpleUnit:
+                    return simpleUnit.ArePropertiesEqual((SimpleUnit)other);
+                case SiteDirectory siteDirectory:
+                    return siteDirectory.ArePropertiesEqual((SiteDirectory)other);
+                case SiteLogEntry siteLogEntry:
+                    return siteLogEntry.ArePropertiesEqual((SiteLogEntry)other);
+                case SiteReferenceDataLibrary siteReferenceDataLibrary:
+                    return siteReferenceDataLibrary.ArePropertiesEqual((SiteReferenceDataLibrary)other);
+                case SpecializedQuantityKind specializedQuantityKind:
+                    return specializedQuantityKind.ArePropertiesEqual((SpecializedQuantityKind)other);
+                case TelephoneNumber telephoneNumber:
+                    return telephoneNumber.ArePropertiesEqual((TelephoneNumber)other);
+                case Term term:
+                    return term.ArePropertiesEqual((Term)other);
+                case TextParameterType textParameterType:
+                    return textParameterType.ArePropertiesEqual((TextParameterType)other);
+                case TimeOfDayParameterType timeOfDayParameterType:
+                    return timeOfDayParameterType.ArePropertiesEqual((TimeOfDayParameterType)other);
+                case UnitFactor unitFactor:
+                    return unitFactor.ArePropertiesEqual((UnitFactor)other);
+                case UnitPrefix unitPrefix:
+                    return unitPrefix.ArePropertiesEqual((UnitPrefix)other);
+                case UserPreference userPreference:
+                    return userPreference.ArePropertiesEqual((UserPreference)other);
+                case UserRuleVerification userRuleVerification:
+                    return userRuleVerification.ArePropertiesEqual((UserRuleVerification)other);
+                case ActionItem actionItem:
+                    return actionItem.ArePropertiesEqual((ActionItem)other);
+                case Approval approval:
+                    return approval.ArePropertiesEqual((Approval)other);
+                case BinaryNote binaryNote:
+                    return binaryNote.ArePropertiesEqual((BinaryNote)other);
+                case Book book:
+                    return book.ArePropertiesEqual((Book)other);
+                case Bounds bounds:
+                    return bounds.ArePropertiesEqual((Bounds)other);
+                case ChangeProposal changeProposal:
+                    return changeProposal.ArePropertiesEqual((ChangeProposal)other);
+                case ChangeRequest changeRequest:
+                    return changeRequest.ArePropertiesEqual((ChangeRequest)other);
+                case ContractChangeNotice contractChangeNotice:
+                    return contractChangeNotice.ArePropertiesEqual((ContractChangeNotice)other);
+                case DiagramCanvas diagramCanvas:
+                    return diagramCanvas.ArePropertiesEqual((DiagramCanvas)other);
+                case DiagramEdge diagramEdge:
+                    return diagramEdge.ArePropertiesEqual((DiagramEdge)other);
+                case DiagramObject diagramObject:
+                    return diagramObject.ArePropertiesEqual((DiagramObject)other);
+                case EngineeringModelDataDiscussionItem engineeringModelDataDiscussionItem:
+                    return engineeringModelDataDiscussionItem.ArePropertiesEqual((EngineeringModelDataDiscussionItem)other);
+                case EngineeringModelDataNote engineeringModelDataNote:
+                    return engineeringModelDataNote.ArePropertiesEqual((EngineeringModelDataNote)other);
+                case Goal goal:
+                    return goal.ArePropertiesEqual((Goal)other);
+                case ModellingThingReference modellingThingReference:
+                    return modellingThingReference.ArePropertiesEqual((ModellingThingReference)other);
+                case OwnedStyle ownedStyle:
+                    return ownedStyle.ArePropertiesEqual((OwnedStyle)other);
+                case Page page:
+                    return page.ArePropertiesEqual((Page)other);
+                case Point point:
+                    return point.ArePropertiesEqual((Point)other);
+                case RelationshipParameterValue relationshipParameterValue:
+                    return relationshipParameterValue.ArePropertiesEqual((RelationshipParameterValue)other);
+                case RequestForDeviation requestForDeviation:
+                    return requestForDeviation.ArePropertiesEqual((RequestForDeviation)other);
+                case RequestForWaiver requestForWaiver:
+                    return requestForWaiver.ArePropertiesEqual((RequestForWaiver)other);
+                case RequirementsContainerParameterValue requirementsContainerParameterValue:
+                    return requirementsContainerParameterValue.ArePropertiesEqual((RequirementsContainerParameterValue)other);
+                case ReviewItemDiscrepancy reviewItemDiscrepancy:
+                    return reviewItemDiscrepancy.ArePropertiesEqual((ReviewItemDiscrepancy)other);
+                case Section section:
+                    return section.ArePropertiesEqual((Section)other);
+                case SharedStyle sharedStyle:
+                    return sharedStyle.ArePropertiesEqual((SharedStyle)other);
+                case SiteDirectoryDataAnnotation siteDirectoryDataAnnotation:
+                    return siteDirectoryDataAnnotation.ArePropertiesEqual((SiteDirectoryDataAnnotation)other);
+                case SiteDirectoryDataDiscussionItem siteDirectoryDataDiscussionItem:
+                    return siteDirectoryDataDiscussionItem.ArePropertiesEqual((SiteDirectoryDataDiscussionItem)other);
+                case SiteDirectoryThingReference siteDirectoryThingReference:
+                    return siteDirectoryThingReference.ArePropertiesEqual((SiteDirectoryThingReference)other);
+                case Solution solution:
+                    return solution.ArePropertiesEqual((Solution)other);
+                case Stakeholder stakeholder:
+                    return stakeholder.ArePropertiesEqual((Stakeholder)other);
+                case StakeholderValue stakeholderValue:
+                    return stakeholderValue.ArePropertiesEqual((StakeholderValue)other);
+                case StakeHolderValueMap stakeHolderValueMap:
+                    return stakeHolderValueMap.ArePropertiesEqual((StakeHolderValueMap)other);
+                case StakeHolderValueMapSettings stakeHolderValueMapSettings:
+                    return stakeHolderValueMapSettings.ArePropertiesEqual((StakeHolderValueMapSettings)other);
+                case TextualNote textualNote:
+                    return textualNote.ArePropertiesEqual((TextualNote)other);
+                case ValueGroup valueGroup:
+                    return valueGroup.ArePropertiesEqual((ValueGroup)other);
+                case DependentParameterTypeAssignment dependentParameterTypeAssignment:
+                    return dependentParameterTypeAssignment.ArePropertiesEqual((DependentParameterTypeAssignment)other);
+                case IndependentParameterTypeAssignment independentParameterTypeAssignment:
+                    return independentParameterTypeAssignment.ArePropertiesEqual((IndependentParameterTypeAssignment)other);
+                case LogEntryChangelogItem logEntryChangelogItem:
+                    return logEntryChangelogItem.ArePropertiesEqual((LogEntryChangelogItem)other);
+                case OrganizationalParticipant organizationalParticipant:
+                    return organizationalParticipant.ArePropertiesEqual((OrganizationalParticipant)other);
+                case SampledFunctionParameterType sampledFunctionParameterType:
+                    return sampledFunctionParameterType.ArePropertiesEqual((SampledFunctionParameterType)other);
+                default:
+                    return false;
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------

--- a/CDP4Common/AutoGenEquatable/TimeOfDayParameterTypeEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/TimeOfDayParameterTypeEquatable.cs
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="TimeOfDayParameterTypeEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | symbol                               | string                       | 1..1        |  1.0.0  |
+ | 10    | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 12    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 13    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="TimeOfDayParameterType"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class TimeOfDayParameterTypeEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="TimeOfDayParameterType"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="TimeOfDayParameterType"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="TimeOfDayParameterType"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="TimeOfDayParameterType"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this TimeOfDayParameterType me, TimeOfDayParameterType other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Symbol == null && other.Symbol != null) return false;
+            if (me.Symbol != null && !me.Symbol.Equals(other.Symbol)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/UnitFactorEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/UnitFactorEquatable.cs
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="UnitFactorEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | exponent                             | string                       | 1..1        |  1.0.0  |
+ | 3     | unit                                 | Guid                         | 1..1        |  1.0.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="UnitFactor"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class UnitFactorEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="UnitFactor"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="UnitFactor"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="UnitFactor"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="UnitFactor"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this UnitFactor me, UnitFactor other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (me.Exponent == null && other.Exponent != null) return false;
+            if (me.Exponent != null && !me.Exponent.Equals(other.Exponent)) return false;
+
+            if (!me.Unit.Equals(other.Unit)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/UnitPrefixEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/UnitPrefixEquatable.cs
@@ -1,0 +1,119 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="UnitPrefixEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.0.0  |
+ | 3     | conversionFactor                     | string                       | 1..1        |  1.0.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.0.0  |
+ | 5     | hyperLink                            | Guid                         | 0..*        |  1.0.0  |
+ | 6     | isDeprecated                         | bool                         | 1..1        |  1.0.0  |
+ | 7     | name                                 | string                       | 1..1        |  1.0.0  |
+ | 8     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 9     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 10    | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 11    | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 12    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="UnitPrefix"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class UnitPrefixEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="UnitPrefix"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="UnitPrefix"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="UnitPrefix"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="UnitPrefix"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this UnitPrefix me, UnitPrefix other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (me.ConversionFactor == null && other.ConversionFactor != null) return false;
+            if (me.ConversionFactor != null && !me.ConversionFactor.Equals(other.ConversionFactor)) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.IsDeprecated.Equals(other.IsDeprecated)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/UserPreferenceEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/UserPreferenceEquatable.cs
@@ -1,0 +1,103 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="UserPreferenceEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | shortName                            | string                       | 1..1        |  1.0.0  |
+ | 3     | value                                | string                       | 1..1        |  1.0.0  |
+ | 4     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 7     | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="UserPreference"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class UserPreferenceEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="UserPreference"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="UserPreference"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="UserPreference"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="UserPreference"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this UserPreference me, UserPreference other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.Value == null && other.Value != null) return false;
+            if (me.Value != null && !me.Value.Equals(other.Value)) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/UserRuleVerificationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/UserRuleVerificationEquatable.cs
@@ -1,0 +1,111 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="UserRuleVerificationEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | executedOn                           | DateTime                     | 0..1        |  1.0.0  |
+ | 3     | isActive                             | bool                         | 1..1        |  1.0.0  |
+ | 4     | rule                                 | Guid                         | 1..1        |  1.0.0  |
+ | 5     | status                               | RuleVerificationStatusKind   | 1..1        |  1.0.0  |
+ | 6     | violation                            | Guid                         | 0..*        |  1.0.0  |
+ | 7     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 8     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 9     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 10    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="UserRuleVerification"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class UserRuleVerificationEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="UserRuleVerification"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="UserRuleVerification"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="UserRuleVerification"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="UserRuleVerification"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this UserRuleVerification me, UserRuleVerification other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.ExecutedOn.HasValue && other.ExecutedOn.HasValue) return false;
+            if (!me.ExecutedOn.Equals(other.ExecutedOn)) return false;
+
+            if (!me.IsActive.Equals(other.IsActive)) return false;
+
+            if (!me.Rule.Equals(other.Rule)) return false;
+
+            if (!me.Status.Equals(other.Status)) return false;
+
+            if (!me.Violation.OrderBy(x => x).SequenceEqual(other.Violation.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenEquatable/UserRuleVerificationEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/UserRuleVerificationEquatable.cs
@@ -81,7 +81,7 @@ namespace CDP4Common.DTO.Equatable
 
             if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
 
-            if (!me.ExecutedOn.HasValue && other.ExecutedOn.HasValue) return false;
+            if (me.ExecutedOn.HasValue != other.ExecutedOn.HasValue) return false;
             if (!me.ExecutedOn.Equals(other.ExecutedOn)) return false;
 
             if (!me.IsActive.Equals(other.IsActive)) return false;

--- a/CDP4Common/AutoGenEquatable/ValueGroupEquatable.cs
+++ b/CDP4Common/AutoGenEquatable/ValueGroupEquatable.cs
@@ -1,0 +1,115 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ValueGroupEquatable.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET-SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET-SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET-SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+/* -------------------------------------------- | ---------------------------- | ----------- | ------- *
+ | index | name                                 | Type                         | Cardinality | version |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 0     | iid                                  | Guid                         |  1..1       |  1.0.0  |
+ | 1     | revisionNumber                       | int                          |  1..1       |  1.0.0  |
+ | -------------------------------------------- | ---------------------------- | ----------- | ------- |
+ | 2     | alias                                | Guid                         | 0..*        |  1.1.0  |
+ | 3     | category                             | Guid                         | 0..*        |  1.1.0  |
+ | 4     | definition                           | Guid                         | 0..*        |  1.1.0  |
+ | 5     | excludedDomain                       | Guid                         | 0..*        |  1.1.0  |
+ | 6     | excludedPerson                       | Guid                         | 0..*        |  1.1.0  |
+ | 7     | hyperLink                            | Guid                         | 0..*        |  1.1.0  |
+ | 8     | modifiedOn                           | DateTime                     | 1..1        |  1.1.0  |
+ | 9     | name                                 | string                       | 1..1        |  1.1.0  |
+ | 10    | shortName                            | string                       | 1..1        |  1.1.0  |
+ | 11    | thingPreference                      | string                       | 0..1        |  1.2.0  |
+ * -------------------------------------------- | ---------------------------- | ----------- | ------- */
+
+namespace CDP4Common.DTO.Equatable
+{
+    using System.Linq;
+
+    using CDP4Common.DTO;
+
+    /// <summary>
+    /// An extension class for the <see cref="ValueGroup"/> to support the computation
+    /// of property based equality
+    /// </summary>
+    public static class ValueGroupEquatable
+    {
+        /// <summary>
+        /// Determines whether 2 <see cref="ValueGroup"/> objects are the same
+        /// by comparing all the properties
+        /// </summary>
+        /// <param name="me">
+        /// The current <see cref="ValueGroup"/>
+        /// </param>
+        /// <param name="other">
+        /// The <see cref="ValueGroup"/> that the <paramref name="me"/> is
+        /// compared to
+        /// </param>
+        /// <returns>
+        /// returns true when all the properties of the <see cref="ValueGroup"/> objects
+        /// have the same value
+        /// </returns>
+        public static bool ArePropertiesEqual(this ValueGroup me, ValueGroup other)
+        {
+            if (me == null && other == null) return true;
+
+            if (me == null || other == null) return false;
+
+            if (!me.Iid.Equals(other.Iid)) return false;
+
+            if (!me.RevisionNumber.Equals(other.RevisionNumber)) return false;
+
+            if (!me.Alias.OrderBy(x => x).SequenceEqual(other.Alias.OrderBy(x => x))) return false;
+
+            if (!me.Category.OrderBy(x => x).SequenceEqual(other.Category.OrderBy(x => x))) return false;
+
+            if (!me.Definition.OrderBy(x => x).SequenceEqual(other.Definition.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedDomain.OrderBy(x => x).SequenceEqual(other.ExcludedDomain.OrderBy(x => x))) return false;
+
+            if (!me.ExcludedPerson.OrderBy(x => x).SequenceEqual(other.ExcludedPerson.OrderBy(x => x))) return false;
+
+            if (!me.HyperLink.OrderBy(x => x).SequenceEqual(other.HyperLink.OrderBy(x => x))) return false;
+
+            if (!me.ModifiedOn.Equals(other.ModifiedOn)) return false;
+
+            if (me.Name == null && other.Name != null) return false;
+            if (me.Name != null && !me.Name.Equals(other.Name)) return false;
+
+            if (me.ShortName == null && other.ShortName != null) return false;
+            if (me.ShortName != null && !me.ShortName.Equals(other.ShortName)) return false;
+
+            if (me.ThingPreference == null && other.ThingPreference != null) return false;
+            if (me.ThingPreference != null && !me.ThingPreference.Equals(other.ThingPreference)) return false;
+
+            return true;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
  - Add generated class for each concrete DTO that provides an extension method in which equality is determined based on property values. Any Enumerable property is first ordered prior to comparison
  - Add generarted class that allows any 2 DTO thigns to be compared 

please have a look at:
  - ActionItemEquatable
  - CategoryEquatable
  - ConstantEquatable
  - DefinitionEquatable

<!-- Thanks for contributing to COMET-SDK! -->