### PR TITLE
[Add] Generate PropertyAccessor files; fixes #271

### DIFF
--- a/CDP4Common.NetCore.Tests/Helpers/PropertyDescriptorTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Helpers/PropertyDescriptorTestFixture.cs
@@ -1,0 +1,139 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PropertyDescriptorTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.NetCore.Tests.Helpers
+{
+	using System;
+
+	using CDP4Common.PropertyAccesor;
+
+	using NUnit.Framework;
+	
+	/// <summary>
+	/// Suite of tests for the <see cref="PropertyDescriptor"/> class.
+	/// </summary>
+	[TestFixture]
+	public class PropertyDescriptorTestFixture
+	{
+		[Test]
+		public void Verify_that_QueryPropertyDescriptor_returns_expected_results()
+		{
+			PropertyDescriptor descriptor = null;
+
+			descriptor = PropertyDescriptor.QueryPropertyDescriptor("Name");
+			Assert.That(descriptor.Name, Is.EqualTo("Name"));
+			Assert.That(descriptor.Lower, Is.Null);
+			Assert.That(descriptor.Upper, Is.Null);
+			Assert.That(descriptor.PathLiteral, Is.EqualTo("Name"));
+			Assert.That(descriptor.NextPath, Is.Empty);
+			
+			descriptor = PropertyDescriptor.QueryPropertyDescriptor("Name.Me");
+			Assert.That(descriptor.Name, Is.EqualTo("Name"));
+			Assert.That(descriptor.Lower, Is.Null);
+			Assert.That(descriptor.Upper, Is.Null);
+			Assert.That(descriptor.PathLiteral, Is.EqualTo("Name"));
+			Assert.That(descriptor.NextPath, Is.EqualTo("Me"));
+			Assert.That(descriptor.Next.Name, Is.EqualTo("Me"));
+
+			descriptor = PropertyDescriptor.QueryPropertyDescriptor("Parameter[1..1]");
+			Assert.That(descriptor.Name, Is.EqualTo("Parameter"));
+			Assert.That(descriptor.Lower, Is.EqualTo(1));
+			Assert.That(descriptor.Upper, Is.EqualTo(1));
+			Assert.That(descriptor.PathLiteral, Is.EqualTo("Parameter[1..1]"));
+			Assert.That(descriptor.NextPath, Is.Empty);
+			Assert.That(descriptor.Next, Is.Null);
+
+			descriptor = PropertyDescriptor.QueryPropertyDescriptor("Parameter[0..*]");
+			Assert.That(descriptor.Name, Is.EqualTo("Parameter"));
+			Assert.That(descriptor.Lower, Is.EqualTo(0));
+			Assert.That(descriptor.Upper, Is.EqualTo(int.MaxValue));
+			Assert.That(descriptor.PathLiteral, Is.EqualTo("Parameter[0..*]"));
+			Assert.That(descriptor.NextPath, Is.Empty);
+			Assert.That(descriptor.Next, Is.Null);
+
+			descriptor = PropertyDescriptor.QueryPropertyDescriptor("Parameter[1..1].Name");
+			Assert.That(descriptor.Name, Is.EqualTo("Parameter"));
+			Assert.That(descriptor.Lower, Is.EqualTo(1));
+			Assert.That(descriptor.Upper, Is.EqualTo(1));
+			Assert.That(descriptor.PathLiteral, Is.EqualTo("Parameter[1..1]"));
+			Assert.That(descriptor.NextPath, Is.EqualTo("Name"));
+			Assert.That(descriptor.Next.Name, Is.EqualTo("Name"));
+			Assert.That(descriptor.Next.PathLiteral, Is.EqualTo("Name"));
+
+			descriptor = PropertyDescriptor.QueryPropertyDescriptor("Parameter[1..*].Name");
+			Assert.That(descriptor.Name, Is.EqualTo("Parameter"));
+			Assert.That(descriptor.Lower, Is.EqualTo(1));
+			Assert.That(descriptor.Upper, Is.EqualTo(int.MaxValue));
+			Assert.That(descriptor.NextPath, Is.EqualTo("Name"));
+
+			descriptor = PropertyDescriptor.QueryPropertyDescriptor("Parameter.Name[1..*]");
+			Assert.That(descriptor.Name, Is.EqualTo("Parameter"));
+			Assert.That(descriptor.Lower, Is.Null);
+			Assert.That(descriptor.Upper, Is.Null);
+			Assert.That(descriptor.PathLiteral, Is.EqualTo("Parameter"));
+			Assert.That(descriptor.NextPath, Is.EqualTo("Name[1..*]"));
+			Assert.That(descriptor.Next.Name, Is.EqualTo("Name"));
+			Assert.That(descriptor.Next.Lower, Is.EqualTo(1));
+			Assert.That(descriptor.Next.Upper, Is.EqualTo(int.MaxValue));
+			Assert.That(descriptor.Next.PathLiteral, Is.EqualTo("Name[1..*]"));
+
+			descriptor = PropertyDescriptor.QueryPropertyDescriptor("Parameter.Name[1..*].Me");
+			Assert.That(descriptor.Name, Is.EqualTo("Parameter"));
+			Assert.That(descriptor.Lower, Is.Null);
+			Assert.That(descriptor.Upper, Is.Null);
+			Assert.That(descriptor.NextPath, Is.EqualTo("Name[1..*].Me"));
+			Assert.That(descriptor.Next.Name, Is.EqualTo("Name"));
+			Assert.That(descriptor.Next.Next.Name, Is.EqualTo("Me"));
+
+			descriptor = PropertyDescriptor.QueryPropertyDescriptor("Parameter[10..11]");
+			Assert.That(descriptor.Name, Is.EqualTo("Parameter"));
+			Assert.That(descriptor.Lower, Is.EqualTo(10));
+			Assert.That(descriptor.Upper, Is.EqualTo(11));
+			Assert.That(descriptor.NextPath, Is.EqualTo(""));
+			Assert.That(descriptor.Next, Is.Null);
+
+			descriptor = PropertyDescriptor.QueryPropertyDescriptor("actionee.selectedDomain.alias[1..1]");
+			Assert.That(descriptor.Name, Is.EqualTo("actionee"));
+			Assert.That(descriptor.Lower, Is.Null);
+			Assert.That(descriptor.Upper, Is.Null);
+			Assert.That(descriptor.NextPath, Is.EqualTo("selectedDomain.alias[1..1]"));
+			Assert.That(descriptor.Next.Next.Name, Is.EqualTo("alias"));
+			Assert.That(descriptor.Next.Next.Lower, Is.EqualTo(1));
+			Assert.That(descriptor.Next.Next.Upper, Is.EqualTo(1));
+			Assert.That(descriptor.Next.Next.Next, Is.Null);
+		}
+
+		[Test]
+		public void Verify_that_QueryPropertyDescriptor_throws_exception_on_incorrect_multiplicity()
+		{
+			PropertyDescriptor descriptor = null;
+
+			Assert.That(() =>
+				PropertyDescriptor.QueryPropertyDescriptor("Parameter[-1..1]"), 
+				Throws.Exception.TypeOf<ArgumentException>()
+					.With.Message.EqualTo("The input may not contain a hyphen or minus sign"));
+		}
+	}
+}

--- a/CDP4Common.NetCore.Tests/PropertyAccessor/ActionItemPropertyAccessorTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/PropertyAccessor/ActionItemPropertyAccessorTestFixture.cs
@@ -1,0 +1,194 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ActionItemPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.NetCore.Tests.PropertyAccessor
+{
+    using System;
+    using System.Collections.Generic;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tets for the <see cref="ActionItem.QueryValue"/> method
+    /// </summary>
+    [TestFixture]
+    public class ActionItemPropertyAccessorTestFixture
+    {
+        [Test]
+        public void Verify_that_ActionItemPropertyAccessor_can_access_approvedby()
+        {
+            var actionitem = new ActionItem
+            {
+                Iid = Guid.Parse("f6157c74-c0a1-4a8c-a6d0-468628496e5c"),
+                RevisionNumber = 1,
+            };
+
+            var approvals = (IEnumerable<string>)actionitem.QueryValue("ApprovedBy[0..*].Content");
+            Assert.That(approvals, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_ActionItemPropertyAccessor_can_access_actionee()
+        {
+            var participant = new Participant()
+            {
+                Iid = Guid.Parse("f6157c74-c0a1-4a8c-a6d0-468628496e5c"),
+                RevisionNumber = 1,
+                IsActive = true
+            };
+
+            var actionItem = new ActionItem
+            {
+                Iid = Guid.Parse("f6157c74-c0a1-4a8c-a6d0-468628496e5c"),
+                RevisionNumber = 1,
+                Actionee = participant
+            };
+
+            var actionee_IsActive = (bool)actionItem.QueryValue("actionee.isActive");
+            Assert.That(actionee_IsActive, Is.True);
+
+            var selectedDomain = (DomainOfExpertise)actionItem.QueryValue("actionee.selectedDomain");
+            Assert.That(selectedDomain, Is.Null);
+
+            var domainOfExpertise = new DomainOfExpertise()
+            {
+                Iid = Guid.Parse("8fe906b1-3529-4c19-8287-25e1ea1839b6"),
+                RevisionNumber = 1,
+                ShortName = "SYS"
+            };
+
+            participant.SelectedDomain = domainOfExpertise;
+
+            selectedDomain = (DomainOfExpertise)actionItem.QueryValue("actionee.selectedDomain");
+            Assert.That(selectedDomain, Is.EqualTo(domainOfExpertise));
+
+            var selectedDomainShortName = (string)actionItem.QueryValue("actionee.selectedDomain.shortname");
+            Assert.That(selectedDomainShortName, Is.EqualTo("SYS"));
+
+            Assert.That(() => actionItem.QueryValue("actionee.selectedDomain.alias[1..1]"),
+                Throws.TypeOf<IndexOutOfRangeException>());
+
+            var queriedAliases = (List<Alias>)actionItem.QueryValue("actionee.selectedDomain.alias[0..*]");
+            Assert.That(queriedAliases, Is.Empty);
+
+            var alias_1 = new Alias(Guid.Parse("2d8a7eef-53f5-400f-9cd1-782b589c70a6"), null, null)
+            {
+                Content = "alias_1 content",
+                IsSynonym = true,
+                LanguageCode = "en-GB"
+            };
+
+            domainOfExpertise.Alias.Add(alias_1);
+            
+            var selectedDomain_Alias_1 = (Alias)actionItem.QueryValue("actionee.selectedDomain.alias[0..0]");
+            Assert.That(selectedDomain_Alias_1, Is.EqualTo(alias_1));
+
+            var selectedDomainFirstAliasContent = (string)actionItem.QueryValue("actionee.selectedDomain.alias[0..0].Content");
+            Assert.That(selectedDomainFirstAliasContent, Is.EqualTo(alias_1.Content));
+
+            var alias_2 = new Alias(Guid.Parse("39c4d145-1212-4cc7-b58a-313925b138a1"), null, null)
+            {
+                Content = "alias_2 content",
+                IsSynonym = false,
+                LanguageCode = "en-CA"
+            };
+
+            domainOfExpertise.Alias.Add(alias_2);
+
+            selectedDomain_Alias_1 = (Alias)actionItem.QueryValue("actionee.selectedDomain.alias[0..0]");
+            Assert.That(selectedDomain_Alias_1, Is.EqualTo(alias_1));
+
+            var selectedDomain_Alias_2 = (Alias)actionItem.QueryValue("actionee.selectedDomain.alias[1..1]");
+            Assert.That(selectedDomain_Alias_2, Is.EqualTo(alias_2));
+
+            var aliases = actionItem.QueryValue("actionee.selectedDomain.alias[0..*]");
+            Assert.That(aliases, Is.EquivalentTo(domainOfExpertise.Alias));
+
+            var selectedDomain_Alias_2_languagecode = (string)actionItem.QueryValue("actionee.selectedDomain.alias[1..1].Languagecode");
+            Assert.That(selectedDomain_Alias_2_languagecode, Is.EqualTo(alias_2.LanguageCode));
+
+            var definition_1 = new Definition(Guid.Parse("63c30711-3c74-44a4-a069-89280ce761e1"), null, null);
+            definition_1.Example.Add("example_1");
+
+            domainOfExpertise.Definition.Add(definition_1);
+
+            var selectedDomain_Definition_1_example_1 = (string)actionItem.QueryValue("actionee.selectedDomain.definition[0..0].Example[0..0]");
+            Assert.That(selectedDomain_Definition_1_example_1, Is.EqualTo(definition_1.Example[0]));
+
+            definition_1.Example.Add("example_2");
+
+            var selectedDomain_Definition_1_examples = (List<string>)actionItem.QueryValue("actionee.selectedDomain.definition[0..0].Example[0..*]");
+            Assert.That(selectedDomain_Definition_1_examples, Is.EquivalentTo(definition_1.Example));
+        }
+        
+        [Test]
+        public void Verify_that_ActionItemPropertyAccessor_returns_iid()
+        {
+            var actionitem = new ActionItem
+            {
+                Iid = Guid.Parse("f6157c74-c0a1-4a8c-a6d0-468628496e5c"),
+                RevisionNumber = 1,
+                CloseOutDate = new DateTime(1976, 8, 20),
+                CloseOutStatement = "this is a closeout statement",
+                Content = "this is some content"
+            };
+
+            var actionItemIid = (Guid)actionitem.QueryValue("iid");
+            Assert.That(actionItemIid, Is.EqualTo(actionitem.Iid));
+
+            var revisionNumber = (int)actionitem.QueryValue("RevisionNumber");
+            Assert.That(revisionNumber, Is.EqualTo(actionitem.RevisionNumber));
+
+            var closeOutDate = (DateTime)actionitem.QueryValue("CloseOutDate");
+            Assert.That(closeOutDate, Is.EqualTo(actionitem.CloseOutDate));
+
+            var closeOutStatement = (string)actionitem.QueryValue("CloseOutStatement");
+            Assert.That(closeOutStatement, Is.EqualTo(actionitem.CloseOutStatement));
+
+            var content = (string)actionitem.QueryValue("Content");
+            Assert.That(content, Is.EqualTo(actionitem.Content));
+        }
+
+        [Test]
+        public void Verify_that_ActionItemPropertyAccessor_returns_actionee_iid()
+        {
+            var actionitem = new ActionItem
+            {
+                Iid = Guid.Parse("f6157c74-c0a1-4a8c-a6d0-468628496e5c"),
+                RevisionNumber = 1,
+                CloseOutDate = new DateTime(1976, 8, 20),
+                CloseOutStatement = "this is a closeout statement",
+                Content = "this is some content"
+            };
+
+            var actionItemIid = (Guid)actionitem.QueryValue("iid");
+            Assert.That(actionItemIid, Is.EqualTo(actionitem.Iid));
+        }
+    }
+}

--- a/CDP4Common.NetCore.Tests/PropertyAccessor/CategoryPropertyAccssorTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/PropertyAccessor/CategoryPropertyAccssorTestFixture.cs
@@ -1,0 +1,70 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CategoryPropertyAccssor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.NetCore.Tests.PropertyAccessor
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tets for the <see cref="Category.QueryValue"/> method
+    /// </summary>
+    [TestFixture]
+    public class CategoryPropertyAccssorTestFixture
+    {
+        [Test]
+        public void Verify_that_the_PermissebleClass_can_be_queried()
+        {
+            var category = new Category(Guid.Parse("22e9dde4-d647-49af-b580-4461d4eef37e"), null, null);
+
+            Assert.That(() => category.QueryValue("permissibleClass"), 
+                Throws.Exception.TypeOf<ArgumentException>()
+                    .With.Message.EqualTo("Invalid Multiplicity for the PermissibleClass property, the lower and upper bound must be specified"));
+
+            var permissibleClasses = (List<ClassKind>)category.QueryValue("permissibleClass[0..*]");
+            Assert.That(permissibleClasses, Is.Empty);
+
+            category.PermissibleClass.Add(ClassKind.ActualFiniteState);
+
+            permissibleClasses = (List<ClassKind>)category.QueryValue("permissibleClass[0..*]");
+            Assert.That(permissibleClasses.Single(), Is.EqualTo(ClassKind.ActualFiniteState));
+
+            var permissibleClass = (ClassKind)category.QueryValue("permissibleClass[0..0]");
+            Assert.That(permissibleClass, Is.EqualTo(ClassKind.ActualFiniteState));
+
+            category.PermissibleClass.Add(ClassKind.Definition);
+
+            permissibleClasses = (List<ClassKind>)category.QueryValue("permissibleClass[0..*]");
+            Assert.That(permissibleClasses, Is.EquivalentTo(new List<ClassKind> { ClassKind.ActualFiniteState, ClassKind.Definition }));
+        }
+    }
+}

--- a/CDP4Common.NetCore.Tests/PropertyAccessor/ConstantPropertyAccessorTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/PropertyAccessor/ConstantPropertyAccessorTestFixture.cs
@@ -1,0 +1,95 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ConstantPropertyAccessorTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.NetCore.Tests.PropertyAccessor
+{
+    using System;
+    using System.Collections.Generic;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tets for the <see cref="Constant.QueryValue"/> method
+    /// </summary>
+    [TestFixture]
+    public class ConstantPropertyAccessorTestFixture
+    {
+        [Test]
+        public void Verify_that_the_value_of_a_Constant_can_be_queried()
+        {
+            var constant = new Constant(Guid.Parse("5e09b1cf-59fe-4b78-9c6d-4d2852448811"), null, null);
+
+            var values = (List<string>)constant.QueryValue("Value[0..*]");
+            Assert.That(values, Is.Empty);
+
+            constant.Value = new ValueArray<string>(new List<string> { "-" });
+
+            values = (List<string>)constant.QueryValue("Value[0..*]");
+            Assert.That(values, Is.EquivalentTo(constant.Value));
+
+            constant.Value = new ValueArray<string>(new List<string> { "-", "abc", "123" });
+
+            values = (List<string>)constant.QueryValue("Value[0..*]");
+            Assert.That(values, Is.EquivalentTo(constant.Value));
+
+            var value = (string)constant.QueryValue("Value[1..1]");
+            Assert.That(value, Is.EqualTo("abc"));
+        }
+
+        [Test]
+        public void Verify_that_the_value_of_an_empyt_list_of_Constant_can_be_queried()
+        {
+            var siteReferenceDataLibrary = new SiteReferenceDataLibrary(Guid.NewGuid(), null, null);
+
+            var constants = (List<Constant>) siteReferenceDataLibrary.QueryValue("constant[0..*]");
+            Assert.That(constants, Is.Empty);
+
+            var values = (List<string>)siteReferenceDataLibrary.QueryValue("constant[0..*].value[0..*]");
+            Assert.That(values, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_the_category_permissibleclass_of_an_empyt_list_of_Constant_can_be_queried()
+        {
+            var siteReferenceDataLibrary = new SiteReferenceDataLibrary(Guid.NewGuid(), null, null);
+
+            var constants = (List<Constant>)siteReferenceDataLibrary.QueryValue("constant[0..*]");
+            Assert.That(constants, Is.Empty);
+
+            var values = (List<string>)siteReferenceDataLibrary.QueryValue("constant[0..*].value[0..*]");
+            Assert.That(values, Is.Empty);
+
+            var categories = (List<Category>)siteReferenceDataLibrary.QueryValue("constant[0..*].category[0..*]");
+            Assert.That(categories, Is.Empty);
+
+            var classkinds = (List<ClassKind>)siteReferenceDataLibrary.QueryValue("constant[0..*].category[0..*].permissibleClass[0..*]");
+            Assert.That(classkinds, Is.Empty);
+        }
+    }
+}

--- a/CDP4Common.NetCore.Tests/PropertyAccessor/SiteDirectoryPropertyAccessorTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/PropertyAccessor/SiteDirectoryPropertyAccessorTestFixture.cs
@@ -1,0 +1,120 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SiteDirectoryPropertyAccessorTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.NetCore.Tests.PropertyAccessor
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tets for the <see cref="SiteDirectory.QueryValue"/> method
+    /// </summary>
+    [TestFixture]
+    public class SiteDirectoryPropertyAccessorTestFixture
+    {
+        [Test]
+        public void Verify_that_empty_domainofexpertise_returns()
+        {
+            var siteDirectory = new SiteDirectory(Guid.NewGuid(), null, null);
+
+            var domainOfExpertises = (List<DomainOfExpertise>)siteDirectory.QueryValue("domain[0..*]");
+            Assert.That(domainOfExpertises, Is.Empty);
+
+            var names = (List<string>) siteDirectory.QueryValue("domain[0..*].name");
+            Assert.That(names, Is.Empty);
+            
+            var aliases = (List<Alias>)siteDirectory.QueryValue("domain[0..*].alias[0..*]");
+            Assert.That(aliases, Is.Empty);
+
+            var contents = (List<string>)siteDirectory.QueryValue("domain[0..*].alias[0..*].content");
+            Assert.That(contents, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_Participant_properties_can_be_accessed()
+        {
+            var siteDirectory = new SiteDirectory(Guid.NewGuid(), null, null);
+
+            var models = (List<EngineeringModelSetup>)siteDirectory.QueryValue("model[0..*]");
+            Assert.That(models, Is.Empty);
+
+            var engineeringModelSetup = new EngineeringModelSetup(Guid.NewGuid(), null, null);
+            siteDirectory.Model.Add(engineeringModelSetup);
+
+            models = (List<EngineeringModelSetup>)siteDirectory.QueryValue("model[0..*]");
+            var model = models.Single();
+            Assert.That(model, Is.EqualTo(siteDirectory.Model.Single()));
+
+            var objects = (List<object>)siteDirectory.QueryValue("model[0..*].participant[0..*]");
+            Assert.That(objects.Count, Is.EqualTo(0));
+            var participants = objects.Cast<Participant>();
+            Assert.That(participants.Count, Is.EqualTo(0));
+
+            objects = (List<object>)siteDirectory.QueryValue("model[0..*].participant[0..*].person");
+            var persons = objects.Cast<Person>();
+            Assert.That(persons.Count, Is.EqualTo(0));
+
+            var participant_1 = new Participant(Guid.NewGuid(), null, null);
+            engineeringModelSetup.Participant.Add(participant_1);
+
+            objects = (List<object>)siteDirectory.QueryValue("model[0..*].participant[0..*].person");
+            persons = objects.Cast<Person>();
+            Assert.That(persons.Count, Is.EqualTo(0));
+
+            objects = (List<object>)siteDirectory.QueryValue("model[0..*].participant[0..*].person.name");
+            var names = objects.Cast<string>();
+            Assert.That(names.Count, Is.EqualTo(0));
+
+            var participant_2 = new Participant(Guid.NewGuid(), null, null);
+            engineeringModelSetup.Participant.Add(participant_2);
+
+            objects = (List<object>)siteDirectory.QueryValue("model[0..*].participant[0..*].person");
+            persons = objects.Cast<Person>();
+            Assert.That(persons.Count, Is.EqualTo(0));
+
+            var person = new Person(Guid.NewGuid(), null, null);
+            participant_1.Person = person;
+
+            objects = (List<object>)siteDirectory.QueryValue("model[0..*].participant[0..*].person");
+            persons = objects.Cast<Person>();
+            Assert.That(persons.Count, Is.EqualTo(1));
+
+            objects = (List<object>)siteDirectory.QueryValue("model[0..*].participant[0..*].person.shortname");
+            var shortnames = objects.Cast<string>();
+            Assert.That(shortnames.Count, Is.EqualTo(0));
+            
+            objects = (List<object>)siteDirectory.QueryValue("model[0..*].participant[0..*].person.name");
+            names = objects.Cast<string>();
+            Assert.That(names.Count, Is.EqualTo(1));
+            Assert.That(names.Single(), Is.EqualTo(" "));
+        }
+    }
+}

--- a/CDP4Common/AutoGenThingPropertyAccessor/ActionItemPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ActionItemPropertyAccessor.cs
@@ -1,0 +1,269 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ActionItemPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ActionItem
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "actionee":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Actionee;
+                    }
+
+                    if (this.Actionee != null)
+                    {
+                        return this.Actionee.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelactionee = new Participant(Guid.Empty, null, null);
+                    return sentinelactionee.QuerySentinelValue(pd.Next.Input, false);
+                case "approvedby":
+                    return base.QueryValue(pd.Input);
+                case "author":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "classification":
+                    return base.QueryValue(pd.Input);
+                case "closeoutdate":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CloseOutDate;
+                case "closeoutstatement":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CloseOutStatement;
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "discussion":
+                    return base.QueryValue(pd.Input);
+                case "duedate":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.DueDate;
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "primaryannotatedthing":
+                    return base.QueryValue(pd.Input);
+                case "relatedthing":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "sourceannotation":
+                    return base.QueryValue(pd.Input);
+                case "status":
+                    return base.QueryValue(pd.Input);
+                case "title":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "actionee":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "approvedby":
+                    return pd.Next == null ? (object) new List<Approval>() : new Approval(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "classification":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationClassificationKind>() : null;
+                case "closeoutdate":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "closeoutstatement":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "discussion":
+                    return pd.Next == null ? (object) new List<EngineeringModelDataDiscussionItem>() : new EngineeringModelDataDiscussionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "duedate":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "primaryannotatedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ModellingThingReference>() : default(ModellingThingReference);
+                case "relatedthing":
+                    return pd.Next == null ? (object) new List<ModellingThingReference>() : new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "sourceannotation":
+                    return pd.Next == null ? (object) new List<ActionItem>() : new ActionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "status":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationStatusKind>() : null;
+                case "title":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ActualFiniteStateListPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ActualFiniteStateListPropertyAccessor.cs
@@ -1,0 +1,421 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ActualFiniteStateListPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ActualFiniteStateList
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "actualstate":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var actualStateUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && actualStateUpperBound == int.MaxValue && !this.ActualState.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ActualFiniteState>();
+                        }
+
+                        var sentinelActualFiniteState = new ActualFiniteState(Guid.Empty, null, null);
+
+                        return sentinelActualFiniteState.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        actualStateUpperBound = this.ActualState.Count - 1;
+                    }
+
+                    if (this.ActualState.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ActualState property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ActualState.Count - 1 < actualStateUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ActualState property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ActualState[pd.Lower.Value];
+                        }
+
+                        return this.ActualState[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var actualStateObjects = new List<ActualFiniteState>();
+
+                        for (var i = pd.Lower.Value; i < actualStateUpperBound + 1; i++)
+                        {
+                            actualStateObjects.Add(this.ActualState[i]);
+                        }
+
+                        return actualStateObjects;
+                    }
+
+                    var actualStateNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < actualStateUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ActualState[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    actualStateNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                actualStateNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return actualStateNextObjects;
+                case "excludeoption":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var excludeOptionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && excludeOptionUpperBound == int.MaxValue && !this.ExcludeOption.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Option>();
+                        }
+
+                        var sentinelOption = new Option(Guid.Empty, null, null);
+
+                        return sentinelOption.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        excludeOptionUpperBound = this.ExcludeOption.Count - 1;
+                    }
+
+                    if (this.ExcludeOption.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ExcludeOption property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ExcludeOption.Count - 1 < excludeOptionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ExcludeOption property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ExcludeOption[pd.Lower.Value];
+                        }
+
+                        return this.ExcludeOption[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var excludeOptionObjects = new List<Option>();
+
+                        for (var i = pd.Lower.Value; i < excludeOptionUpperBound + 1; i++)
+                        {
+                            excludeOptionObjects.Add(this.ExcludeOption[i]);
+                        }
+
+                        return excludeOptionObjects;
+                    }
+
+                    var excludeOptionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < excludeOptionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ExcludeOption[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    excludeOptionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                excludeOptionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return excludeOptionNextObjects;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "possiblefinitestatelist":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var possibleFiniteStateListUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && possibleFiniteStateListUpperBound == int.MaxValue && !this.PossibleFiniteStateList.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<PossibleFiniteStateList>();
+                        }
+
+                        var sentinelPossibleFiniteStateList = new PossibleFiniteStateList(Guid.Empty, null, null);
+
+                        return sentinelPossibleFiniteStateList.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        possibleFiniteStateListUpperBound = this.PossibleFiniteStateList.Count - 1;
+                    }
+
+                    if (this.PossibleFiniteStateList.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for PossibleFiniteStateList property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.PossibleFiniteStateList.Count - 1 < possibleFiniteStateListUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the PossibleFiniteStateList property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.PossibleFiniteStateList[pd.Lower.Value];
+                        }
+
+                        return this.PossibleFiniteStateList[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var possibleFiniteStateListObjects = new List<PossibleFiniteStateList>();
+
+                        for (var i = pd.Lower.Value; i < possibleFiniteStateListUpperBound + 1; i++)
+                        {
+                            possibleFiniteStateListObjects.Add(this.PossibleFiniteStateList[i]);
+                        }
+
+                        return possibleFiniteStateListObjects;
+                    }
+
+                    var possibleFiniteStateListNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < possibleFiniteStateListUpperBound + 1; i++)
+                    {
+                        var queryResult = this.PossibleFiniteStateList[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    possibleFiniteStateListNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                possibleFiniteStateListNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return possibleFiniteStateListNextObjects;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "actualstate":
+                    return pd.Next == null ? (object) new List<ActualFiniteState>() : new ActualFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludeoption":
+                    return pd.Next == null ? (object) new List<Option>() : new Option(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "possiblefinitestatelist":
+                    return pd.Next == null ? (object) new List<PossibleFiniteStateList>() : new PossibleFiniteStateList(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ActualFiniteStatePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ActualFiniteStatePropertyAccessor.cs
@@ -1,0 +1,263 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ActualFiniteStatePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ActualFiniteState
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "kind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Kind;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "possiblestate":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var possibleStateUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && possibleStateUpperBound == int.MaxValue && !this.PossibleState.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<PossibleFiniteState>();
+                        }
+
+                        var sentinelPossibleFiniteState = new PossibleFiniteState(Guid.Empty, null, null);
+
+                        return sentinelPossibleFiniteState.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        possibleStateUpperBound = this.PossibleState.Count - 1;
+                    }
+
+                    if (this.PossibleState.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for PossibleState property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.PossibleState.Count - 1 < possibleStateUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the PossibleState property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.PossibleState[pd.Lower.Value];
+                        }
+
+                        return this.PossibleState[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var possibleStateObjects = new List<PossibleFiniteState>();
+
+                        for (var i = pd.Lower.Value; i < possibleStateUpperBound + 1; i++)
+                        {
+                            possibleStateObjects.Add(this.PossibleState[i]);
+                        }
+
+                        return possibleStateObjects;
+                    }
+
+                    var possibleStateNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < possibleStateUpperBound + 1; i++)
+                    {
+                        var queryResult = this.PossibleState[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    possibleStateNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                possibleStateNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return possibleStateNextObjects;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "kind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ActualFiniteStateKind>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "possiblestate":
+                    return pd.Next == null ? (object) new List<PossibleFiniteState>() : new PossibleFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/AliasPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/AliasPropertyAccessor.cs
@@ -1,0 +1,157 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="AliasPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.CommonData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Alias
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Content;
+                case "issynonym":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsSynonym;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.LanguageCode;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "issynonym":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/AndExpressionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/AndExpressionPropertyAccessor.cs
@@ -1,0 +1,221 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="AndExpressionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class AndExpression
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "term":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var termUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && termUpperBound == int.MaxValue && !this.Term.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<BooleanExpression>();
+                        }
+
+                        var sentinelBooleanExpression = new AndExpression(Guid.Empty, null, null);
+
+                        return sentinelBooleanExpression.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        termUpperBound = this.Term.Count - 1;
+                    }
+
+                    if (this.Term.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Term property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Term.Count - 1 < termUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Term property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Term[pd.Lower.Value];
+                        }
+
+                        return this.Term[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var termObjects = new List<BooleanExpression>();
+
+                        for (var i = pd.Lower.Value; i < termUpperBound + 1; i++)
+                        {
+                            termObjects.Add(this.Term[i]);
+                        }
+
+                        return termObjects;
+                    }
+
+                    var termNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < termUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Term[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    termNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                termNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return termNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "term":
+                    return pd.Next == null ? (object) new List<AndExpression>() : new AndExpression(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ApprovalPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ApprovalPropertyAccessor.cs
@@ -1,0 +1,208 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ApprovalPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Approval
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Author;
+                    }
+
+                    if (this.Author != null)
+                    {
+                        return this.Author.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelauthor = new Participant(Guid.Empty, null, null);
+                    return sentinelauthor.QuerySentinelValue(pd.Next.Input, false);
+                case "classification":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Classification;
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "classification":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationApprovalKind>() : null;
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ArrayParameterTypePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ArrayParameterTypePropertyAccessor.cs
@@ -1,0 +1,249 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ArrayParameterTypePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ArrayParameterType
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "component":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "dimension":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for the Dimension property, the lower and upper bound must be specified");
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Dimension.Any())
+                    {
+                        return new List<int>();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Dimension.Count - 1;
+                    }
+
+                    if (this.Dimension.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Dimension property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Dimension.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Dimension property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Dimension[pd.Lower.Value];
+                    }
+
+                    var dimensionobjects = new List<int>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        dimensionobjects.Add(this.Dimension[i]);
+                    }
+
+                    return dimensionobjects;
+                case "hassinglecomponenttype":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.HasSingleComponentType;
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "isfinalized":
+                    return base.QueryValue(pd.Input);
+                case "istensor":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsTensor;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "rank":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Rank;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "component":
+                    return pd.Next == null ? (object) new List<ParameterTypeComponent>() : new ParameterTypeComponent(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "dimension":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<int>() : null;
+                case "hassinglecomponenttype":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "isfinalized":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "istensor":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberofvalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "rank":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "symbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/BinaryNotePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/BinaryNotePropertyAccessor.cs
@@ -1,0 +1,199 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BinaryNotePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class BinaryNote
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "caption":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Caption;
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "filetype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.FileType;
+                    }
+
+                    if (this.FileType != null)
+                    {
+                        return this.FileType.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelfiletype = new FileType(Guid.Empty, null, null);
+                    return sentinelfiletype.QuerySentinelValue(pd.Next.Input, false);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "caption":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "filetype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new FileType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<FileType>() : default(FileType);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/BinaryRelationshipPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/BinaryRelationshipPropertyAccessor.cs
@@ -1,0 +1,211 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BinaryRelationshipPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class BinaryRelationship
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "parametervalue":
+                    return base.QueryValue(pd.Input);
+                case "source":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Source;
+                    }
+
+                    if (this.Source != null)
+                    {
+                        return this.Source.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelsource = new ActualFiniteState(Guid.Empty, null, null);
+                    return sentinelsource.QuerySentinelValue(pd.Next.Input, false);
+                case "target":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Target;
+                    }
+
+                    if (this.Target != null)
+                    {
+                        return this.Target.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineltarget = new ActualFiniteState(Guid.Empty, null, null);
+                    return sentineltarget.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "parametervalue":
+                    return pd.Next == null ? (object) new List<RelationshipParameterValue>() : new RelationshipParameterValue(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "source":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ActualFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Thing>() : default(Thing);
+                case "target":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ActualFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Thing>() : default(Thing);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/BinaryRelationshipRulePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/BinaryRelationshipRulePropertyAccessor.cs
@@ -1,0 +1,250 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BinaryRelationshipRulePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class BinaryRelationshipRule
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "forwardrelationshipname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ForwardRelationshipName;
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "inverserelationshipname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.InverseRelationshipName;
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "relationshipcategory":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.RelationshipCategory;
+                    }
+
+                    if (this.RelationshipCategory != null)
+                    {
+                        return this.RelationshipCategory.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelrelationshipcategory = new Category(Guid.Empty, null, null);
+                    return sentinelrelationshipcategory.QuerySentinelValue(pd.Next.Input, false);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "sourcecategory":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.SourceCategory;
+                    }
+
+                    if (this.SourceCategory != null)
+                    {
+                        return this.SourceCategory.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelsourcecategory = new Category(Guid.Empty, null, null);
+                    return sentinelsourcecategory.QuerySentinelValue(pd.Next.Input, false);
+                case "targetcategory":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.TargetCategory;
+                    }
+
+                    if (this.TargetCategory != null)
+                    {
+                        return this.TargetCategory.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineltargetcategory = new Category(Guid.Empty, null, null);
+                    return sentineltargetcategory.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "forwardrelationshipname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "inverserelationshipname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "relationshipcategory":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Category>() : default(Category);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "sourcecategory":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Category>() : default(Category);
+                case "targetcategory":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Category>() : default(Category);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/BookPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/BookPropertyAccessor.cs
@@ -1,0 +1,345 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BookPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Book
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "section":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var sectionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && sectionUpperBound == int.MaxValue && !this.Section.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Section>();
+                        }
+
+                        var sentinelSection = new Section(Guid.Empty, null, null);
+
+                        return sentinelSection.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        sectionUpperBound = this.Section.Count - 1;
+                    }
+
+                    if (this.Section.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Section property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Section.Count - 1 < sectionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Section property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Section[pd.Lower.Value];
+                        }
+
+                        return this.Section[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var sectionObjects = new List<Section>();
+
+                        for (var i = pd.Lower.Value; i < sectionUpperBound + 1; i++)
+                        {
+                            sectionObjects.Add(this.Section[i]);
+                        }
+
+                        return sectionObjects;
+                    }
+
+                    var sectionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < sectionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Section[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    sectionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                sectionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return sectionNextObjects;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "section":
+                    return pd.Next == null ? (object) new List<Section>() : new Section(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/BooleanExpressionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/BooleanExpressionPropertyAccessor.cs
@@ -1,0 +1,92 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BooleanExpressionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class BooleanExpression
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/BooleanParameterTypePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/BooleanParameterTypePropertyAccessor.cs
@@ -1,0 +1,180 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BooleanParameterTypePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class BooleanParameterType
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberofvalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "symbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/BoundsPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/BoundsPropertyAccessor.cs
@@ -1,0 +1,168 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BoundsPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.DiagramData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Bounds
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "height":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Height;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "width":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Width;
+                case "x":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.X;
+                case "y":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Y;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "height":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "width":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                case "x":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                case "y":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/BuiltInRuleVerificationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/BuiltInRuleVerificationPropertyAccessor.cs
@@ -1,0 +1,174 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="BuiltInRuleVerificationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class BuiltInRuleVerification
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "executedon":
+                    return base.QueryValue(pd.Input);
+                case "isactive":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "status":
+                    return base.QueryValue(pd.Input);
+                case "violation":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "executedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "isactive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "status":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<RuleVerificationStatusKind>() : null;
+                case "violation":
+                    return pd.Next == null ? (object) new List<RuleViolation>() : new RuleViolation(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/CategoryPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/CategoryPropertyAccessor.cs
@@ -1,0 +1,309 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="CategoryPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Category
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isabstract":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsAbstract;
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "permissibleclass":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new ArgumentException("Invalid Multiplicity for the PermissibleClass property, the lower and upper bound must be specified");
+                    }
+
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for the PermissibleClass property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.PermissibleClass.Any())
+                    {
+                        return new List<ClassKind>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.PermissibleClass.Any())
+                    {
+                        return this.PermissibleClass.ToList();
+                    }
+
+                    var permissibleClassUpperBound = pd.Upper.Value;
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        permissibleClassUpperBound = this.PermissibleClass.Count - 1;
+                    }
+
+                    if (this.PermissibleClass.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the PermissibleClass property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.PermissibleClass.Count - 1 < permissibleClassUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the PermissibleClass property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == permissibleClassUpperBound)
+                    {
+                        return this.PermissibleClass[pd.Lower.Value];
+                    }
+
+                    var permissibleClassObjects = new List<ClassKind>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        permissibleClassObjects.Add(this.PermissibleClass[i]);
+                    }
+
+                    return permissibleClassObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "supercategory":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var superCategoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && superCategoryUpperBound == int.MaxValue && !this.SuperCategory.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        superCategoryUpperBound = this.SuperCategory.Count - 1;
+                    }
+
+                    if (this.SuperCategory.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for SuperCategory property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.SuperCategory.Count - 1 < superCategoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the SuperCategory property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.SuperCategory[pd.Lower.Value];
+                        }
+
+                        return this.SuperCategory[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var superCategoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < superCategoryUpperBound + 1; i++)
+                        {
+                            superCategoryObjects.Add(this.SuperCategory[i]);
+                        }
+
+                        return superCategoryObjects;
+                    }
+
+                    var superCategoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < superCategoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.SuperCategory[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    superCategoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                superCategoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return superCategoryNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isabstract":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "permissibleclass":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<ClassKind>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "supercategory":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ChangeProposalPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ChangeProposalPropertyAccessor.cs
@@ -1,0 +1,251 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ChangeProposalPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ChangeProposal
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "approvedby":
+                    return base.QueryValue(pd.Input);
+                case "author":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "changerequest":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ChangeRequest;
+                    }
+
+                    if (this.ChangeRequest != null)
+                    {
+                        return this.ChangeRequest.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelchangerequest = new ChangeRequest(Guid.Empty, null, null);
+                    return sentinelchangerequest.QuerySentinelValue(pd.Next.Input, false);
+                case "classification":
+                    return base.QueryValue(pd.Input);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "discussion":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "primaryannotatedthing":
+                    return base.QueryValue(pd.Input);
+                case "relatedthing":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "sourceannotation":
+                    return base.QueryValue(pd.Input);
+                case "status":
+                    return base.QueryValue(pd.Input);
+                case "title":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "approvedby":
+                    return pd.Next == null ? (object) new List<Approval>() : new Approval(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "changerequest":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ChangeRequest(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ChangeRequest>() : default(ChangeRequest);
+                case "classification":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationClassificationKind>() : null;
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "discussion":
+                    return pd.Next == null ? (object) new List<EngineeringModelDataDiscussionItem>() : new EngineeringModelDataDiscussionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "primaryannotatedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ModellingThingReference>() : default(ModellingThingReference);
+                case "relatedthing":
+                    return pd.Next == null ? (object) new List<ModellingThingReference>() : new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "sourceannotation":
+                    return pd.Next == null ? (object) new List<ActionItem>() : new ActionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "status":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationStatusKind>() : null;
+                case "title":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ChangeRequestPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ChangeRequestPropertyAccessor.cs
@@ -1,0 +1,227 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ChangeRequestPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ChangeRequest
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "approvedby":
+                    return base.QueryValue(pd.Input);
+                case "author":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "classification":
+                    return base.QueryValue(pd.Input);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "discussion":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "primaryannotatedthing":
+                    return base.QueryValue(pd.Input);
+                case "relatedthing":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "sourceannotation":
+                    return base.QueryValue(pd.Input);
+                case "status":
+                    return base.QueryValue(pd.Input);
+                case "title":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "approvedby":
+                    return pd.Next == null ? (object) new List<Approval>() : new Approval(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "classification":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationClassificationKind>() : null;
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "discussion":
+                    return pd.Next == null ? (object) new List<EngineeringModelDataDiscussionItem>() : new EngineeringModelDataDiscussionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "primaryannotatedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ModellingThingReference>() : default(ModellingThingReference);
+                case "relatedthing":
+                    return pd.Next == null ? (object) new List<ModellingThingReference>() : new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "sourceannotation":
+                    return pd.Next == null ? (object) new List<ActionItem>() : new ActionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "status":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationStatusKind>() : null;
+                case "title":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/CitationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/CitationPropertyAccessor.cs
@@ -1,0 +1,187 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="CitationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.CommonData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Citation
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "isadaptation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsAdaptation;
+                case "location":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Location;
+                case "remark":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Remark;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                case "source":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Source;
+                    }
+
+                    if (this.Source != null)
+                    {
+                        return this.Source.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelsource = new ReferenceSource(Guid.Empty, null, null);
+                    return sentinelsource.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "isadaptation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "location":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "remark":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "source":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ReferenceSource(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ReferenceSource>() : default(ReferenceSource);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ColorPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ColorPropertyAccessor.cs
@@ -1,0 +1,162 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ColorPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.DiagramData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Color
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "blue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Blue;
+                case "green":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Green;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "red":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Red;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "blue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "green":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "red":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/CommonFileStorePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/CommonFileStorePropertyAccessor.cs
@@ -1,0 +1,168 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="CommonFileStorePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class CommonFileStore
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "file":
+                    return base.QueryValue(pd.Input);
+                case "folder":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "file":
+                    return pd.Next == null ? (object) new List<File>() : new File(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "folder":
+                    return pd.Next == null ? (object) new List<Folder>() : new Folder(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/CompoundParameterTypePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/CompoundParameterTypePropertyAccessor.cs
@@ -1,0 +1,268 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="CompoundParameterTypePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class CompoundParameterType
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "component":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var componentUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && componentUpperBound == int.MaxValue && !this.Component.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ParameterTypeComponent>();
+                        }
+
+                        var sentinelParameterTypeComponent = new ParameterTypeComponent(Guid.Empty, null, null);
+
+                        return sentinelParameterTypeComponent.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        componentUpperBound = this.Component.Count - 1;
+                    }
+
+                    if (this.Component.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Component property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Component.Count - 1 < componentUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Component property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Component[pd.Lower.Value];
+                        }
+
+                        return this.Component[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var componentObjects = new List<ParameterTypeComponent>();
+
+                        for (var i = pd.Lower.Value; i < componentUpperBound + 1; i++)
+                        {
+                            componentObjects.Add(this.Component[i]);
+                        }
+
+                        return componentObjects;
+                    }
+
+                    var componentNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < componentUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Component[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    componentNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                componentNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return componentNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "isfinalized":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsFinalized;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "component":
+                    return pd.Next == null ? (object) new List<ParameterTypeComponent>() : new ParameterTypeComponent(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "isfinalized":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberofvalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "symbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ConstantPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ConstantPropertyAccessor.cs
@@ -1,0 +1,349 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ConstantPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Constant
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ParameterType;
+                    }
+
+                    if (this.ParameterType != null)
+                    {
+                        return this.ParameterType.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelparametertype = new CompoundParameterType(Guid.Empty, null, null);
+                    return sentinelparametertype.QuerySentinelValue(pd.Next.Input, false);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Scale;
+                    }
+
+                    if (this.Scale != null)
+                    {
+                        return this.Scale.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelscale = new IntervalScale(Guid.Empty, null, null);
+                    return sentinelscale.QuerySentinelValue(pd.Next.Input, false);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "value":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for Value property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for Value property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Value.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.Value.Any())
+                    {
+                        return this.Value.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Value.Count - 1;
+                    }
+
+                    if (this.Value.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Value property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Value.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Value property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Value[pd.Lower.Value];
+                    }
+
+                    var valueObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        valueObjects.Add(this.Value[i]);
+                    }
+
+                    return valueObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterType>() : default(ParameterType);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "value":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ContractChangeNoticePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ContractChangeNoticePropertyAccessor.cs
@@ -1,0 +1,251 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ContractChangeNoticePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ContractChangeNotice
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "approvedby":
+                    return base.QueryValue(pd.Input);
+                case "author":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "changeproposal":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ChangeProposal;
+                    }
+
+                    if (this.ChangeProposal != null)
+                    {
+                        return this.ChangeProposal.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelchangeproposal = new ChangeProposal(Guid.Empty, null, null);
+                    return sentinelchangeproposal.QuerySentinelValue(pd.Next.Input, false);
+                case "classification":
+                    return base.QueryValue(pd.Input);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "discussion":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "primaryannotatedthing":
+                    return base.QueryValue(pd.Input);
+                case "relatedthing":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "sourceannotation":
+                    return base.QueryValue(pd.Input);
+                case "status":
+                    return base.QueryValue(pd.Input);
+                case "title":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "approvedby":
+                    return pd.Next == null ? (object) new List<Approval>() : new Approval(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "changeproposal":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ChangeProposal(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ChangeProposal>() : default(ChangeProposal);
+                case "classification":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationClassificationKind>() : null;
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "discussion":
+                    return pd.Next == null ? (object) new List<EngineeringModelDataDiscussionItem>() : new EngineeringModelDataDiscussionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "primaryannotatedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ModellingThingReference>() : default(ModellingThingReference);
+                case "relatedthing":
+                    return pd.Next == null ? (object) new List<ModellingThingReference>() : new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "sourceannotation":
+                    return pd.Next == null ? (object) new List<ActionItem>() : new ActionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "status":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationStatusKind>() : null;
+                case "title":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ContractDeviationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ContractDeviationPropertyAccessor.cs
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ContractDeviationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ContractDeviation
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "approvedby":
+                    return base.QueryValue(pd.Input);
+                case "author":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "classification":
+                    return base.QueryValue(pd.Input);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "discussion":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "primaryannotatedthing":
+                    return base.QueryValue(pd.Input);
+                case "relatedthing":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "sourceannotation":
+                    return base.QueryValue(pd.Input);
+                case "status":
+                    return base.QueryValue(pd.Input);
+                case "title":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ConversionBasedUnitPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ConversionBasedUnitPropertyAccessor.cs
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ConversionBasedUnitPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ConversionBasedUnit
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "conversionfactor":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ConversionFactor;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "referenceunit":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ReferenceUnit;
+                    }
+
+                    if (this.ReferenceUnit != null)
+                    {
+                        return this.ReferenceUnit.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelreferenceunit = new DerivedUnit(Guid.Empty, null, null);
+                    return sentinelreferenceunit.QuerySentinelValue(pd.Next.Input, false);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/CyclicRatioScalePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/CyclicRatioScalePropertyAccessor.cs
@@ -1,0 +1,226 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="CyclicRatioScalePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class CyclicRatioScale
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "ismaximuminclusive":
+                    return base.QueryValue(pd.Input);
+                case "isminimuminclusive":
+                    return base.QueryValue(pd.Input);
+                case "mappingtoreferencescale":
+                    return base.QueryValue(pd.Input);
+                case "maximumpermissiblevalue":
+                    return base.QueryValue(pd.Input);
+                case "minimumpermissiblevalue":
+                    return base.QueryValue(pd.Input);
+                case "modulus":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Modulus;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "negativevalueconnotation":
+                    return base.QueryValue(pd.Input);
+                case "numberset":
+                    return base.QueryValue(pd.Input);
+                case "positivevalueconnotation":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "unit":
+                    return base.QueryValue(pd.Input);
+                case "valuedefinition":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "ismaximuminclusive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "isminimuminclusive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "mappingtoreferencescale":
+                    return pd.Next == null ? (object) new List<MappingToReferenceScale>() : new MappingToReferenceScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "maximumpermissiblevalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "minimumpermissiblevalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "modulus":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "negativevalueconnotation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberset":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<NumberSetKind>() : null;
+                case "positivevalueconnotation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "unit":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DerivedUnit(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementUnit>() : default(MeasurementUnit);
+                case "valuedefinition":
+                    return pd.Next == null ? (object) new List<ScaleValueDefinition>() : new ScaleValueDefinition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DateParameterTypePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DateParameterTypePropertyAccessor.cs
@@ -1,0 +1,180 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DateParameterTypePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DateParameterType
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberofvalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "symbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DateTimeParameterTypePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DateTimeParameterTypePropertyAccessor.cs
@@ -1,0 +1,180 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DateTimeParameterTypePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DateTimeParameterType
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberofvalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "symbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DecompositionRulePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DecompositionRulePropertyAccessor.cs
@@ -1,0 +1,284 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DecompositionRulePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DecompositionRule
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "containedcategory":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var containedCategoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && containedCategoryUpperBound == int.MaxValue && !this.ContainedCategory.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        containedCategoryUpperBound = this.ContainedCategory.Count - 1;
+                    }
+
+                    if (this.ContainedCategory.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ContainedCategory property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ContainedCategory.Count - 1 < containedCategoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ContainedCategory property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ContainedCategory[pd.Lower.Value];
+                        }
+
+                        return this.ContainedCategory[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var containedCategoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < containedCategoryUpperBound + 1; i++)
+                        {
+                            containedCategoryObjects.Add(this.ContainedCategory[i]);
+                        }
+
+                        return containedCategoryObjects;
+                    }
+
+                    var containedCategoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < containedCategoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ContainedCategory[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    containedCategoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                containedCategoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return containedCategoryNextObjects;
+                case "containingcategory":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ContainingCategory;
+                    }
+
+                    if (this.ContainingCategory != null)
+                    {
+                        return this.ContainingCategory.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelcontainingcategory = new Category(Guid.Empty, null, null);
+                    return sentinelcontainingcategory.QuerySentinelValue(pd.Next.Input, false);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "maxcontained":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.MaxContained;
+                case "mincontained":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.MinContained;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "containedcategory":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "containingcategory":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Category>() : default(Category);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "maxcontained":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "mincontained":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DefinedThingPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DefinedThingPropertyAccessor.cs
@@ -1,0 +1,338 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DefinedThingPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.CommonData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DefinedThing
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var aliasUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && aliasUpperBound == int.MaxValue && !this.Alias.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Alias>();
+                        }
+
+                        var sentinelAlias = new Alias(Guid.Empty, null, null);
+
+                        return sentinelAlias.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        aliasUpperBound = this.Alias.Count - 1;
+                    }
+
+                    if (this.Alias.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Alias property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Alias.Count - 1 < aliasUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Alias property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Alias[pd.Lower.Value];
+                        }
+
+                        return this.Alias[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var aliasObjects = new List<Alias>();
+
+                        for (var i = pd.Lower.Value; i < aliasUpperBound + 1; i++)
+                        {
+                            aliasObjects.Add(this.Alias[i]);
+                        }
+
+                        return aliasObjects;
+                    }
+
+                    var aliasNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < aliasUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Alias[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    aliasNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                aliasNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return aliasNextObjects;
+                case "definition":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var definitionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && definitionUpperBound == int.MaxValue && !this.Definition.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Definition>();
+                        }
+
+                        var sentinelDefinition = new Definition(Guid.Empty, null, null);
+
+                        return sentinelDefinition.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        definitionUpperBound = this.Definition.Count - 1;
+                    }
+
+                    if (this.Definition.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Definition property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Definition.Count - 1 < definitionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Definition property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Definition[pd.Lower.Value];
+                        }
+
+                        return this.Definition[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var definitionObjects = new List<Definition>();
+
+                        for (var i = pd.Lower.Value; i < definitionUpperBound + 1; i++)
+                        {
+                            definitionObjects.Add(this.Definition[i]);
+                        }
+
+                        return definitionObjects;
+                    }
+
+                    var definitionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < definitionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Definition[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    definitionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                definitionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return definitionNextObjects;
+                case "hyperlink":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var hyperLinkUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && hyperLinkUpperBound == int.MaxValue && !this.HyperLink.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<HyperLink>();
+                        }
+
+                        var sentinelHyperLink = new HyperLink(Guid.Empty, null, null);
+
+                        return sentinelHyperLink.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        hyperLinkUpperBound = this.HyperLink.Count - 1;
+                    }
+
+                    if (this.HyperLink.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for HyperLink property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.HyperLink.Count - 1 < hyperLinkUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the HyperLink property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.HyperLink[pd.Lower.Value];
+                        }
+
+                        return this.HyperLink[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var hyperLinkObjects = new List<HyperLink>();
+
+                        for (var i = pd.Lower.Value; i < hyperLinkUpperBound + 1; i++)
+                        {
+                            hyperLinkObjects.Add(this.HyperLink[i]);
+                        }
+
+                        return hyperLinkObjects;
+                    }
+
+                    var hyperLinkNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < hyperLinkUpperBound + 1; i++)
+                    {
+                        var queryResult = this.HyperLink[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    hyperLinkNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                hyperLinkNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return hyperLinkNextObjects;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DefinitionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DefinitionPropertyAccessor.cs
@@ -1,0 +1,317 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DefinitionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.CommonData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Definition
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "citation":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var citationUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && citationUpperBound == int.MaxValue && !this.Citation.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Citation>();
+                        }
+
+                        var sentinelCitation = new Citation(Guid.Empty, null, null);
+
+                        return sentinelCitation.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        citationUpperBound = this.Citation.Count - 1;
+                    }
+
+                    if (this.Citation.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Citation property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Citation.Count - 1 < citationUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Citation property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Citation[pd.Lower.Value];
+                        }
+
+                        return this.Citation[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var citationObjects = new List<Citation>();
+
+                        for (var i = pd.Lower.Value; i < citationUpperBound + 1; i++)
+                        {
+                            citationObjects.Add(this.Citation[i]);
+                        }
+
+                        return citationObjects;
+                    }
+
+                    var citationNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < citationUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Citation[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    citationNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                citationNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return citationNextObjects;
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Content;
+                case "example":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for the Example property, the lower and upper bound must be specified");
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Example.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Example.Count - 1;
+                    }
+
+                    if (this.Example.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Example property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Example.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Example property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Example[pd.Lower.Value];
+                    }
+
+                    var exampleobjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        exampleobjects.Add(this.Example[i]);
+                    }
+
+                    return exampleobjects;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.LanguageCode;
+                case "note":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for the Note property, the lower and upper bound must be specified");
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Note.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Note.Count - 1;
+                    }
+
+                    if (this.Note.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Note property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Note.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Note property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Note[pd.Lower.Value];
+                    }
+
+                    var noteobjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        noteobjects.Add(this.Note[i]);
+                    }
+
+                    return noteobjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "citation":
+                    return pd.Next == null ? (object) new List<Citation>() : new Citation(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "example":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "note":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DependentParameterTypeAssignmentPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DependentParameterTypeAssignmentPropertyAccessor.cs
@@ -1,0 +1,187 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DependentParameterTypeAssignmentPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DependentParameterTypeAssignment
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "measurementscale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.MeasurementScale;
+                    }
+
+                    if (this.MeasurementScale != null)
+                    {
+                        return this.MeasurementScale.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelmeasurementscale = new IntervalScale(Guid.Empty, null, null);
+                    return sentinelmeasurementscale.QuerySentinelValue(pd.Next.Input, false);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ParameterType;
+                    }
+
+                    if (this.ParameterType != null)
+                    {
+                        return this.ParameterType.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelparametertype = new CompoundParameterType(Guid.Empty, null, null);
+                    return sentinelparametertype.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "measurementscale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterType>() : default(ParameterType);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DerivedQuantityKindPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DerivedQuantityKindPropertyAccessor.cs
@@ -1,0 +1,296 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DerivedQuantityKindPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DerivedQuantityKind
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "allpossiblescale":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "defaultscale":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "possiblescale":
+                    return base.QueryValue(pd.Input);
+                case "quantitydimensionexponent":
+                    return base.QueryValue(pd.Input);
+                case "quantitydimensionexpression":
+                    return base.QueryValue(pd.Input);
+                case "quantitydimensionsymbol":
+                    return base.QueryValue(pd.Input);
+                case "quantitykindfactor":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var quantityKindFactorUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && quantityKindFactorUpperBound == int.MaxValue && !this.QuantityKindFactor.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<QuantityKindFactor>();
+                        }
+
+                        var sentinelQuantityKindFactor = new QuantityKindFactor(Guid.Empty, null, null);
+
+                        return sentinelQuantityKindFactor.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        quantityKindFactorUpperBound = this.QuantityKindFactor.Count - 1;
+                    }
+
+                    if (this.QuantityKindFactor.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for QuantityKindFactor property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.QuantityKindFactor.Count - 1 < quantityKindFactorUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the QuantityKindFactor property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.QuantityKindFactor[pd.Lower.Value];
+                        }
+
+                        return this.QuantityKindFactor[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var quantityKindFactorObjects = new List<QuantityKindFactor>();
+
+                        for (var i = pd.Lower.Value; i < quantityKindFactorUpperBound + 1; i++)
+                        {
+                            quantityKindFactorObjects.Add(this.QuantityKindFactor[i]);
+                        }
+
+                        return quantityKindFactorObjects;
+                    }
+
+                    var quantityKindFactorNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < quantityKindFactorUpperBound + 1; i++)
+                    {
+                        var queryResult = this.QuantityKindFactor[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    quantityKindFactorNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                quantityKindFactorNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return quantityKindFactorNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "allpossiblescale":
+                    return pd.Next == null ? (object) new List<IntervalScale>() : new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "defaultscale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberofvalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "possiblescale":
+                    return pd.Next == null ? (object) new List<IntervalScale>() : new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "quantitydimensionexponent":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "quantitydimensionexpression":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "quantitydimensionsymbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "quantitykindfactor":
+                    return pd.Next == null ? (object) new List<QuantityKindFactor>() : new QuantityKindFactor(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "symbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DerivedUnitPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DerivedUnitPropertyAccessor.cs
@@ -1,0 +1,248 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DerivedUnitPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DerivedUnit
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "unitfactor":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var unitFactorUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && unitFactorUpperBound == int.MaxValue && !this.UnitFactor.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<UnitFactor>();
+                        }
+
+                        var sentinelUnitFactor = new UnitFactor(Guid.Empty, null, null);
+
+                        return sentinelUnitFactor.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        unitFactorUpperBound = this.UnitFactor.Count - 1;
+                    }
+
+                    if (this.UnitFactor.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for UnitFactor property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.UnitFactor.Count - 1 < unitFactorUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the UnitFactor property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.UnitFactor[pd.Lower.Value];
+                        }
+
+                        return this.UnitFactor[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var unitFactorObjects = new List<UnitFactor>();
+
+                        for (var i = pd.Lower.Value; i < unitFactorUpperBound + 1; i++)
+                        {
+                            unitFactorObjects.Add(this.UnitFactor[i]);
+                        }
+
+                        return unitFactorObjects;
+                    }
+
+                    var unitFactorNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < unitFactorUpperBound + 1; i++)
+                    {
+                        var queryResult = this.UnitFactor[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    unitFactorNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                unitFactorNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return unitFactorNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "unitfactor":
+                    return pd.Next == null ? (object) new List<UnitFactor>() : new UnitFactor(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DiagramCanvasPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DiagramCanvasPropertyAccessor.cs
@@ -1,0 +1,158 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DiagramCanvasPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.DiagramData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DiagramCanvas
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "bounds":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "diagramelement":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "bounds":
+                    return pd.Next == null ? (object) new List<Bounds>() : new Bounds(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "diagramelement":
+                    return pd.Next == null ? (object) new List<DiagramEdge>() : new DiagramEdge(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DiagramEdgePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DiagramEdgePropertyAccessor.cs
@@ -1,0 +1,308 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DiagramEdgePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.DiagramData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DiagramEdge
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "bounds":
+                    return base.QueryValue(pd.Input);
+                case "depictedthing":
+                    return base.QueryValue(pd.Input);
+                case "diagramelement":
+                    return base.QueryValue(pd.Input);
+                case "localstyle":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "point":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var pointUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && pointUpperBound == int.MaxValue && !this.Point.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Point>();
+                        }
+
+                        var sentinelPoint = new Point(Guid.Empty, null, null);
+
+                        return sentinelPoint.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pointUpperBound = this.Point.Count - 1;
+                    }
+
+                    if (this.Point.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Point property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Point.Count - 1 < pointUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Point property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Point[pd.Lower.Value];
+                        }
+
+                        return this.Point[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var pointObjects = new List<Point>();
+
+                        for (var i = pd.Lower.Value; i < pointUpperBound + 1; i++)
+                        {
+                            pointObjects.Add(this.Point[i]);
+                        }
+
+                        return pointObjects;
+                    }
+
+                    var pointNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < pointUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Point[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    pointNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                pointNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return pointNextObjects;
+                case "sharedstyle":
+                    return base.QueryValue(pd.Input);
+                case "source":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Source;
+                    }
+
+                    if (this.Source != null)
+                    {
+                        return this.Source.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelsource = new DiagramEdge(Guid.Empty, null, null);
+                    return sentinelsource.QuerySentinelValue(pd.Next.Input, false);
+                case "target":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Target;
+                    }
+
+                    if (this.Target != null)
+                    {
+                        return this.Target.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineltarget = new DiagramEdge(Guid.Empty, null, null);
+                    return sentineltarget.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "bounds":
+                    return pd.Next == null ? (object) new List<Bounds>() : new Bounds(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "depictedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ActualFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Thing>() : default(Thing);
+                case "diagramelement":
+                    return pd.Next == null ? (object) new List<DiagramEdge>() : new DiagramEdge(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "localstyle":
+                    return pd.Next == null ? (object) new List<OwnedStyle>() : new OwnedStyle(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "point":
+                    return pd.Next == null ? (object) new List<Point>() : new Point(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "sharedstyle":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new SharedStyle(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<SharedStyle>() : default(SharedStyle);
+                case "source":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DiagramEdge(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DiagramElementThing>() : default(DiagramElementThing);
+                case "target":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DiagramEdge(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DiagramElementThing>() : default(DiagramElementThing);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DiagramElementContainerPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DiagramElementContainerPropertyAccessor.cs
@@ -1,0 +1,254 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DiagramElementContainerPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.DiagramData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DiagramElementContainer
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "bounds":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var boundsUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && boundsUpperBound == int.MaxValue && !this.Bounds.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Bounds>();
+                        }
+
+                        var sentinelBounds = new Bounds(Guid.Empty, null, null);
+
+                        return sentinelBounds.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        boundsUpperBound = this.Bounds.Count - 1;
+                    }
+
+                    if (this.Bounds.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Bounds property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Bounds.Count - 1 < boundsUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Bounds property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Bounds[pd.Lower.Value];
+                        }
+
+                        return this.Bounds[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var boundsObjects = new List<Bounds>();
+
+                        for (var i = pd.Lower.Value; i < boundsUpperBound + 1; i++)
+                        {
+                            boundsObjects.Add(this.Bounds[i]);
+                        }
+
+                        return boundsObjects;
+                    }
+
+                    var boundsNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < boundsUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Bounds[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    boundsNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                boundsNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return boundsNextObjects;
+                case "diagramelement":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var diagramElementUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && diagramElementUpperBound == int.MaxValue && !this.DiagramElement.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<DiagramElementThing>();
+                        }
+
+                        var sentinelDiagramElementThing = new DiagramEdge(Guid.Empty, null, null);
+
+                        return sentinelDiagramElementThing.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        diagramElementUpperBound = this.DiagramElement.Count - 1;
+                    }
+
+                    if (this.DiagramElement.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for DiagramElement property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.DiagramElement.Count - 1 < diagramElementUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the DiagramElement property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.DiagramElement[pd.Lower.Value];
+                        }
+
+                        return this.DiagramElement[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var diagramElementObjects = new List<DiagramElementThing>();
+
+                        for (var i = pd.Lower.Value; i < diagramElementUpperBound + 1; i++)
+                        {
+                            diagramElementObjects.Add(this.DiagramElement[i]);
+                        }
+
+                        return diagramElementObjects;
+                    }
+
+                    var diagramElementNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < diagramElementUpperBound + 1; i++)
+                    {
+                        var queryResult = this.DiagramElement[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    diagramElementNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                diagramElementNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return diagramElementNextObjects;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DiagramElementThingPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DiagramElementThingPropertyAccessor.cs
@@ -1,0 +1,208 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DiagramElementThingPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.DiagramData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DiagramElementThing
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "bounds":
+                    return base.QueryValue(pd.Input);
+                case "depictedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.DepictedThing;
+                    }
+
+                    if (this.DepictedThing != null)
+                    {
+                        return this.DepictedThing.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineldepictedthing = new ActualFiniteState(Guid.Empty, null, null);
+                    return sentineldepictedthing.QuerySentinelValue(pd.Next.Input, false);
+                case "diagramelement":
+                    return base.QueryValue(pd.Input);
+                case "localstyle":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var localStyleUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && localStyleUpperBound == int.MaxValue && !this.LocalStyle.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<OwnedStyle>();
+                        }
+
+                        var sentinelOwnedStyle = new OwnedStyle(Guid.Empty, null, null);
+
+                        return sentinelOwnedStyle.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        localStyleUpperBound = this.LocalStyle.Count - 1;
+                    }
+
+                    if (this.LocalStyle.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for LocalStyle property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.LocalStyle.Count - 1 < localStyleUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the LocalStyle property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.LocalStyle[pd.Lower.Value];
+                        }
+
+                        return this.LocalStyle[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var localStyleObjects = new List<OwnedStyle>();
+
+                        for (var i = pd.Lower.Value; i < localStyleUpperBound + 1; i++)
+                        {
+                            localStyleObjects.Add(this.LocalStyle[i]);
+                        }
+
+                        return localStyleObjects;
+                    }
+
+                    var localStyleNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < localStyleUpperBound + 1; i++)
+                    {
+                        var queryResult = this.LocalStyle[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    localStyleNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                localStyleNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return localStyleNextObjects;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "sharedstyle":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.SharedStyle;
+                    }
+
+                    if (this.SharedStyle != null)
+                    {
+                        return this.SharedStyle.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelsharedstyle = new SharedStyle(Guid.Empty, null, null);
+                    return sentinelsharedstyle.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DiagramObjectPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DiagramObjectPropertyAccessor.cs
@@ -1,0 +1,190 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DiagramObjectPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.DiagramData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DiagramObject
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "bounds":
+                    return base.QueryValue(pd.Input);
+                case "depictedthing":
+                    return base.QueryValue(pd.Input);
+                case "diagramelement":
+                    return base.QueryValue(pd.Input);
+                case "documentation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Documentation;
+                case "localstyle":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "resolution":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Resolution;
+                case "sharedstyle":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "bounds":
+                    return pd.Next == null ? (object) new List<Bounds>() : new Bounds(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "depictedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ActualFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Thing>() : default(Thing);
+                case "diagramelement":
+                    return pd.Next == null ? (object) new List<DiagramEdge>() : new DiagramEdge(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "documentation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "localstyle":
+                    return pd.Next == null ? (object) new List<OwnedStyle>() : new OwnedStyle(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "resolution":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                case "sharedstyle":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new SharedStyle(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<SharedStyle>() : default(SharedStyle);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DiagramShapePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DiagramShapePropertyAccessor.cs
@@ -1,0 +1,104 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DiagramShapePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.DiagramData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DiagramShape
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "bounds":
+                    return base.QueryValue(pd.Input);
+                case "depictedthing":
+                    return base.QueryValue(pd.Input);
+                case "diagramelement":
+                    return base.QueryValue(pd.Input);
+                case "localstyle":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "sharedstyle":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DiagramThingBasePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DiagramThingBasePropertyAccessor.cs
@@ -1,0 +1,95 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DiagramThingBasePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.DiagramData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DiagramThingBase
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DiagrammingStylePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DiagrammingStylePropertyAccessor.cs
@@ -1,0 +1,246 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DiagrammingStylePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.DiagramData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DiagrammingStyle
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "fillcolor":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.FillColor;
+                    }
+
+                    if (this.FillColor != null)
+                    {
+                        return this.FillColor.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelfillcolor = new Color(Guid.Empty, null, null);
+                    return sentinelfillcolor.QuerySentinelValue(pd.Next.Input, false);
+                case "fillopacity":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.FillOpacity;
+                case "fontbold":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.FontBold;
+                case "fontcolor":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.FontColor;
+                    }
+
+                    if (this.FontColor != null)
+                    {
+                        return this.FontColor.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelfontcolor = new Color(Guid.Empty, null, null);
+                    return sentinelfontcolor.QuerySentinelValue(pd.Next.Input, false);
+                case "fontitalic":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.FontItalic;
+                case "fontname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.FontName;
+                case "fontsize":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.FontSize;
+                case "fontstrokethrough":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.FontStrokeThrough;
+                case "fontunderline":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.FontUnderline;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "strokecolor":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.StrokeColor;
+                    }
+
+                    if (this.StrokeColor != null)
+                    {
+                        return this.StrokeColor.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelstrokecolor = new Color(Guid.Empty, null, null);
+                    return sentinelstrokecolor.QuerySentinelValue(pd.Next.Input, false);
+                case "strokeopacity":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.StrokeOpacity;
+                case "strokewidth":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.StrokeWidth;
+                case "usedcolor":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var usedColorUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && usedColorUpperBound == int.MaxValue && !this.UsedColor.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Color>();
+                        }
+
+                        var sentinelColor = new Color(Guid.Empty, null, null);
+
+                        return sentinelColor.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        usedColorUpperBound = this.UsedColor.Count - 1;
+                    }
+
+                    if (this.UsedColor.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for UsedColor property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.UsedColor.Count - 1 < usedColorUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the UsedColor property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.UsedColor[pd.Lower.Value];
+                        }
+
+                        return this.UsedColor[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var usedColorObjects = new List<Color>();
+
+                        for (var i = pd.Lower.Value; i < usedColorUpperBound + 1; i++)
+                        {
+                            usedColorObjects.Add(this.UsedColor[i]);
+                        }
+
+                        return usedColorObjects;
+                    }
+
+                    var usedColorNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < usedColorUpperBound + 1; i++)
+                    {
+                        var queryResult = this.UsedColor[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    usedColorNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                usedColorNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return usedColorNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DiscussionItemPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DiscussionItemPropertyAccessor.cs
@@ -1,0 +1,113 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DiscussionItemPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DiscussionItem
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "replyto":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ReplyTo;
+                    }
+
+                    if (this.ReplyTo != null)
+                    {
+                        return this.ReplyTo.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelreplyto = new EngineeringModelDataDiscussionItem(Guid.Empty, null, null);
+                    return sentinelreplyto.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DomainFileStorePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DomainFileStorePropertyAccessor.cs
@@ -1,0 +1,174 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DomainFileStorePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DomainFileStore
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "file":
+                    return base.QueryValue(pd.Input);
+                case "folder":
+                    return base.QueryValue(pd.Input);
+                case "ishidden":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsHidden;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "file":
+                    return pd.Next == null ? (object) new List<File>() : new File(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "folder":
+                    return pd.Next == null ? (object) new List<Folder>() : new Folder(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "ishidden":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DomainOfExpertiseGroupPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DomainOfExpertiseGroupPropertyAccessor.cs
@@ -1,0 +1,249 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DomainOfExpertiseGroupPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DomainOfExpertiseGroup
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "domain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var domainUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && domainUpperBound == int.MaxValue && !this.Domain.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<DomainOfExpertise>();
+                        }
+
+                        var sentinelDomainOfExpertise = new DomainOfExpertise(Guid.Empty, null, null);
+
+                        return sentinelDomainOfExpertise.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        domainUpperBound = this.Domain.Count - 1;
+                    }
+
+                    if (this.Domain.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Domain property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Domain.Count - 1 < domainUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Domain property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Domain[pd.Lower.Value];
+                        }
+
+                        return this.Domain[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var domainObjects = new List<DomainOfExpertise>();
+
+                        for (var i = pd.Lower.Value; i < domainUpperBound + 1; i++)
+                        {
+                            domainObjects.Add(this.Domain[i]);
+                        }
+
+                        return domainObjects;
+                    }
+
+                    var domainNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < domainUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Domain[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    domainNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                domainNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return domainNextObjects;
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "domain":
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/DomainOfExpertisePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/DomainOfExpertisePropertyAccessor.cs
@@ -1,0 +1,249 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="DomainOfExpertisePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class DomainOfExpertise
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ElementBasePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ElementBasePropertyAccessor.cs
@@ -1,0 +1,197 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ElementBasePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ElementBase
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ElementDefinitionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ElementDefinitionPropertyAccessor.cs
@@ -1,0 +1,586 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ElementDefinitionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ElementDefinition
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "containedelement":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var containedElementUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && containedElementUpperBound == int.MaxValue && !this.ContainedElement.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ElementUsage>();
+                        }
+
+                        var sentinelElementUsage = new ElementUsage(Guid.Empty, null, null);
+
+                        return sentinelElementUsage.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        containedElementUpperBound = this.ContainedElement.Count - 1;
+                    }
+
+                    if (this.ContainedElement.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ContainedElement property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ContainedElement.Count - 1 < containedElementUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ContainedElement property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ContainedElement[pd.Lower.Value];
+                        }
+
+                        return this.ContainedElement[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var containedElementObjects = new List<ElementUsage>();
+
+                        for (var i = pd.Lower.Value; i < containedElementUpperBound + 1; i++)
+                        {
+                            containedElementObjects.Add(this.ContainedElement[i]);
+                        }
+
+                        return containedElementObjects;
+                    }
+
+                    var containedElementNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < containedElementUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ContainedElement[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    containedElementNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                containedElementNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return containedElementNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "organizationalparticipant":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var organizationalParticipantUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && organizationalParticipantUpperBound == int.MaxValue && !this.OrganizationalParticipant.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<OrganizationalParticipant>();
+                        }
+
+                        var sentinelOrganizationalParticipant = new OrganizationalParticipant(Guid.Empty, null, null);
+
+                        return sentinelOrganizationalParticipant.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        organizationalParticipantUpperBound = this.OrganizationalParticipant.Count - 1;
+                    }
+
+                    if (this.OrganizationalParticipant.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for OrganizationalParticipant property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.OrganizationalParticipant.Count - 1 < organizationalParticipantUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the OrganizationalParticipant property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.OrganizationalParticipant[pd.Lower.Value];
+                        }
+
+                        return this.OrganizationalParticipant[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var organizationalParticipantObjects = new List<OrganizationalParticipant>();
+
+                        for (var i = pd.Lower.Value; i < organizationalParticipantUpperBound + 1; i++)
+                        {
+                            organizationalParticipantObjects.Add(this.OrganizationalParticipant[i]);
+                        }
+
+                        return organizationalParticipantObjects;
+                    }
+
+                    var organizationalParticipantNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < organizationalParticipantUpperBound + 1; i++)
+                    {
+                        var queryResult = this.OrganizationalParticipant[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    organizationalParticipantNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                organizationalParticipantNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return organizationalParticipantNextObjects;
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "parameter":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var parameterUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && parameterUpperBound == int.MaxValue && !this.Parameter.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Parameter>();
+                        }
+
+                        var sentinelParameter = new Parameter(Guid.Empty, null, null);
+
+                        return sentinelParameter.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        parameterUpperBound = this.Parameter.Count - 1;
+                    }
+
+                    if (this.Parameter.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Parameter property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Parameter.Count - 1 < parameterUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Parameter property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Parameter[pd.Lower.Value];
+                        }
+
+                        return this.Parameter[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var parameterObjects = new List<Parameter>();
+
+                        for (var i = pd.Lower.Value; i < parameterUpperBound + 1; i++)
+                        {
+                            parameterObjects.Add(this.Parameter[i]);
+                        }
+
+                        return parameterObjects;
+                    }
+
+                    var parameterNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < parameterUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Parameter[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    parameterNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                parameterNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return parameterNextObjects;
+                case "parametergroup":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var parameterGroupUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && parameterGroupUpperBound == int.MaxValue && !this.ParameterGroup.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ParameterGroup>();
+                        }
+
+                        var sentinelParameterGroup = new ParameterGroup(Guid.Empty, null, null);
+
+                        return sentinelParameterGroup.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        parameterGroupUpperBound = this.ParameterGroup.Count - 1;
+                    }
+
+                    if (this.ParameterGroup.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ParameterGroup property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ParameterGroup.Count - 1 < parameterGroupUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ParameterGroup property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ParameterGroup[pd.Lower.Value];
+                        }
+
+                        return this.ParameterGroup[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var parameterGroupObjects = new List<ParameterGroup>();
+
+                        for (var i = pd.Lower.Value; i < parameterGroupUpperBound + 1; i++)
+                        {
+                            parameterGroupObjects.Add(this.ParameterGroup[i]);
+                        }
+
+                        return parameterGroupObjects;
+                    }
+
+                    var parameterGroupNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < parameterGroupUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ParameterGroup[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    parameterGroupNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                parameterGroupNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return parameterGroupNextObjects;
+                case "referencedelement":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var referencedElementUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && referencedElementUpperBound == int.MaxValue && !this.ReferencedElement.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<NestedElement>();
+                        }
+
+                        var sentinelNestedElement = new NestedElement(Guid.Empty, null, null);
+
+                        return sentinelNestedElement.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        referencedElementUpperBound = this.ReferencedElement.Count - 1;
+                    }
+
+                    if (this.ReferencedElement.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ReferencedElement property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ReferencedElement.Count - 1 < referencedElementUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ReferencedElement property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ReferencedElement[pd.Lower.Value];
+                        }
+
+                        return this.ReferencedElement[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var referencedElementObjects = new List<NestedElement>();
+
+                        for (var i = pd.Lower.Value; i < referencedElementUpperBound + 1; i++)
+                        {
+                            referencedElementObjects.Add(this.ReferencedElement[i]);
+                        }
+
+                        return referencedElementObjects;
+                    }
+
+                    var referencedElementNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < referencedElementUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ReferencedElement[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    referencedElementNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                referencedElementNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return referencedElementNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "containedelement":
+                    return pd.Next == null ? (object) new List<ElementUsage>() : new ElementUsage(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "organizationalparticipant":
+                    return pd.Next == null ? (object) new List<OrganizationalParticipant>() : new OrganizationalParticipant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "parameter":
+                    return pd.Next == null ? (object) new List<Parameter>() : new Parameter(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "parametergroup":
+                    return pd.Next == null ? (object) new List<ParameterGroup>() : new ParameterGroup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "referencedelement":
+                    return pd.Next == null ? (object) new List<NestedElement>() : new NestedElement(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ElementUsagePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ElementUsagePropertyAccessor.cs
@@ -1,0 +1,370 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ElementUsagePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ElementUsage
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "elementdefinition":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ElementDefinition;
+                    }
+
+                    if (this.ElementDefinition != null)
+                    {
+                        return this.ElementDefinition.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelelementdefinition = new ElementDefinition(Guid.Empty, null, null);
+                    return sentinelelementdefinition.QuerySentinelValue(pd.Next.Input, false);
+                case "excludeoption":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var excludeOptionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && excludeOptionUpperBound == int.MaxValue && !this.ExcludeOption.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Option>();
+                        }
+
+                        var sentinelOption = new Option(Guid.Empty, null, null);
+
+                        return sentinelOption.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        excludeOptionUpperBound = this.ExcludeOption.Count - 1;
+                    }
+
+                    if (this.ExcludeOption.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ExcludeOption property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ExcludeOption.Count - 1 < excludeOptionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ExcludeOption property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ExcludeOption[pd.Lower.Value];
+                        }
+
+                        return this.ExcludeOption[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var excludeOptionObjects = new List<Option>();
+
+                        for (var i = pd.Lower.Value; i < excludeOptionUpperBound + 1; i++)
+                        {
+                            excludeOptionObjects.Add(this.ExcludeOption[i]);
+                        }
+
+                        return excludeOptionObjects;
+                    }
+
+                    var excludeOptionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < excludeOptionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ExcludeOption[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    excludeOptionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                excludeOptionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return excludeOptionNextObjects;
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "interfaceend":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.InterfaceEnd;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "parameteroverride":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var parameterOverrideUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && parameterOverrideUpperBound == int.MaxValue && !this.ParameterOverride.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ParameterOverride>();
+                        }
+
+                        var sentinelParameterOverride = new ParameterOverride(Guid.Empty, null, null);
+
+                        return sentinelParameterOverride.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        parameterOverrideUpperBound = this.ParameterOverride.Count - 1;
+                    }
+
+                    if (this.ParameterOverride.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ParameterOverride property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ParameterOverride.Count - 1 < parameterOverrideUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ParameterOverride property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ParameterOverride[pd.Lower.Value];
+                        }
+
+                        return this.ParameterOverride[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var parameterOverrideObjects = new List<ParameterOverride>();
+
+                        for (var i = pd.Lower.Value; i < parameterOverrideUpperBound + 1; i++)
+                        {
+                            parameterOverrideObjects.Add(this.ParameterOverride[i]);
+                        }
+
+                        return parameterOverrideObjects;
+                    }
+
+                    var parameterOverrideNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < parameterOverrideUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ParameterOverride[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    parameterOverrideNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                parameterOverrideNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return parameterOverrideNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "elementdefinition":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ElementDefinition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ElementDefinition>() : default(ElementDefinition);
+                case "excludeoption":
+                    return pd.Next == null ? (object) new List<Option>() : new Option(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "interfaceend":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<InterfaceEndKind>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "parameteroverride":
+                    return pd.Next == null ? (object) new List<ParameterOverride>() : new ParameterOverride(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/EmailAddressPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/EmailAddressPropertyAccessor.cs
@@ -1,0 +1,151 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EmailAddressPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class EmailAddress
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "value":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Value;
+                case "vcardtype":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.VcardType;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "value":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "vcardtype":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<VcardEmailAddressKind>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/EngineeringModelDataAnnotationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/EngineeringModelDataAnnotationPropertyAccessor.cs
@@ -1,0 +1,288 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EngineeringModelDataAnnotationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class EngineeringModelDataAnnotation
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Author;
+                    }
+
+                    if (this.Author != null)
+                    {
+                        return this.Author.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelauthor = new Participant(Guid.Empty, null, null);
+                    return sentinelauthor.QuerySentinelValue(pd.Next.Input, false);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "discussion":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var discussionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && discussionUpperBound == int.MaxValue && !this.Discussion.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<EngineeringModelDataDiscussionItem>();
+                        }
+
+                        var sentinelEngineeringModelDataDiscussionItem = new EngineeringModelDataDiscussionItem(Guid.Empty, null, null);
+
+                        return sentinelEngineeringModelDataDiscussionItem.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        discussionUpperBound = this.Discussion.Count - 1;
+                    }
+
+                    if (this.Discussion.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Discussion property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Discussion.Count - 1 < discussionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Discussion property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Discussion[pd.Lower.Value];
+                        }
+
+                        return this.Discussion[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var discussionObjects = new List<EngineeringModelDataDiscussionItem>();
+
+                        for (var i = pd.Lower.Value; i < discussionUpperBound + 1; i++)
+                        {
+                            discussionObjects.Add(this.Discussion[i]);
+                        }
+
+                        return discussionObjects;
+                    }
+
+                    var discussionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < discussionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Discussion[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    discussionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                discussionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return discussionNextObjects;
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "primaryannotatedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.PrimaryAnnotatedThing;
+                    }
+
+                    if (this.PrimaryAnnotatedThing != null)
+                    {
+                        return this.PrimaryAnnotatedThing.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelprimaryannotatedthing = new ModellingThingReference(Guid.Empty, null, null);
+                    return sentinelprimaryannotatedthing.QuerySentinelValue(pd.Next.Input, false);
+                case "relatedthing":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var relatedThingUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && relatedThingUpperBound == int.MaxValue && !this.RelatedThing.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ModellingThingReference>();
+                        }
+
+                        var sentinelModellingThingReference = new ModellingThingReference(Guid.Empty, null, null);
+
+                        return sentinelModellingThingReference.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        relatedThingUpperBound = this.RelatedThing.Count - 1;
+                    }
+
+                    if (this.RelatedThing.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for RelatedThing property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.RelatedThing.Count - 1 < relatedThingUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the RelatedThing property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.RelatedThing[pd.Lower.Value];
+                        }
+
+                        return this.RelatedThing[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var relatedThingObjects = new List<ModellingThingReference>();
+
+                        for (var i = pd.Lower.Value; i < relatedThingUpperBound + 1; i++)
+                        {
+                            relatedThingObjects.Add(this.RelatedThing[i]);
+                        }
+
+                        return relatedThingObjects;
+                    }
+
+                    var relatedThingNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < relatedThingUpperBound + 1; i++)
+                    {
+                        var queryResult = this.RelatedThing[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    relatedThingNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                relatedThingNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return relatedThingNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/EngineeringModelDataDiscussionItemPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/EngineeringModelDataDiscussionItemPropertyAccessor.cs
@@ -1,0 +1,189 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EngineeringModelDataDiscussionItemPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class EngineeringModelDataDiscussionItem
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Author;
+                    }
+
+                    if (this.Author != null)
+                    {
+                        return this.Author.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelauthor = new Participant(Guid.Empty, null, null);
+                    return sentinelauthor.QuerySentinelValue(pd.Next.Input, false);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "replyto":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "replyto":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new EngineeringModelDataDiscussionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DiscussionItem>() : default(DiscussionItem);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/EngineeringModelDataNotePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/EngineeringModelDataNotePropertyAccessor.cs
@@ -1,0 +1,184 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EngineeringModelDataNotePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class EngineeringModelDataNote
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "author":
+                    return base.QueryValue(pd.Input);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "discussion":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "primaryannotatedthing":
+                    return base.QueryValue(pd.Input);
+                case "relatedthing":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "discussion":
+                    return pd.Next == null ? (object) new List<EngineeringModelDataDiscussionItem>() : new EngineeringModelDataDiscussionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "primaryannotatedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ModellingThingReference>() : default(ModellingThingReference);
+                case "relatedthing":
+                    return pd.Next == null ? (object) new List<ModellingThingReference>() : new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/EngineeringModelPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/EngineeringModelPropertyAccessor.cs
@@ -1,0 +1,660 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EngineeringModelPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class EngineeringModel
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "book":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var bookUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && bookUpperBound == int.MaxValue && !this.Book.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Book>();
+                        }
+
+                        var sentinelBook = new Book(Guid.Empty, null, null);
+
+                        return sentinelBook.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        bookUpperBound = this.Book.Count - 1;
+                    }
+
+                    if (this.Book.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Book property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Book.Count - 1 < bookUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Book property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Book[pd.Lower.Value];
+                        }
+
+                        return this.Book[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var bookObjects = new List<Book>();
+
+                        for (var i = pd.Lower.Value; i < bookUpperBound + 1; i++)
+                        {
+                            bookObjects.Add(this.Book[i]);
+                        }
+
+                        return bookObjects;
+                    }
+
+                    var bookNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < bookUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Book[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    bookNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                bookNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return bookNextObjects;
+                case "commonfilestore":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var commonFileStoreUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && commonFileStoreUpperBound == int.MaxValue && !this.CommonFileStore.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<CommonFileStore>();
+                        }
+
+                        var sentinelCommonFileStore = new CommonFileStore(Guid.Empty, null, null);
+
+                        return sentinelCommonFileStore.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        commonFileStoreUpperBound = this.CommonFileStore.Count - 1;
+                    }
+
+                    if (this.CommonFileStore.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for CommonFileStore property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.CommonFileStore.Count - 1 < commonFileStoreUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the CommonFileStore property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.CommonFileStore[pd.Lower.Value];
+                        }
+
+                        return this.CommonFileStore[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var commonFileStoreObjects = new List<CommonFileStore>();
+
+                        for (var i = pd.Lower.Value; i < commonFileStoreUpperBound + 1; i++)
+                        {
+                            commonFileStoreObjects.Add(this.CommonFileStore[i]);
+                        }
+
+                        return commonFileStoreObjects;
+                    }
+
+                    var commonFileStoreNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < commonFileStoreUpperBound + 1; i++)
+                    {
+                        var queryResult = this.CommonFileStore[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    commonFileStoreNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                commonFileStoreNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return commonFileStoreNextObjects;
+                case "engineeringmodelsetup":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.EngineeringModelSetup;
+                    }
+
+                    if (this.EngineeringModelSetup != null)
+                    {
+                        return this.EngineeringModelSetup.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelengineeringmodelsetup = new EngineeringModelSetup(Guid.Empty, null, null);
+                    return sentinelengineeringmodelsetup.QuerySentinelValue(pd.Next.Input, false);
+                case "genericnote":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var genericNoteUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && genericNoteUpperBound == int.MaxValue && !this.GenericNote.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<EngineeringModelDataNote>();
+                        }
+
+                        var sentinelEngineeringModelDataNote = new EngineeringModelDataNote(Guid.Empty, null, null);
+
+                        return sentinelEngineeringModelDataNote.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        genericNoteUpperBound = this.GenericNote.Count - 1;
+                    }
+
+                    if (this.GenericNote.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for GenericNote property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.GenericNote.Count - 1 < genericNoteUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the GenericNote property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.GenericNote[pd.Lower.Value];
+                        }
+
+                        return this.GenericNote[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var genericNoteObjects = new List<EngineeringModelDataNote>();
+
+                        for (var i = pd.Lower.Value; i < genericNoteUpperBound + 1; i++)
+                        {
+                            genericNoteObjects.Add(this.GenericNote[i]);
+                        }
+
+                        return genericNoteObjects;
+                    }
+
+                    var genericNoteNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < genericNoteUpperBound + 1; i++)
+                    {
+                        var queryResult = this.GenericNote[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    genericNoteNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                genericNoteNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return genericNoteNextObjects;
+                case "iteration":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var iterationUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && iterationUpperBound == int.MaxValue && !this.Iteration.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Iteration>();
+                        }
+
+                        var sentinelIteration = new Iteration(Guid.Empty, null, null);
+
+                        return sentinelIteration.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        iterationUpperBound = this.Iteration.Count - 1;
+                    }
+
+                    if (this.Iteration.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Iteration property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Iteration.Count - 1 < iterationUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Iteration property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Iteration[pd.Lower.Value];
+                        }
+
+                        return this.Iteration[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var iterationObjects = new List<Iteration>();
+
+                        for (var i = pd.Lower.Value; i < iterationUpperBound + 1; i++)
+                        {
+                            iterationObjects.Add(this.Iteration[i]);
+                        }
+
+                        return iterationObjects;
+                    }
+
+                    var iterationNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < iterationUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Iteration[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    iterationNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                iterationNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return iterationNextObjects;
+                case "lastmodifiedon":
+                    return base.QueryValue(pd.Input);
+                case "logentry":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var logEntryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && logEntryUpperBound == int.MaxValue && !this.LogEntry.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ModelLogEntry>();
+                        }
+
+                        var sentinelModelLogEntry = new ModelLogEntry(Guid.Empty, null, null);
+
+                        return sentinelModelLogEntry.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        logEntryUpperBound = this.LogEntry.Count - 1;
+                    }
+
+                    if (this.LogEntry.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for LogEntry property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.LogEntry.Count - 1 < logEntryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the LogEntry property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.LogEntry[pd.Lower.Value];
+                        }
+
+                        return this.LogEntry[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var logEntryObjects = new List<ModelLogEntry>();
+
+                        for (var i = pd.Lower.Value; i < logEntryUpperBound + 1; i++)
+                        {
+                            logEntryObjects.Add(this.LogEntry[i]);
+                        }
+
+                        return logEntryObjects;
+                    }
+
+                    var logEntryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < logEntryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.LogEntry[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    logEntryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                logEntryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return logEntryNextObjects;
+                case "modellingannotation":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var modellingAnnotationUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && modellingAnnotationUpperBound == int.MaxValue && !this.ModellingAnnotation.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ModellingAnnotationItem>();
+                        }
+
+                        var sentinelModellingAnnotationItem = new ActionItem(Guid.Empty, null, null);
+
+                        return sentinelModellingAnnotationItem.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        modellingAnnotationUpperBound = this.ModellingAnnotation.Count - 1;
+                    }
+
+                    if (this.ModellingAnnotation.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ModellingAnnotation property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ModellingAnnotation.Count - 1 < modellingAnnotationUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ModellingAnnotation property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ModellingAnnotation[pd.Lower.Value];
+                        }
+
+                        return this.ModellingAnnotation[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var modellingAnnotationObjects = new List<ModellingAnnotationItem>();
+
+                        for (var i = pd.Lower.Value; i < modellingAnnotationUpperBound + 1; i++)
+                        {
+                            modellingAnnotationObjects.Add(this.ModellingAnnotation[i]);
+                        }
+
+                        return modellingAnnotationObjects;
+                    }
+
+                    var modellingAnnotationNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < modellingAnnotationUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ModellingAnnotation[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    modellingAnnotationNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                modellingAnnotationNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return modellingAnnotationNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "book":
+                    return pd.Next == null ? (object) new List<Book>() : new Book(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "commonfilestore":
+                    return pd.Next == null ? (object) new List<CommonFileStore>() : new CommonFileStore(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "engineeringmodelsetup":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new EngineeringModelSetup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<EngineeringModelSetup>() : default(EngineeringModelSetup);
+                case "genericnote":
+                    return pd.Next == null ? (object) new List<EngineeringModelDataNote>() : new EngineeringModelDataNote(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "iteration":
+                    return pd.Next == null ? (object) new List<Iteration>() : new Iteration(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "lastmodifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "logentry":
+                    return pd.Next == null ? (object) new List<ModelLogEntry>() : new ModelLogEntry(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modellingannotation":
+                    return pd.Next == null ? (object) new List<ActionItem>() : new ActionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/EngineeringModelSetupPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/EngineeringModelSetupPropertyAccessor.cs
@@ -1,0 +1,619 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EngineeringModelSetupPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class EngineeringModelSetup
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "activedomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var activeDomainUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && activeDomainUpperBound == int.MaxValue && !this.ActiveDomain.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<DomainOfExpertise>();
+                        }
+
+                        var sentinelDomainOfExpertise = new DomainOfExpertise(Guid.Empty, null, null);
+
+                        return sentinelDomainOfExpertise.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        activeDomainUpperBound = this.ActiveDomain.Count - 1;
+                    }
+
+                    if (this.ActiveDomain.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ActiveDomain property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ActiveDomain.Count - 1 < activeDomainUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ActiveDomain property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ActiveDomain[pd.Lower.Value];
+                        }
+
+                        return this.ActiveDomain[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var activeDomainObjects = new List<DomainOfExpertise>();
+
+                        for (var i = pd.Lower.Value; i < activeDomainUpperBound + 1; i++)
+                        {
+                            activeDomainObjects.Add(this.ActiveDomain[i]);
+                        }
+
+                        return activeDomainObjects;
+                    }
+
+                    var activeDomainNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < activeDomainUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ActiveDomain[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    activeDomainNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                activeDomainNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return activeDomainNextObjects;
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "defaultorganizationalparticipant":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.DefaultOrganizationalParticipant;
+                    }
+
+                    if (this.DefaultOrganizationalParticipant != null)
+                    {
+                        return this.DefaultOrganizationalParticipant.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineldefaultorganizationalparticipant = new OrganizationalParticipant(Guid.Empty, null, null);
+                    return sentineldefaultorganizationalparticipant.QuerySentinelValue(pd.Next.Input, false);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "engineeringmodeliid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.EngineeringModelIid;
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "iterationsetup":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var iterationSetupUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && iterationSetupUpperBound == int.MaxValue && !this.IterationSetup.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<IterationSetup>();
+                        }
+
+                        var sentinelIterationSetup = new IterationSetup(Guid.Empty, null, null);
+
+                        return sentinelIterationSetup.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        iterationSetupUpperBound = this.IterationSetup.Count - 1;
+                    }
+
+                    if (this.IterationSetup.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for IterationSetup property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.IterationSetup.Count - 1 < iterationSetupUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the IterationSetup property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.IterationSetup[pd.Lower.Value];
+                        }
+
+                        return this.IterationSetup[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var iterationSetupObjects = new List<IterationSetup>();
+
+                        for (var i = pd.Lower.Value; i < iterationSetupUpperBound + 1; i++)
+                        {
+                            iterationSetupObjects.Add(this.IterationSetup[i]);
+                        }
+
+                        return iterationSetupObjects;
+                    }
+
+                    var iterationSetupNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < iterationSetupUpperBound + 1; i++)
+                    {
+                        var queryResult = this.IterationSetup[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    iterationSetupNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                iterationSetupNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return iterationSetupNextObjects;
+                case "kind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Kind;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "organizationalparticipant":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var organizationalParticipantUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && organizationalParticipantUpperBound == int.MaxValue && !this.OrganizationalParticipant.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<OrganizationalParticipant>();
+                        }
+
+                        var sentinelOrganizationalParticipant = new OrganizationalParticipant(Guid.Empty, null, null);
+
+                        return sentinelOrganizationalParticipant.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        organizationalParticipantUpperBound = this.OrganizationalParticipant.Count - 1;
+                    }
+
+                    if (this.OrganizationalParticipant.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for OrganizationalParticipant property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.OrganizationalParticipant.Count - 1 < organizationalParticipantUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the OrganizationalParticipant property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.OrganizationalParticipant[pd.Lower.Value];
+                        }
+
+                        return this.OrganizationalParticipant[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var organizationalParticipantObjects = new List<OrganizationalParticipant>();
+
+                        for (var i = pd.Lower.Value; i < organizationalParticipantUpperBound + 1; i++)
+                        {
+                            organizationalParticipantObjects.Add(this.OrganizationalParticipant[i]);
+                        }
+
+                        return organizationalParticipantObjects;
+                    }
+
+                    var organizationalParticipantNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < organizationalParticipantUpperBound + 1; i++)
+                    {
+                        var queryResult = this.OrganizationalParticipant[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    organizationalParticipantNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                organizationalParticipantNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return organizationalParticipantNextObjects;
+                case "participant":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var participantUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && participantUpperBound == int.MaxValue && !this.Participant.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Participant>();
+                        }
+
+                        var sentinelParticipant = new Participant(Guid.Empty, null, null);
+
+                        return sentinelParticipant.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        participantUpperBound = this.Participant.Count - 1;
+                    }
+
+                    if (this.Participant.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Participant property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Participant.Count - 1 < participantUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Participant property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Participant[pd.Lower.Value];
+                        }
+
+                        return this.Participant[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var participantObjects = new List<Participant>();
+
+                        for (var i = pd.Lower.Value; i < participantUpperBound + 1; i++)
+                        {
+                            participantObjects.Add(this.Participant[i]);
+                        }
+
+                        return participantObjects;
+                    }
+
+                    var participantNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < participantUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Participant[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    participantNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                participantNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return participantNextObjects;
+                case "requiredrdl":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var requiredRdlUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && requiredRdlUpperBound == int.MaxValue && !this.RequiredRdl.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ModelReferenceDataLibrary>();
+                        }
+
+                        var sentinelModelReferenceDataLibrary = new ModelReferenceDataLibrary(Guid.Empty, null, null);
+
+                        return sentinelModelReferenceDataLibrary.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        requiredRdlUpperBound = this.RequiredRdl.Count - 1;
+                    }
+
+                    if (this.RequiredRdl.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for RequiredRdl property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.RequiredRdl.Count - 1 < requiredRdlUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the RequiredRdl property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.RequiredRdl[pd.Lower.Value];
+                        }
+
+                        return this.RequiredRdl[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var requiredRdlObjects = new List<ModelReferenceDataLibrary>();
+
+                        for (var i = pd.Lower.Value; i < requiredRdlUpperBound + 1; i++)
+                        {
+                            requiredRdlObjects.Add(this.RequiredRdl[i]);
+                        }
+
+                        return requiredRdlObjects;
+                    }
+
+                    var requiredRdlNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < requiredRdlUpperBound + 1; i++)
+                    {
+                        var queryResult = this.RequiredRdl[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    requiredRdlNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                requiredRdlNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return requiredRdlNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "sourceengineeringmodelsetupiid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.SourceEngineeringModelSetupIid;
+                case "studyphase":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.StudyPhase;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "activedomain":
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "defaultorganizationalparticipant":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new OrganizationalParticipant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<OrganizationalParticipant>() : default(OrganizationalParticipant);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "engineeringmodeliid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "iterationsetup":
+                    return pd.Next == null ? (object) new List<IterationSetup>() : new IterationSetup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "kind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<EngineeringModelKind>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "organizationalparticipant":
+                    return pd.Next == null ? (object) new List<OrganizationalParticipant>() : new OrganizationalParticipant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "participant":
+                    return pd.Next == null ? (object) new List<Participant>() : new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "requiredrdl":
+                    return pd.Next == null ? (object) new List<ModelReferenceDataLibrary>() : new ModelReferenceDataLibrary(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "sourceengineeringmodelsetupiid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "studyphase":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<StudyPhaseKind>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/EnumerationParameterTypePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/EnumerationParameterTypePropertyAccessor.cs
@@ -1,0 +1,268 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EnumerationParameterTypePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class EnumerationParameterType
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "allowmultiselect":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.AllowMultiSelect;
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                case "valuedefinition":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var valueDefinitionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && valueDefinitionUpperBound == int.MaxValue && !this.ValueDefinition.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<EnumerationValueDefinition>();
+                        }
+
+                        var sentinelEnumerationValueDefinition = new EnumerationValueDefinition(Guid.Empty, null, null);
+
+                        return sentinelEnumerationValueDefinition.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        valueDefinitionUpperBound = this.ValueDefinition.Count - 1;
+                    }
+
+                    if (this.ValueDefinition.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ValueDefinition property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ValueDefinition.Count - 1 < valueDefinitionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ValueDefinition property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ValueDefinition[pd.Lower.Value];
+                        }
+
+                        return this.ValueDefinition[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var valueDefinitionObjects = new List<EnumerationValueDefinition>();
+
+                        for (var i = pd.Lower.Value; i < valueDefinitionUpperBound + 1; i++)
+                        {
+                            valueDefinitionObjects.Add(this.ValueDefinition[i]);
+                        }
+
+                        return valueDefinitionObjects;
+                    }
+
+                    var valueDefinitionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < valueDefinitionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ValueDefinition[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    valueDefinitionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                valueDefinitionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return valueDefinitionNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "allowmultiselect":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberofvalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "symbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "valuedefinition":
+                    return pd.Next == null ? (object) new List<EnumerationValueDefinition>() : new EnumerationValueDefinition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/EnumerationValueDefinitionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/EnumerationValueDefinitionPropertyAccessor.cs
@@ -1,0 +1,161 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="EnumerationValueDefinitionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class EnumerationValueDefinition
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ExclusiveOrExpressionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ExclusiveOrExpressionPropertyAccessor.cs
@@ -1,0 +1,221 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ExclusiveOrExpressionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ExclusiveOrExpression
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "term":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var termUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && termUpperBound == int.MaxValue && !this.Term.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<BooleanExpression>();
+                        }
+
+                        var sentinelBooleanExpression = new AndExpression(Guid.Empty, null, null);
+
+                        return sentinelBooleanExpression.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        termUpperBound = this.Term.Count - 1;
+                    }
+
+                    if (this.Term.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Term property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Term.Count - 1 < termUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Term property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Term[pd.Lower.Value];
+                        }
+
+                        return this.Term[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var termObjects = new List<BooleanExpression>();
+
+                        for (var i = pd.Lower.Value; i < termUpperBound + 1; i++)
+                        {
+                            termObjects.Add(this.Term[i]);
+                        }
+
+                        return termObjects;
+                    }
+
+                    var termNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < termUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Term[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    termNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                termNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return termNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "term":
+                    return pd.Next == null ? (object) new List<AndExpression>() : new AndExpression(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ExternalIdentifierMapPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ExternalIdentifierMapPropertyAccessor.cs
@@ -1,0 +1,293 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ExternalIdentifierMapPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ExternalIdentifierMap
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "correspondence":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var correspondenceUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && correspondenceUpperBound == int.MaxValue && !this.Correspondence.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<IdCorrespondence>();
+                        }
+
+                        var sentinelIdCorrespondence = new IdCorrespondence(Guid.Empty, null, null);
+
+                        return sentinelIdCorrespondence.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        correspondenceUpperBound = this.Correspondence.Count - 1;
+                    }
+
+                    if (this.Correspondence.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Correspondence property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Correspondence.Count - 1 < correspondenceUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Correspondence property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Correspondence[pd.Lower.Value];
+                        }
+
+                        return this.Correspondence[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var correspondenceObjects = new List<IdCorrespondence>();
+
+                        for (var i = pd.Lower.Value; i < correspondenceUpperBound + 1; i++)
+                        {
+                            correspondenceObjects.Add(this.Correspondence[i]);
+                        }
+
+                        return correspondenceObjects;
+                    }
+
+                    var correspondenceNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < correspondenceUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Correspondence[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    correspondenceNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                correspondenceNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return correspondenceNextObjects;
+                case "externalformat":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ExternalFormat;
+                    }
+
+                    if (this.ExternalFormat != null)
+                    {
+                        return this.ExternalFormat.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelexternalformat = new ReferenceSource(Guid.Empty, null, null);
+                    return sentinelexternalformat.QuerySentinelValue(pd.Next.Input, false);
+                case "externalmodelname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ExternalModelName;
+                case "externaltoolname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ExternalToolName;
+                case "externaltoolversion":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ExternalToolVersion;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "correspondence":
+                    return pd.Next == null ? (object) new List<IdCorrespondence>() : new IdCorrespondence(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "externalformat":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ReferenceSource(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ReferenceSource>() : default(ReferenceSource);
+                case "externalmodelname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "externaltoolname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "externaltoolversion":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/FilePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/FilePropertyAccessor.cs
@@ -1,0 +1,351 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="FilePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class File
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "filerevision":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var fileRevisionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && fileRevisionUpperBound == int.MaxValue && !this.FileRevision.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<FileRevision>();
+                        }
+
+                        var sentinelFileRevision = new FileRevision(Guid.Empty, null, null);
+
+                        return sentinelFileRevision.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        fileRevisionUpperBound = this.FileRevision.Count - 1;
+                    }
+
+                    if (this.FileRevision.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for FileRevision property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.FileRevision.Count - 1 < fileRevisionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the FileRevision property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.FileRevision[pd.Lower.Value];
+                        }
+
+                        return this.FileRevision[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var fileRevisionObjects = new List<FileRevision>();
+
+                        for (var i = pd.Lower.Value; i < fileRevisionUpperBound + 1; i++)
+                        {
+                            fileRevisionObjects.Add(this.FileRevision[i]);
+                        }
+
+                        return fileRevisionObjects;
+                    }
+
+                    var fileRevisionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < fileRevisionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.FileRevision[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    fileRevisionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                fileRevisionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return fileRevisionNextObjects;
+                case "lockedby":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.LockedBy;
+                    }
+
+                    if (this.LockedBy != null)
+                    {
+                        return this.LockedBy.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinellockedby = new Person(Guid.Empty, null, null);
+                    return sentinellockedby.QuerySentinelValue(pd.Next.Input, false);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "filerevision":
+                    return pd.Next == null ? (object) new List<FileRevision>() : new FileRevision(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "lockedby":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Person(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Person>() : default(Person);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/FileRevisionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/FileRevisionPropertyAccessor.cs
@@ -1,0 +1,293 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="FileRevisionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class FileRevision
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "containingfolder":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ContainingFolder;
+                    }
+
+                    if (this.ContainingFolder != null)
+                    {
+                        return this.ContainingFolder.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelcontainingfolder = new Folder(Guid.Empty, null, null);
+                    return sentinelcontainingfolder.QuerySentinelValue(pd.Next.Input, false);
+                case "contenthash":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ContentHash;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "creator":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Creator;
+                    }
+
+                    if (this.Creator != null)
+                    {
+                        return this.Creator.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelcreator = new Participant(Guid.Empty, null, null);
+                    return sentinelcreator.QuerySentinelValue(pd.Next.Input, false);
+                case "filetype":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var fileTypeUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && fileTypeUpperBound == int.MaxValue && !this.FileType.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<FileType>();
+                        }
+
+                        var sentinelFileType = new FileType(Guid.Empty, null, null);
+
+                        return sentinelFileType.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        fileTypeUpperBound = this.FileType.Count - 1;
+                    }
+
+                    if (this.FileType.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for FileType property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.FileType.Count - 1 < fileTypeUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the FileType property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.FileType[pd.Lower.Value];
+                        }
+
+                        return this.FileType[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var fileTypeObjects = new List<FileType>();
+
+                        for (var i = pd.Lower.Value; i < fileTypeUpperBound + 1; i++)
+                        {
+                            fileTypeObjects.Add(this.FileType[i]);
+                        }
+
+                        return fileTypeObjects;
+                    }
+
+                    var fileTypeNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < fileTypeUpperBound + 1; i++)
+                    {
+                        var queryResult = this.FileType[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    fileTypeNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                fileTypeNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return fileTypeNextObjects;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "path":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Path;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "containingfolder":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Folder(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Folder>() : default(Folder);
+                case "contenthash":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "creator":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "filetype":
+                    return pd.Next == null ? (object) new List<FileType>() : new FileType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "path":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/FileStorePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/FileStorePropertyAccessor.cs
@@ -1,0 +1,273 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="FileStorePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class FileStore
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "file":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var fileUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && fileUpperBound == int.MaxValue && !this.File.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<File>();
+                        }
+
+                        var sentinelFile = new File(Guid.Empty, null, null);
+
+                        return sentinelFile.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        fileUpperBound = this.File.Count - 1;
+                    }
+
+                    if (this.File.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for File property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.File.Count - 1 < fileUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the File property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.File[pd.Lower.Value];
+                        }
+
+                        return this.File[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var fileObjects = new List<File>();
+
+                        for (var i = pd.Lower.Value; i < fileUpperBound + 1; i++)
+                        {
+                            fileObjects.Add(this.File[i]);
+                        }
+
+                        return fileObjects;
+                    }
+
+                    var fileNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < fileUpperBound + 1; i++)
+                    {
+                        var queryResult = this.File[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    fileNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                fileNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return fileNextObjects;
+                case "folder":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var folderUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && folderUpperBound == int.MaxValue && !this.Folder.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Folder>();
+                        }
+
+                        var sentinelFolder = new Folder(Guid.Empty, null, null);
+
+                        return sentinelFolder.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        folderUpperBound = this.Folder.Count - 1;
+                    }
+
+                    if (this.Folder.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Folder property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Folder.Count - 1 < folderUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Folder property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Folder[pd.Lower.Value];
+                        }
+
+                        return this.Folder[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var folderObjects = new List<Folder>();
+
+                        for (var i = pd.Lower.Value; i < folderUpperBound + 1; i++)
+                        {
+                            folderObjects.Add(this.Folder[i]);
+                        }
+
+                        return folderObjects;
+                    }
+
+                    var folderNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < folderUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Folder[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    folderNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                folderNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return folderNextObjects;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/FileTypePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/FileTypePropertyAccessor.cs
@@ -1,0 +1,255 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="FileTypePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class FileType
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "extension":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Extension;
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "extension":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/FolderPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/FolderPropertyAccessor.cs
@@ -1,0 +1,229 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="FolderPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Folder
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "containingfolder":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ContainingFolder;
+                    }
+
+                    if (this.ContainingFolder != null)
+                    {
+                        return this.ContainingFolder.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelcontainingfolder = new Folder(Guid.Empty, null, null);
+                    return sentinelcontainingfolder.QuerySentinelValue(pd.Next.Input, false);
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "creator":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Creator;
+                    }
+
+                    if (this.Creator != null)
+                    {
+                        return this.Creator.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelcreator = new Participant(Guid.Empty, null, null);
+                    return sentinelcreator.QuerySentinelValue(pd.Next.Input, false);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "path":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Path;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "containingfolder":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Folder(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Folder>() : default(Folder);
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "creator":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "path":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/GenericAnnotationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/GenericAnnotationPropertyAccessor.cs
@@ -1,0 +1,101 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="GenericAnnotationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class GenericAnnotation
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Content;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.LanguageCode;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/GlossaryPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/GlossaryPropertyAccessor.cs
@@ -1,0 +1,331 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="GlossaryPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Glossary
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "term":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var termUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && termUpperBound == int.MaxValue && !this.Term.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Term>();
+                        }
+
+                        var sentinelTerm = new Term(Guid.Empty, null, null);
+
+                        return sentinelTerm.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        termUpperBound = this.Term.Count - 1;
+                    }
+
+                    if (this.Term.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Term property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Term.Count - 1 < termUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Term property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Term[pd.Lower.Value];
+                        }
+
+                        return this.Term[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var termObjects = new List<Term>();
+
+                        for (var i = pd.Lower.Value; i < termUpperBound + 1; i++)
+                        {
+                            termObjects.Add(this.Term[i]);
+                        }
+
+                        return termObjects;
+                    }
+
+                    var termNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < termUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Term[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    termNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                termNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return termNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "term":
+                    return pd.Next == null ? (object) new List<Term>() : new Term(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/GoalPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/GoalPropertyAccessor.cs
@@ -1,0 +1,243 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="GoalPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Goal
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/HyperLinkPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/HyperLinkPropertyAccessor.cs
@@ -1,0 +1,157 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="HyperLinkPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.CommonData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class HyperLink
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Content;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.LanguageCode;
+                case "uri":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Uri;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "uri":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/IdCorrespondencePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/IdCorrespondencePropertyAccessor.cs
@@ -1,0 +1,175 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IdCorrespondencePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class IdCorrespondence
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "externalid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ExternalId;
+                case "internalthing":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.InternalThing;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "externalid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "internalthing":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/IndependentParameterTypeAssignmentPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/IndependentParameterTypeAssignmentPropertyAccessor.cs
@@ -1,0 +1,187 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IndependentParameterTypeAssignmentPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class IndependentParameterTypeAssignment
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "measurementscale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.MeasurementScale;
+                    }
+
+                    if (this.MeasurementScale != null)
+                    {
+                        return this.MeasurementScale.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelmeasurementscale = new IntervalScale(Guid.Empty, null, null);
+                    return sentinelmeasurementscale.QuerySentinelValue(pd.Next.Input, false);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ParameterType;
+                    }
+
+                    if (this.ParameterType != null)
+                    {
+                        return this.ParameterType.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelparametertype = new CompoundParameterType(Guid.Empty, null, null);
+                    return sentinelparametertype.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "measurementscale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterType>() : default(ParameterType);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/IntervalScalePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/IntervalScalePropertyAccessor.cs
@@ -1,0 +1,220 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IntervalScalePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class IntervalScale
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "ismaximuminclusive":
+                    return base.QueryValue(pd.Input);
+                case "isminimuminclusive":
+                    return base.QueryValue(pd.Input);
+                case "mappingtoreferencescale":
+                    return base.QueryValue(pd.Input);
+                case "maximumpermissiblevalue":
+                    return base.QueryValue(pd.Input);
+                case "minimumpermissiblevalue":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "negativevalueconnotation":
+                    return base.QueryValue(pd.Input);
+                case "numberset":
+                    return base.QueryValue(pd.Input);
+                case "positivevalueconnotation":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "unit":
+                    return base.QueryValue(pd.Input);
+                case "valuedefinition":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "ismaximuminclusive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "isminimuminclusive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "mappingtoreferencescale":
+                    return pd.Next == null ? (object) new List<MappingToReferenceScale>() : new MappingToReferenceScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "maximumpermissiblevalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "minimumpermissiblevalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "negativevalueconnotation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberset":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<NumberSetKind>() : null;
+                case "positivevalueconnotation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "unit":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DerivedUnit(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementUnit>() : default(MeasurementUnit);
+                case "valuedefinition":
+                    return pd.Next == null ? (object) new List<ScaleValueDefinition>() : new ScaleValueDefinition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/IterationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/IterationPropertyAccessor.cs
@@ -1,0 +1,1611 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IterationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Iteration
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "actualfinitestatelist":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var actualFiniteStateListUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && actualFiniteStateListUpperBound == int.MaxValue && !this.ActualFiniteStateList.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ActualFiniteStateList>();
+                        }
+
+                        var sentinelActualFiniteStateList = new ActualFiniteStateList(Guid.Empty, null, null);
+
+                        return sentinelActualFiniteStateList.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        actualFiniteStateListUpperBound = this.ActualFiniteStateList.Count - 1;
+                    }
+
+                    if (this.ActualFiniteStateList.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ActualFiniteStateList property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ActualFiniteStateList.Count - 1 < actualFiniteStateListUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ActualFiniteStateList property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ActualFiniteStateList[pd.Lower.Value];
+                        }
+
+                        return this.ActualFiniteStateList[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var actualFiniteStateListObjects = new List<ActualFiniteStateList>();
+
+                        for (var i = pd.Lower.Value; i < actualFiniteStateListUpperBound + 1; i++)
+                        {
+                            actualFiniteStateListObjects.Add(this.ActualFiniteStateList[i]);
+                        }
+
+                        return actualFiniteStateListObjects;
+                    }
+
+                    var actualFiniteStateListNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < actualFiniteStateListUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ActualFiniteStateList[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    actualFiniteStateListNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                actualFiniteStateListNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return actualFiniteStateListNextObjects;
+                case "defaultoption":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.DefaultOption;
+                    }
+
+                    if (this.DefaultOption != null)
+                    {
+                        return this.DefaultOption.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineldefaultoption = new Option(Guid.Empty, null, null);
+                    return sentineldefaultoption.QuerySentinelValue(pd.Next.Input, false);
+                case "diagramcanvas":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var diagramCanvasUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && diagramCanvasUpperBound == int.MaxValue && !this.DiagramCanvas.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<DiagramCanvas>();
+                        }
+
+                        var sentinelDiagramCanvas = new DiagramCanvas(Guid.Empty, null, null);
+
+                        return sentinelDiagramCanvas.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        diagramCanvasUpperBound = this.DiagramCanvas.Count - 1;
+                    }
+
+                    if (this.DiagramCanvas.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for DiagramCanvas property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.DiagramCanvas.Count - 1 < diagramCanvasUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the DiagramCanvas property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.DiagramCanvas[pd.Lower.Value];
+                        }
+
+                        return this.DiagramCanvas[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var diagramCanvasObjects = new List<DiagramCanvas>();
+
+                        for (var i = pd.Lower.Value; i < diagramCanvasUpperBound + 1; i++)
+                        {
+                            diagramCanvasObjects.Add(this.DiagramCanvas[i]);
+                        }
+
+                        return diagramCanvasObjects;
+                    }
+
+                    var diagramCanvasNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < diagramCanvasUpperBound + 1; i++)
+                    {
+                        var queryResult = this.DiagramCanvas[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    diagramCanvasNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                diagramCanvasNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return diagramCanvasNextObjects;
+                case "domainfilestore":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var domainFileStoreUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && domainFileStoreUpperBound == int.MaxValue && !this.DomainFileStore.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<DomainFileStore>();
+                        }
+
+                        var sentinelDomainFileStore = new DomainFileStore(Guid.Empty, null, null);
+
+                        return sentinelDomainFileStore.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        domainFileStoreUpperBound = this.DomainFileStore.Count - 1;
+                    }
+
+                    if (this.DomainFileStore.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for DomainFileStore property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.DomainFileStore.Count - 1 < domainFileStoreUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the DomainFileStore property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.DomainFileStore[pd.Lower.Value];
+                        }
+
+                        return this.DomainFileStore[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var domainFileStoreObjects = new List<DomainFileStore>();
+
+                        for (var i = pd.Lower.Value; i < domainFileStoreUpperBound + 1; i++)
+                        {
+                            domainFileStoreObjects.Add(this.DomainFileStore[i]);
+                        }
+
+                        return domainFileStoreObjects;
+                    }
+
+                    var domainFileStoreNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < domainFileStoreUpperBound + 1; i++)
+                    {
+                        var queryResult = this.DomainFileStore[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    domainFileStoreNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                domainFileStoreNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return domainFileStoreNextObjects;
+                case "element":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var elementUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && elementUpperBound == int.MaxValue && !this.Element.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ElementDefinition>();
+                        }
+
+                        var sentinelElementDefinition = new ElementDefinition(Guid.Empty, null, null);
+
+                        return sentinelElementDefinition.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        elementUpperBound = this.Element.Count - 1;
+                    }
+
+                    if (this.Element.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Element property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Element.Count - 1 < elementUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Element property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Element[pd.Lower.Value];
+                        }
+
+                        return this.Element[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var elementObjects = new List<ElementDefinition>();
+
+                        for (var i = pd.Lower.Value; i < elementUpperBound + 1; i++)
+                        {
+                            elementObjects.Add(this.Element[i]);
+                        }
+
+                        return elementObjects;
+                    }
+
+                    var elementNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < elementUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Element[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    elementNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                elementNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return elementNextObjects;
+                case "externalidentifiermap":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var externalIdentifierMapUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && externalIdentifierMapUpperBound == int.MaxValue && !this.ExternalIdentifierMap.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ExternalIdentifierMap>();
+                        }
+
+                        var sentinelExternalIdentifierMap = new ExternalIdentifierMap(Guid.Empty, null, null);
+
+                        return sentinelExternalIdentifierMap.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        externalIdentifierMapUpperBound = this.ExternalIdentifierMap.Count - 1;
+                    }
+
+                    if (this.ExternalIdentifierMap.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ExternalIdentifierMap property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ExternalIdentifierMap.Count - 1 < externalIdentifierMapUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ExternalIdentifierMap property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ExternalIdentifierMap[pd.Lower.Value];
+                        }
+
+                        return this.ExternalIdentifierMap[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var externalIdentifierMapObjects = new List<ExternalIdentifierMap>();
+
+                        for (var i = pd.Lower.Value; i < externalIdentifierMapUpperBound + 1; i++)
+                        {
+                            externalIdentifierMapObjects.Add(this.ExternalIdentifierMap[i]);
+                        }
+
+                        return externalIdentifierMapObjects;
+                    }
+
+                    var externalIdentifierMapNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < externalIdentifierMapUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ExternalIdentifierMap[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    externalIdentifierMapNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                externalIdentifierMapNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return externalIdentifierMapNextObjects;
+                case "goal":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var goalUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && goalUpperBound == int.MaxValue && !this.Goal.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Goal>();
+                        }
+
+                        var sentinelGoal = new Goal(Guid.Empty, null, null);
+
+                        return sentinelGoal.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        goalUpperBound = this.Goal.Count - 1;
+                    }
+
+                    if (this.Goal.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Goal property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Goal.Count - 1 < goalUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Goal property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Goal[pd.Lower.Value];
+                        }
+
+                        return this.Goal[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var goalObjects = new List<Goal>();
+
+                        for (var i = pd.Lower.Value; i < goalUpperBound + 1; i++)
+                        {
+                            goalObjects.Add(this.Goal[i]);
+                        }
+
+                        return goalObjects;
+                    }
+
+                    var goalNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < goalUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Goal[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    goalNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                goalNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return goalNextObjects;
+                case "iterationsetup":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.IterationSetup;
+                    }
+
+                    if (this.IterationSetup != null)
+                    {
+                        return this.IterationSetup.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineliterationsetup = new IterationSetup(Guid.Empty, null, null);
+                    return sentineliterationsetup.QuerySentinelValue(pd.Next.Input, false);
+                case "option":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var optionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && optionUpperBound == int.MaxValue && !this.Option.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Option>();
+                        }
+
+                        var sentinelOption = new Option(Guid.Empty, null, null);
+
+                        return sentinelOption.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        optionUpperBound = this.Option.Count - 1;
+                    }
+
+                    if (this.Option.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Option property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Option.Count - 1 < optionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Option property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Option[pd.Lower.Value];
+                        }
+
+                        return this.Option[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var optionObjects = new List<Option>();
+
+                        for (var i = pd.Lower.Value; i < optionUpperBound + 1; i++)
+                        {
+                            optionObjects.Add(this.Option[i]);
+                        }
+
+                        return optionObjects;
+                    }
+
+                    var optionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < optionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Option[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    optionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                optionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return optionNextObjects;
+                case "possiblefinitestatelist":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var possibleFiniteStateListUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && possibleFiniteStateListUpperBound == int.MaxValue && !this.PossibleFiniteStateList.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<PossibleFiniteStateList>();
+                        }
+
+                        var sentinelPossibleFiniteStateList = new PossibleFiniteStateList(Guid.Empty, null, null);
+
+                        return sentinelPossibleFiniteStateList.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        possibleFiniteStateListUpperBound = this.PossibleFiniteStateList.Count - 1;
+                    }
+
+                    if (this.PossibleFiniteStateList.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for PossibleFiniteStateList property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.PossibleFiniteStateList.Count - 1 < possibleFiniteStateListUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the PossibleFiniteStateList property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.PossibleFiniteStateList[pd.Lower.Value];
+                        }
+
+                        return this.PossibleFiniteStateList[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var possibleFiniteStateListObjects = new List<PossibleFiniteStateList>();
+
+                        for (var i = pd.Lower.Value; i < possibleFiniteStateListUpperBound + 1; i++)
+                        {
+                            possibleFiniteStateListObjects.Add(this.PossibleFiniteStateList[i]);
+                        }
+
+                        return possibleFiniteStateListObjects;
+                    }
+
+                    var possibleFiniteStateListNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < possibleFiniteStateListUpperBound + 1; i++)
+                    {
+                        var queryResult = this.PossibleFiniteStateList[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    possibleFiniteStateListNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                possibleFiniteStateListNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return possibleFiniteStateListNextObjects;
+                case "publication":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var publicationUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && publicationUpperBound == int.MaxValue && !this.Publication.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Publication>();
+                        }
+
+                        var sentinelPublication = new Publication(Guid.Empty, null, null);
+
+                        return sentinelPublication.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        publicationUpperBound = this.Publication.Count - 1;
+                    }
+
+                    if (this.Publication.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Publication property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Publication.Count - 1 < publicationUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Publication property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Publication[pd.Lower.Value];
+                        }
+
+                        return this.Publication[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var publicationObjects = new List<Publication>();
+
+                        for (var i = pd.Lower.Value; i < publicationUpperBound + 1; i++)
+                        {
+                            publicationObjects.Add(this.Publication[i]);
+                        }
+
+                        return publicationObjects;
+                    }
+
+                    var publicationNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < publicationUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Publication[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    publicationNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                publicationNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return publicationNextObjects;
+                case "relationship":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var relationshipUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && relationshipUpperBound == int.MaxValue && !this.Relationship.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Relationship>();
+                        }
+
+                        var sentinelRelationship = new BinaryRelationship(Guid.Empty, null, null);
+
+                        return sentinelRelationship.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        relationshipUpperBound = this.Relationship.Count - 1;
+                    }
+
+                    if (this.Relationship.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Relationship property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Relationship.Count - 1 < relationshipUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Relationship property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Relationship[pd.Lower.Value];
+                        }
+
+                        return this.Relationship[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var relationshipObjects = new List<Relationship>();
+
+                        for (var i = pd.Lower.Value; i < relationshipUpperBound + 1; i++)
+                        {
+                            relationshipObjects.Add(this.Relationship[i]);
+                        }
+
+                        return relationshipObjects;
+                    }
+
+                    var relationshipNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < relationshipUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Relationship[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    relationshipNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                relationshipNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return relationshipNextObjects;
+                case "requirementsspecification":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var requirementsSpecificationUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && requirementsSpecificationUpperBound == int.MaxValue && !this.RequirementsSpecification.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<RequirementsSpecification>();
+                        }
+
+                        var sentinelRequirementsSpecification = new RequirementsSpecification(Guid.Empty, null, null);
+
+                        return sentinelRequirementsSpecification.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        requirementsSpecificationUpperBound = this.RequirementsSpecification.Count - 1;
+                    }
+
+                    if (this.RequirementsSpecification.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for RequirementsSpecification property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.RequirementsSpecification.Count - 1 < requirementsSpecificationUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the RequirementsSpecification property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.RequirementsSpecification[pd.Lower.Value];
+                        }
+
+                        return this.RequirementsSpecification[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var requirementsSpecificationObjects = new List<RequirementsSpecification>();
+
+                        for (var i = pd.Lower.Value; i < requirementsSpecificationUpperBound + 1; i++)
+                        {
+                            requirementsSpecificationObjects.Add(this.RequirementsSpecification[i]);
+                        }
+
+                        return requirementsSpecificationObjects;
+                    }
+
+                    var requirementsSpecificationNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < requirementsSpecificationUpperBound + 1; i++)
+                    {
+                        var queryResult = this.RequirementsSpecification[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    requirementsSpecificationNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                requirementsSpecificationNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return requirementsSpecificationNextObjects;
+                case "ruleverificationlist":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var ruleVerificationListUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && ruleVerificationListUpperBound == int.MaxValue && !this.RuleVerificationList.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<RuleVerificationList>();
+                        }
+
+                        var sentinelRuleVerificationList = new RuleVerificationList(Guid.Empty, null, null);
+
+                        return sentinelRuleVerificationList.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        ruleVerificationListUpperBound = this.RuleVerificationList.Count - 1;
+                    }
+
+                    if (this.RuleVerificationList.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for RuleVerificationList property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.RuleVerificationList.Count - 1 < ruleVerificationListUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the RuleVerificationList property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.RuleVerificationList[pd.Lower.Value];
+                        }
+
+                        return this.RuleVerificationList[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var ruleVerificationListObjects = new List<RuleVerificationList>();
+
+                        for (var i = pd.Lower.Value; i < ruleVerificationListUpperBound + 1; i++)
+                        {
+                            ruleVerificationListObjects.Add(this.RuleVerificationList[i]);
+                        }
+
+                        return ruleVerificationListObjects;
+                    }
+
+                    var ruleVerificationListNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < ruleVerificationListUpperBound + 1; i++)
+                    {
+                        var queryResult = this.RuleVerificationList[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    ruleVerificationListNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                ruleVerificationListNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return ruleVerificationListNextObjects;
+                case "shareddiagramstyle":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var sharedDiagramStyleUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && sharedDiagramStyleUpperBound == int.MaxValue && !this.SharedDiagramStyle.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<SharedStyle>();
+                        }
+
+                        var sentinelSharedStyle = new SharedStyle(Guid.Empty, null, null);
+
+                        return sentinelSharedStyle.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        sharedDiagramStyleUpperBound = this.SharedDiagramStyle.Count - 1;
+                    }
+
+                    if (this.SharedDiagramStyle.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for SharedDiagramStyle property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.SharedDiagramStyle.Count - 1 < sharedDiagramStyleUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the SharedDiagramStyle property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.SharedDiagramStyle[pd.Lower.Value];
+                        }
+
+                        return this.SharedDiagramStyle[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var sharedDiagramStyleObjects = new List<SharedStyle>();
+
+                        for (var i = pd.Lower.Value; i < sharedDiagramStyleUpperBound + 1; i++)
+                        {
+                            sharedDiagramStyleObjects.Add(this.SharedDiagramStyle[i]);
+                        }
+
+                        return sharedDiagramStyleObjects;
+                    }
+
+                    var sharedDiagramStyleNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < sharedDiagramStyleUpperBound + 1; i++)
+                    {
+                        var queryResult = this.SharedDiagramStyle[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    sharedDiagramStyleNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                sharedDiagramStyleNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return sharedDiagramStyleNextObjects;
+                case "sourceiterationiid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.SourceIterationIid;
+                case "stakeholder":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var stakeholderUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && stakeholderUpperBound == int.MaxValue && !this.Stakeholder.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Stakeholder>();
+                        }
+
+                        var sentinelStakeholder = new Stakeholder(Guid.Empty, null, null);
+
+                        return sentinelStakeholder.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        stakeholderUpperBound = this.Stakeholder.Count - 1;
+                    }
+
+                    if (this.Stakeholder.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Stakeholder property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Stakeholder.Count - 1 < stakeholderUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Stakeholder property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Stakeholder[pd.Lower.Value];
+                        }
+
+                        return this.Stakeholder[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var stakeholderObjects = new List<Stakeholder>();
+
+                        for (var i = pd.Lower.Value; i < stakeholderUpperBound + 1; i++)
+                        {
+                            stakeholderObjects.Add(this.Stakeholder[i]);
+                        }
+
+                        return stakeholderObjects;
+                    }
+
+                    var stakeholderNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < stakeholderUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Stakeholder[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    stakeholderNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                stakeholderNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return stakeholderNextObjects;
+                case "stakeholdervalue":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var stakeholderValueUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && stakeholderValueUpperBound == int.MaxValue && !this.StakeholderValue.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<StakeholderValue>();
+                        }
+
+                        var sentinelStakeholderValue = new StakeholderValue(Guid.Empty, null, null);
+
+                        return sentinelStakeholderValue.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        stakeholderValueUpperBound = this.StakeholderValue.Count - 1;
+                    }
+
+                    if (this.StakeholderValue.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for StakeholderValue property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.StakeholderValue.Count - 1 < stakeholderValueUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the StakeholderValue property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.StakeholderValue[pd.Lower.Value];
+                        }
+
+                        return this.StakeholderValue[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var stakeholderValueObjects = new List<StakeholderValue>();
+
+                        for (var i = pd.Lower.Value; i < stakeholderValueUpperBound + 1; i++)
+                        {
+                            stakeholderValueObjects.Add(this.StakeholderValue[i]);
+                        }
+
+                        return stakeholderValueObjects;
+                    }
+
+                    var stakeholderValueNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < stakeholderValueUpperBound + 1; i++)
+                    {
+                        var queryResult = this.StakeholderValue[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    stakeholderValueNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                stakeholderValueNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return stakeholderValueNextObjects;
+                case "stakeholdervaluemap":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var stakeholderValueMapUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && stakeholderValueMapUpperBound == int.MaxValue && !this.StakeholderValueMap.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<StakeHolderValueMap>();
+                        }
+
+                        var sentinelStakeHolderValueMap = new StakeHolderValueMap(Guid.Empty, null, null);
+
+                        return sentinelStakeHolderValueMap.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        stakeholderValueMapUpperBound = this.StakeholderValueMap.Count - 1;
+                    }
+
+                    if (this.StakeholderValueMap.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for StakeholderValueMap property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.StakeholderValueMap.Count - 1 < stakeholderValueMapUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the StakeholderValueMap property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.StakeholderValueMap[pd.Lower.Value];
+                        }
+
+                        return this.StakeholderValueMap[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var stakeholderValueMapObjects = new List<StakeHolderValueMap>();
+
+                        for (var i = pd.Lower.Value; i < stakeholderValueMapUpperBound + 1; i++)
+                        {
+                            stakeholderValueMapObjects.Add(this.StakeholderValueMap[i]);
+                        }
+
+                        return stakeholderValueMapObjects;
+                    }
+
+                    var stakeholderValueMapNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < stakeholderValueMapUpperBound + 1; i++)
+                    {
+                        var queryResult = this.StakeholderValueMap[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    stakeholderValueMapNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                stakeholderValueMapNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return stakeholderValueMapNextObjects;
+                case "topelement":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.TopElement;
+                    }
+
+                    if (this.TopElement != null)
+                    {
+                        return this.TopElement.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineltopelement = new ElementDefinition(Guid.Empty, null, null);
+                    return sentineltopelement.QuerySentinelValue(pd.Next.Input, false);
+                case "valuegroup":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var valueGroupUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && valueGroupUpperBound == int.MaxValue && !this.ValueGroup.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ValueGroup>();
+                        }
+
+                        var sentinelValueGroup = new ValueGroup(Guid.Empty, null, null);
+
+                        return sentinelValueGroup.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        valueGroupUpperBound = this.ValueGroup.Count - 1;
+                    }
+
+                    if (this.ValueGroup.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ValueGroup property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ValueGroup.Count - 1 < valueGroupUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ValueGroup property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ValueGroup[pd.Lower.Value];
+                        }
+
+                        return this.ValueGroup[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var valueGroupObjects = new List<ValueGroup>();
+
+                        for (var i = pd.Lower.Value; i < valueGroupUpperBound + 1; i++)
+                        {
+                            valueGroupObjects.Add(this.ValueGroup[i]);
+                        }
+
+                        return valueGroupObjects;
+                    }
+
+                    var valueGroupNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < valueGroupUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ValueGroup[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    valueGroupNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                valueGroupNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return valueGroupNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "actualfinitestatelist":
+                    return pd.Next == null ? (object) new List<ActualFiniteStateList>() : new ActualFiniteStateList(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "defaultoption":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Option(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Option>() : default(Option);
+                case "diagramcanvas":
+                    return pd.Next == null ? (object) new List<DiagramCanvas>() : new DiagramCanvas(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "domainfilestore":
+                    return pd.Next == null ? (object) new List<DomainFileStore>() : new DomainFileStore(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "element":
+                    return pd.Next == null ? (object) new List<ElementDefinition>() : new ElementDefinition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "externalidentifiermap":
+                    return pd.Next == null ? (object) new List<ExternalIdentifierMap>() : new ExternalIdentifierMap(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "goal":
+                    return pd.Next == null ? (object) new List<Goal>() : new Goal(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "iterationsetup":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IterationSetup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<IterationSetup>() : default(IterationSetup);
+                case "option":
+                    return pd.Next == null ? (object) new List<Option>() : new Option(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "possiblefinitestatelist":
+                    return pd.Next == null ? (object) new List<PossibleFiniteStateList>() : new PossibleFiniteStateList(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "publication":
+                    return pd.Next == null ? (object) new List<Publication>() : new Publication(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "relationship":
+                    return pd.Next == null ? (object) new List<BinaryRelationship>() : new BinaryRelationship(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "requirementsspecification":
+                    return pd.Next == null ? (object) new List<RequirementsSpecification>() : new RequirementsSpecification(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "ruleverificationlist":
+                    return pd.Next == null ? (object) new List<RuleVerificationList>() : new RuleVerificationList(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shareddiagramstyle":
+                    return pd.Next == null ? (object) new List<SharedStyle>() : new SharedStyle(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "sourceiterationiid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "stakeholder":
+                    return pd.Next == null ? (object) new List<Stakeholder>() : new Stakeholder(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "stakeholdervalue":
+                    return pd.Next == null ? (object) new List<StakeholderValue>() : new StakeholderValue(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "stakeholdervaluemap":
+                    return pd.Next == null ? (object) new List<StakeHolderValueMap>() : new StakeHolderValueMap(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "topelement":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ElementDefinition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ElementDefinition>() : default(ElementDefinition);
+                case "valuegroup":
+                    return pd.Next == null ? (object) new List<ValueGroup>() : new ValueGroup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/IterationSetupPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/IterationSetupPropertyAccessor.cs
@@ -1,0 +1,199 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="IterationSetupPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class IterationSetup
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "description":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Description;
+                case "frozenon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.FrozenOn;
+                case "isdeleted":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeleted;
+                case "iterationiid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IterationIid;
+                case "iterationnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IterationNumber;
+                case "sourceiterationsetup":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.SourceIterationSetup;
+                    }
+
+                    if (this.SourceIterationSetup != null)
+                    {
+                        return this.SourceIterationSetup.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelsourceiterationsetup = new IterationSetup(Guid.Empty, null, null);
+                    return sentinelsourceiterationsetup.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "description":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "frozenon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "isdeleted":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "iterationiid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "iterationnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "sourceiterationsetup":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IterationSetup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<IterationSetup>() : default(IterationSetup);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/LinearConversionUnitPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/LinearConversionUnitPropertyAccessor.cs
@@ -1,0 +1,182 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="LinearConversionUnitPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class LinearConversionUnit
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "conversionfactor":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "referenceunit":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "conversionfactor":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "referenceunit":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DerivedUnit(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementUnit>() : default(MeasurementUnit);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/LogEntryChangelogItemPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/LogEntryChangelogItemPropertyAccessor.cs
@@ -1,0 +1,199 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="LogEntryChangelogItemPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.CommonData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class LogEntryChangelogItem
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "affecteditemiid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.AffectedItemIid;
+                case "affectedreferenceiid":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for the AffectedReferenceIid property, the lower and upper bound must be specified");
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.AffectedReferenceIid.Any())
+                    {
+                        return new List<Guid>();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.AffectedReferenceIid.Count - 1;
+                    }
+
+                    if (this.AffectedReferenceIid.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the AffectedReferenceIid property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.AffectedReferenceIid.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the AffectedReferenceIid property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.AffectedReferenceIid[pd.Lower.Value];
+                    }
+
+                    var affectedReferenceIidobjects = new List<Guid>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        affectedReferenceIidobjects.Add(this.AffectedReferenceIid[i]);
+                    }
+
+                    return affectedReferenceIidobjects;
+                case "changedescription":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ChangeDescription;
+                case "changelogkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ChangelogKind;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "affecteditemiid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "affectedreferenceiid":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<Guid>() : null;
+                case "changedescription":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "changelogkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<LogEntryChangelogItemKind>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/LogarithmicScalePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/LogarithmicScalePropertyAccessor.cs
@@ -1,0 +1,344 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="LogarithmicScalePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class LogarithmicScale
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "exponent":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Exponent;
+                case "factor":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Factor;
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "ismaximuminclusive":
+                    return base.QueryValue(pd.Input);
+                case "isminimuminclusive":
+                    return base.QueryValue(pd.Input);
+                case "logarithmbase":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.LogarithmBase;
+                case "mappingtoreferencescale":
+                    return base.QueryValue(pd.Input);
+                case "maximumpermissiblevalue":
+                    return base.QueryValue(pd.Input);
+                case "minimumpermissiblevalue":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "negativevalueconnotation":
+                    return base.QueryValue(pd.Input);
+                case "numberset":
+                    return base.QueryValue(pd.Input);
+                case "positivevalueconnotation":
+                    return base.QueryValue(pd.Input);
+                case "referencequantitykind":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ReferenceQuantityKind;
+                    }
+
+                    if (this.ReferenceQuantityKind != null)
+                    {
+                        return this.ReferenceQuantityKind.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelreferencequantitykind = new DerivedQuantityKind(Guid.Empty, null, null);
+                    return sentinelreferencequantitykind.QuerySentinelValue(pd.Next.Input, false);
+                case "referencequantityvalue":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var referenceQuantityValueUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && referenceQuantityValueUpperBound == int.MaxValue && !this.ReferenceQuantityValue.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ScaleReferenceQuantityValue>();
+                        }
+
+                        var sentinelScaleReferenceQuantityValue = new ScaleReferenceQuantityValue(Guid.Empty, null, null);
+
+                        return sentinelScaleReferenceQuantityValue.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        referenceQuantityValueUpperBound = this.ReferenceQuantityValue.Count - 1;
+                    }
+
+                    if (this.ReferenceQuantityValue.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ReferenceQuantityValue property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ReferenceQuantityValue.Count - 1 < referenceQuantityValueUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ReferenceQuantityValue property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ReferenceQuantityValue[pd.Lower.Value];
+                        }
+
+                        return this.ReferenceQuantityValue[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var referenceQuantityValueObjects = new List<ScaleReferenceQuantityValue>();
+
+                        for (var i = pd.Lower.Value; i < referenceQuantityValueUpperBound + 1; i++)
+                        {
+                            referenceQuantityValueObjects.Add(this.ReferenceQuantityValue[i]);
+                        }
+
+                        return referenceQuantityValueObjects;
+                    }
+
+                    var referenceQuantityValueNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < referenceQuantityValueUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ReferenceQuantityValue[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    referenceQuantityValueNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                referenceQuantityValueNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return referenceQuantityValueNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "unit":
+                    return base.QueryValue(pd.Input);
+                case "valuedefinition":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "exponent":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "factor":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "ismaximuminclusive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "isminimuminclusive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "logarithmbase":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<LogarithmBaseKind>() : null;
+                case "mappingtoreferencescale":
+                    return pd.Next == null ? (object) new List<MappingToReferenceScale>() : new MappingToReferenceScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "maximumpermissiblevalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "minimumpermissiblevalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "negativevalueconnotation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberset":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<NumberSetKind>() : null;
+                case "positivevalueconnotation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "referencequantitykind":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DerivedQuantityKind(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<QuantityKind>() : default(QuantityKind);
+                case "referencequantityvalue":
+                    return pd.Next == null ? (object) new List<ScaleReferenceQuantityValue>() : new ScaleReferenceQuantityValue(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "unit":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DerivedUnit(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementUnit>() : default(MeasurementUnit);
+                case "valuedefinition":
+                    return pd.Next == null ? (object) new List<ScaleValueDefinition>() : new ScaleValueDefinition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/MappingToReferenceScalePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/MappingToReferenceScalePropertyAccessor.cs
@@ -1,0 +1,187 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="MappingToReferenceScalePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class MappingToReferenceScale
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "dependentscalevalue":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.DependentScaleValue;
+                    }
+
+                    if (this.DependentScaleValue != null)
+                    {
+                        return this.DependentScaleValue.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineldependentscalevalue = new ScaleValueDefinition(Guid.Empty, null, null);
+                    return sentineldependentscalevalue.QuerySentinelValue(pd.Next.Input, false);
+                case "referencescalevalue":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ReferenceScaleValue;
+                    }
+
+                    if (this.ReferenceScaleValue != null)
+                    {
+                        return this.ReferenceScaleValue.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelreferencescalevalue = new ScaleValueDefinition(Guid.Empty, null, null);
+                    return sentinelreferencescalevalue.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "dependentscalevalue":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ScaleValueDefinition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ScaleValueDefinition>() : default(ScaleValueDefinition);
+                case "referencescalevalue":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ScaleValueDefinition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ScaleValueDefinition>() : default(ScaleValueDefinition);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/MeasurementScalePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/MeasurementScalePropertyAccessor.cs
@@ -1,0 +1,301 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="MeasurementScalePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class MeasurementScale
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "ismaximuminclusive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsMaximumInclusive;
+                case "isminimuminclusive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsMinimumInclusive;
+                case "mappingtoreferencescale":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var mappingToReferenceScaleUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && mappingToReferenceScaleUpperBound == int.MaxValue && !this.MappingToReferenceScale.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<MappingToReferenceScale>();
+                        }
+
+                        var sentinelMappingToReferenceScale = new MappingToReferenceScale(Guid.Empty, null, null);
+
+                        return sentinelMappingToReferenceScale.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        mappingToReferenceScaleUpperBound = this.MappingToReferenceScale.Count - 1;
+                    }
+
+                    if (this.MappingToReferenceScale.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for MappingToReferenceScale property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.MappingToReferenceScale.Count - 1 < mappingToReferenceScaleUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the MappingToReferenceScale property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.MappingToReferenceScale[pd.Lower.Value];
+                        }
+
+                        return this.MappingToReferenceScale[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var mappingToReferenceScaleObjects = new List<MappingToReferenceScale>();
+
+                        for (var i = pd.Lower.Value; i < mappingToReferenceScaleUpperBound + 1; i++)
+                        {
+                            mappingToReferenceScaleObjects.Add(this.MappingToReferenceScale[i]);
+                        }
+
+                        return mappingToReferenceScaleObjects;
+                    }
+
+                    var mappingToReferenceScaleNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < mappingToReferenceScaleUpperBound + 1; i++)
+                    {
+                        var queryResult = this.MappingToReferenceScale[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    mappingToReferenceScaleNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                mappingToReferenceScaleNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return mappingToReferenceScaleNextObjects;
+                case "maximumpermissiblevalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.MaximumPermissibleValue;
+                case "minimumpermissiblevalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.MinimumPermissibleValue;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "negativevalueconnotation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.NegativeValueConnotation;
+                case "numberset":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.NumberSet;
+                case "positivevalueconnotation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.PositiveValueConnotation;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "unit":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Unit;
+                    }
+
+                    if (this.Unit != null)
+                    {
+                        return this.Unit.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelunit = new DerivedUnit(Guid.Empty, null, null);
+                    return sentinelunit.QuerySentinelValue(pd.Next.Input, false);
+                case "valuedefinition":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var valueDefinitionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && valueDefinitionUpperBound == int.MaxValue && !this.ValueDefinition.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ScaleValueDefinition>();
+                        }
+
+                        var sentinelScaleValueDefinition = new ScaleValueDefinition(Guid.Empty, null, null);
+
+                        return sentinelScaleValueDefinition.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        valueDefinitionUpperBound = this.ValueDefinition.Count - 1;
+                    }
+
+                    if (this.ValueDefinition.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ValueDefinition property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ValueDefinition.Count - 1 < valueDefinitionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ValueDefinition property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ValueDefinition[pd.Lower.Value];
+                        }
+
+                        return this.ValueDefinition[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var valueDefinitionObjects = new List<ScaleValueDefinition>();
+
+                        for (var i = pd.Lower.Value; i < valueDefinitionUpperBound + 1; i++)
+                        {
+                            valueDefinitionObjects.Add(this.ValueDefinition[i]);
+                        }
+
+                        return valueDefinitionObjects;
+                    }
+
+                    var valueDefinitionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < valueDefinitionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ValueDefinition[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    valueDefinitionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                valueDefinitionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return valueDefinitionNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/MeasurementUnitPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/MeasurementUnitPropertyAccessor.cs
@@ -1,0 +1,105 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="MeasurementUnitPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class MeasurementUnit
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ModelLogEntryPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ModelLogEntryPropertyAccessor.cs
@@ -1,0 +1,435 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ModelLogEntryPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ModelLogEntry
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "affecteddomainiid":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for the AffectedDomainIid property, the lower and upper bound must be specified");
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.AffectedDomainIid.Any())
+                    {
+                        return new List<Guid>();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.AffectedDomainIid.Count - 1;
+                    }
+
+                    if (this.AffectedDomainIid.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the AffectedDomainIid property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.AffectedDomainIid.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the AffectedDomainIid property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.AffectedDomainIid[pd.Lower.Value];
+                    }
+
+                    var affectedDomainIidobjects = new List<Guid>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        affectedDomainIidobjects.Add(this.AffectedDomainIid[i]);
+                    }
+
+                    return affectedDomainIidobjects;
+                case "affecteditemiid":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for the AffectedItemIid property, the lower and upper bound must be specified");
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.AffectedItemIid.Any())
+                    {
+                        return new List<Guid>();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.AffectedItemIid.Count - 1;
+                    }
+
+                    if (this.AffectedItemIid.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the AffectedItemIid property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.AffectedItemIid.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the AffectedItemIid property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.AffectedItemIid[pd.Lower.Value];
+                    }
+
+                    var affectedItemIidobjects = new List<Guid>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        affectedItemIidobjects.Add(this.AffectedItemIid[i]);
+                    }
+
+                    return affectedItemIidobjects;
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Author;
+                    }
+
+                    if (this.Author != null)
+                    {
+                        return this.Author.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelauthor = new Person(Guid.Empty, null, null);
+                    return sentinelauthor.QuerySentinelValue(pd.Next.Input, false);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Content;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.LanguageCode;
+                case "level":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Level;
+                case "logentrychangelogitem":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var logEntryChangelogItemUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && logEntryChangelogItemUpperBound == int.MaxValue && !this.LogEntryChangelogItem.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<LogEntryChangelogItem>();
+                        }
+
+                        var sentinelLogEntryChangelogItem = new LogEntryChangelogItem(Guid.Empty, null, null);
+
+                        return sentinelLogEntryChangelogItem.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        logEntryChangelogItemUpperBound = this.LogEntryChangelogItem.Count - 1;
+                    }
+
+                    if (this.LogEntryChangelogItem.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for LogEntryChangelogItem property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.LogEntryChangelogItem.Count - 1 < logEntryChangelogItemUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the LogEntryChangelogItem property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.LogEntryChangelogItem[pd.Lower.Value];
+                        }
+
+                        return this.LogEntryChangelogItem[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var logEntryChangelogItemObjects = new List<LogEntryChangelogItem>();
+
+                        for (var i = pd.Lower.Value; i < logEntryChangelogItemUpperBound + 1; i++)
+                        {
+                            logEntryChangelogItemObjects.Add(this.LogEntryChangelogItem[i]);
+                        }
+
+                        return logEntryChangelogItemObjects;
+                    }
+
+                    var logEntryChangelogItemNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < logEntryChangelogItemUpperBound + 1; i++)
+                    {
+                        var queryResult = this.LogEntryChangelogItem[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    logEntryChangelogItemNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                logEntryChangelogItemNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return logEntryChangelogItemNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "affecteddomainiid":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<Guid>() : null;
+                case "affecteditemiid":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<Guid>() : null;
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Person(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Person>() : default(Person);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "level":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<LogLevelKind>() : null;
+                case "logentrychangelogitem":
+                    return pd.Next == null ? (object) new List<LogEntryChangelogItem>() : new LogEntryChangelogItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ModelReferenceDataLibraryPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ModelReferenceDataLibraryPropertyAccessor.cs
@@ -1,0 +1,220 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ModelReferenceDataLibraryPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ModelReferenceDataLibrary
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "basequantitykind":
+                    return base.QueryValue(pd.Input);
+                case "baseunit":
+                    return base.QueryValue(pd.Input);
+                case "constant":
+                    return base.QueryValue(pd.Input);
+                case "definedcategory":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "filetype":
+                    return base.QueryValue(pd.Input);
+                case "glossary":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "parametertype":
+                    return base.QueryValue(pd.Input);
+                case "referencesource":
+                    return base.QueryValue(pd.Input);
+                case "requiredrdl":
+                    return base.QueryValue(pd.Input);
+                case "rule":
+                    return base.QueryValue(pd.Input);
+                case "scale":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "unit":
+                    return base.QueryValue(pd.Input);
+                case "unitprefix":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "basequantitykind":
+                    return pd.Next == null ? (object) new List<DerivedQuantityKind>() : new DerivedQuantityKind(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "baseunit":
+                    return pd.Next == null ? (object) new List<DerivedUnit>() : new DerivedUnit(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "constant":
+                    return pd.Next == null ? (object) new List<Constant>() : new Constant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definedcategory":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "filetype":
+                    return pd.Next == null ? (object) new List<FileType>() : new FileType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "glossary":
+                    return pd.Next == null ? (object) new List<Glossary>() : new Glossary(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "parametertype":
+                    return pd.Next == null ? (object) new List<CompoundParameterType>() : new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "referencesource":
+                    return pd.Next == null ? (object) new List<ReferenceSource>() : new ReferenceSource(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "requiredrdl":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new SiteReferenceDataLibrary(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<SiteReferenceDataLibrary>() : default(SiteReferenceDataLibrary);
+                case "rule":
+                    return pd.Next == null ? (object) new List<BinaryRelationshipRule>() : new BinaryRelationshipRule(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "scale":
+                    return pd.Next == null ? (object) new List<IntervalScale>() : new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "unit":
+                    return pd.Next == null ? (object) new List<DerivedUnit>() : new DerivedUnit(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "unitprefix":
+                    return pd.Next == null ? (object) new List<UnitPrefix>() : new UnitPrefix(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ModellingAnnotationItemPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ModellingAnnotationItemPropertyAccessor.cs
@@ -1,0 +1,373 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ModellingAnnotationItemPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ModellingAnnotationItem
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "approvedby":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var approvedByUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && approvedByUpperBound == int.MaxValue && !this.ApprovedBy.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Approval>();
+                        }
+
+                        var sentinelApproval = new Approval(Guid.Empty, null, null);
+
+                        return sentinelApproval.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        approvedByUpperBound = this.ApprovedBy.Count - 1;
+                    }
+
+                    if (this.ApprovedBy.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ApprovedBy property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ApprovedBy.Count - 1 < approvedByUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ApprovedBy property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ApprovedBy[pd.Lower.Value];
+                        }
+
+                        return this.ApprovedBy[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var approvedByObjects = new List<Approval>();
+
+                        for (var i = pd.Lower.Value; i < approvedByUpperBound + 1; i++)
+                        {
+                            approvedByObjects.Add(this.ApprovedBy[i]);
+                        }
+
+                        return approvedByObjects;
+                    }
+
+                    var approvedByNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < approvedByUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ApprovedBy[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    approvedByNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                approvedByNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return approvedByNextObjects;
+                case "author":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "classification":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Classification;
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "discussion":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "primaryannotatedthing":
+                    return base.QueryValue(pd.Input);
+                case "relatedthing":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                case "sourceannotation":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var sourceAnnotationUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && sourceAnnotationUpperBound == int.MaxValue && !this.SourceAnnotation.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ModellingAnnotationItem>();
+                        }
+
+                        var sentinelModellingAnnotationItem = new ActionItem(Guid.Empty, null, null);
+
+                        return sentinelModellingAnnotationItem.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        sourceAnnotationUpperBound = this.SourceAnnotation.Count - 1;
+                    }
+
+                    if (this.SourceAnnotation.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for SourceAnnotation property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.SourceAnnotation.Count - 1 < sourceAnnotationUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the SourceAnnotation property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.SourceAnnotation[pd.Lower.Value];
+                        }
+
+                        return this.SourceAnnotation[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var sourceAnnotationObjects = new List<ModellingAnnotationItem>();
+
+                        for (var i = pd.Lower.Value; i < sourceAnnotationUpperBound + 1; i++)
+                        {
+                            sourceAnnotationObjects.Add(this.SourceAnnotation[i]);
+                        }
+
+                        return sourceAnnotationObjects;
+                    }
+
+                    var sourceAnnotationNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < sourceAnnotationUpperBound + 1; i++)
+                    {
+                        var queryResult = this.SourceAnnotation[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    sourceAnnotationNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                sourceAnnotationNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return sourceAnnotationNextObjects;
+                case "status":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Status;
+                case "title":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Title;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ModellingThingReferencePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ModellingThingReferencePropertyAccessor.cs
@@ -1,0 +1,155 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ModellingThingReferencePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ModellingThingReference
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "referencedrevisionnumber":
+                    return base.QueryValue(pd.Input);
+                case "referencedthing":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "referencedrevisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "referencedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ActualFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Thing>() : default(Thing);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/MultiRelationshipPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/MultiRelationshipPropertyAccessor.cs
@@ -1,0 +1,245 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="MultiRelationshipPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class MultiRelationship
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "parametervalue":
+                    return base.QueryValue(pd.Input);
+                case "relatedthing":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var relatedThingUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && relatedThingUpperBound == int.MaxValue && !this.RelatedThing.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Thing>();
+                        }
+
+                        var sentinelThing = new ActualFiniteState(Guid.Empty, null, null);
+
+                        return sentinelThing.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        relatedThingUpperBound = this.RelatedThing.Count - 1;
+                    }
+
+                    if (this.RelatedThing.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for RelatedThing property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.RelatedThing.Count - 1 < relatedThingUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the RelatedThing property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.RelatedThing[pd.Lower.Value];
+                        }
+
+                        return this.RelatedThing[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var relatedThingObjects = new List<Thing>();
+
+                        for (var i = pd.Lower.Value; i < relatedThingUpperBound + 1; i++)
+                        {
+                            relatedThingObjects.Add(this.RelatedThing[i]);
+                        }
+
+                        return relatedThingObjects;
+                    }
+
+                    var relatedThingNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < relatedThingUpperBound + 1; i++)
+                    {
+                        var queryResult = this.RelatedThing[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    relatedThingNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                relatedThingNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return relatedThingNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "parametervalue":
+                    return pd.Next == null ? (object) new List<RelationshipParameterValue>() : new RelationshipParameterValue(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "relatedthing":
+                    return pd.Next == null ? (object) new List<ActualFiniteState>() : new ActualFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/MultiRelationshipRulePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/MultiRelationshipRulePropertyAccessor.cs
@@ -1,0 +1,284 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="MultiRelationshipRulePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class MultiRelationshipRule
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "maxrelated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.MaxRelated;
+                case "minrelated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.MinRelated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "relatedcategory":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var relatedCategoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && relatedCategoryUpperBound == int.MaxValue && !this.RelatedCategory.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        relatedCategoryUpperBound = this.RelatedCategory.Count - 1;
+                    }
+
+                    if (this.RelatedCategory.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for RelatedCategory property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.RelatedCategory.Count - 1 < relatedCategoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the RelatedCategory property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.RelatedCategory[pd.Lower.Value];
+                        }
+
+                        return this.RelatedCategory[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var relatedCategoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < relatedCategoryUpperBound + 1; i++)
+                        {
+                            relatedCategoryObjects.Add(this.RelatedCategory[i]);
+                        }
+
+                        return relatedCategoryObjects;
+                    }
+
+                    var relatedCategoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < relatedCategoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.RelatedCategory[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    relatedCategoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                relatedCategoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return relatedCategoryNextObjects;
+                case "relationshipcategory":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.RelationshipCategory;
+                    }
+
+                    if (this.RelationshipCategory != null)
+                    {
+                        return this.RelationshipCategory.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelrelationshipcategory = new Category(Guid.Empty, null, null);
+                    return sentinelrelationshipcategory.QuerySentinelValue(pd.Next.Input, false);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "maxrelated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "minrelated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "relatedcategory":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "relationshipcategory":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Category>() : default(Category);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/NaturalLanguagePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/NaturalLanguagePropertyAccessor.cs
@@ -1,0 +1,157 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="NaturalLanguagePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class NaturalLanguage
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.LanguageCode;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "nativename":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.NativeName;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "nativename":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/NestedElementPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/NestedElementPropertyAccessor.cs
@@ -1,0 +1,369 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="NestedElementPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class NestedElement
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "elementusage":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var elementUsageUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && elementUsageUpperBound == int.MaxValue && !this.ElementUsage.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ElementUsage>();
+                        }
+
+                        var sentinelElementUsage = new ElementUsage(Guid.Empty, null, null);
+
+                        return sentinelElementUsage.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        elementUsageUpperBound = this.ElementUsage.Count - 1;
+                    }
+
+                    if (this.ElementUsage.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ElementUsage property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ElementUsage.Count - 1 < elementUsageUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ElementUsage property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ElementUsage[pd.Lower.Value];
+                        }
+
+                        return this.ElementUsage[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var elementUsageObjects = new List<ElementUsage>();
+
+                        for (var i = pd.Lower.Value; i < elementUsageUpperBound + 1; i++)
+                        {
+                            elementUsageObjects.Add(this.ElementUsage[i]);
+                        }
+
+                        return elementUsageObjects;
+                    }
+
+                    var elementUsageNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < elementUsageUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ElementUsage[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    elementUsageNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                elementUsageNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return elementUsageNextObjects;
+                case "isvolatile":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsVolatile;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "nestedparameter":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var nestedParameterUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && nestedParameterUpperBound == int.MaxValue && !this.NestedParameter.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<NestedParameter>();
+                        }
+
+                        var sentinelNestedParameter = new NestedParameter(Guid.Empty, null, null);
+
+                        return sentinelNestedParameter.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        nestedParameterUpperBound = this.NestedParameter.Count - 1;
+                    }
+
+                    if (this.NestedParameter.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for NestedParameter property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.NestedParameter.Count - 1 < nestedParameterUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the NestedParameter property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.NestedParameter[pd.Lower.Value];
+                        }
+
+                        return this.NestedParameter[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var nestedParameterObjects = new List<NestedParameter>();
+
+                        for (var i = pd.Lower.Value; i < nestedParameterUpperBound + 1; i++)
+                        {
+                            nestedParameterObjects.Add(this.NestedParameter[i]);
+                        }
+
+                        return nestedParameterObjects;
+                    }
+
+                    var nestedParameterNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < nestedParameterUpperBound + 1; i++)
+                    {
+                        var queryResult = this.NestedParameter[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    nestedParameterNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                nestedParameterNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return nestedParameterNextObjects;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "rootelement":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.RootElement;
+                    }
+
+                    if (this.RootElement != null)
+                    {
+                        return this.RootElement.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelrootelement = new ElementDefinition(Guid.Empty, null, null);
+                    return sentinelrootelement.QuerySentinelValue(pd.Next.Input, false);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "elementusage":
+                    return pd.Next == null ? (object) new List<ElementUsage>() : new ElementUsage(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isvolatile":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "nestedparameter":
+                    return pd.Next == null ? (object) new List<NestedParameter>() : new NestedParameter(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "rootelement":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ElementDefinition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ElementDefinition>() : default(ElementDefinition);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/NestedParameterPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/NestedParameterPropertyAccessor.cs
@@ -1,0 +1,235 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="NestedParameterPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class NestedParameter
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "actualstate":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ActualState;
+                    }
+
+                    if (this.ActualState != null)
+                    {
+                        return this.ActualState.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelactualstate = new ActualFiniteState(Guid.Empty, null, null);
+                    return sentinelactualstate.QuerySentinelValue(pd.Next.Input, false);
+                case "actualvalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ActualValue;
+                case "associatedparameter":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.AssociatedParameter;
+                    }
+
+                    if (this.AssociatedParameter != null)
+                    {
+                        return this.AssociatedParameter.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelassociatedparameter = new ParameterSubscription(Guid.Empty, null, null);
+                    return sentinelassociatedparameter.QuerySentinelValue(pd.Next.Input, false);
+                case "formula":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Formula;
+                case "isvolatile":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsVolatile;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "path":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Path;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "actualstate":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ActualFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ActualFiniteState>() : default(ActualFiniteState);
+                case "actualvalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "associatedparameter":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ParameterSubscription(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterBase>() : default(ParameterBase);
+                case "formula":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "isvolatile":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "path":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/NotExpressionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/NotExpressionPropertyAccessor.cs
@@ -1,0 +1,163 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="NotExpressionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class NotExpression
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "term":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Term;
+                    }
+
+                    if (this.Term != null)
+                    {
+                        return this.Term.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelterm = new AndExpression(Guid.Empty, null, null);
+                    return sentinelterm.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "term":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new AndExpression(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<BooleanExpression>() : default(BooleanExpression);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/NotePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/NotePropertyAccessor.cs
@@ -1,0 +1,196 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="NotePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Note
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/OptionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/OptionPropertyAccessor.cs
@@ -1,0 +1,325 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="OptionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Option
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "nestedelement":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var nestedElementUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && nestedElementUpperBound == int.MaxValue && !this.NestedElement.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<NestedElement>();
+                        }
+
+                        var sentinelNestedElement = new NestedElement(Guid.Empty, null, null);
+
+                        return sentinelNestedElement.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        nestedElementUpperBound = this.NestedElement.Count - 1;
+                    }
+
+                    if (this.NestedElement.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for NestedElement property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.NestedElement.Count - 1 < nestedElementUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the NestedElement property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.NestedElement[pd.Lower.Value];
+                        }
+
+                        return this.NestedElement[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var nestedElementObjects = new List<NestedElement>();
+
+                        for (var i = pd.Lower.Value; i < nestedElementUpperBound + 1; i++)
+                        {
+                            nestedElementObjects.Add(this.NestedElement[i]);
+                        }
+
+                        return nestedElementObjects;
+                    }
+
+                    var nestedElementNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < nestedElementUpperBound + 1; i++)
+                    {
+                        var queryResult = this.NestedElement[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    nestedElementNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                nestedElementNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return nestedElementNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "nestedelement":
+                    return pd.Next == null ? (object) new List<NestedElement>() : new NestedElement(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/OrExpressionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/OrExpressionPropertyAccessor.cs
@@ -1,0 +1,221 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="OrExpressionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class OrExpression
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "term":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var termUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && termUpperBound == int.MaxValue && !this.Term.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<BooleanExpression>();
+                        }
+
+                        var sentinelBooleanExpression = new AndExpression(Guid.Empty, null, null);
+
+                        return sentinelBooleanExpression.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        termUpperBound = this.Term.Count - 1;
+                    }
+
+                    if (this.Term.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Term property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Term.Count - 1 < termUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Term property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Term[pd.Lower.Value];
+                        }
+
+                        return this.Term[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var termObjects = new List<BooleanExpression>();
+
+                        for (var i = pd.Lower.Value; i < termUpperBound + 1; i++)
+                        {
+                            termObjects.Add(this.Term[i]);
+                        }
+
+                        return termObjects;
+                    }
+
+                    var termNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < termUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Term[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    termNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                termNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return termNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "term":
+                    return pd.Next == null ? (object) new List<AndExpression>() : new AndExpression(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/OrdinalScalePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/OrdinalScalePropertyAccessor.cs
@@ -1,0 +1,226 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="OrdinalScalePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class OrdinalScale
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "ismaximuminclusive":
+                    return base.QueryValue(pd.Input);
+                case "isminimuminclusive":
+                    return base.QueryValue(pd.Input);
+                case "mappingtoreferencescale":
+                    return base.QueryValue(pd.Input);
+                case "maximumpermissiblevalue":
+                    return base.QueryValue(pd.Input);
+                case "minimumpermissiblevalue":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "negativevalueconnotation":
+                    return base.QueryValue(pd.Input);
+                case "numberset":
+                    return base.QueryValue(pd.Input);
+                case "positivevalueconnotation":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "unit":
+                    return base.QueryValue(pd.Input);
+                case "useshortnamevalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.UseShortNameValues;
+                case "valuedefinition":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "ismaximuminclusive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "isminimuminclusive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "mappingtoreferencescale":
+                    return pd.Next == null ? (object) new List<MappingToReferenceScale>() : new MappingToReferenceScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "maximumpermissiblevalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "minimumpermissiblevalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "negativevalueconnotation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberset":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<NumberSetKind>() : null;
+                case "positivevalueconnotation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "unit":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DerivedUnit(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementUnit>() : default(MeasurementUnit);
+                case "useshortnamevalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "valuedefinition":
+                    return pd.Next == null ? (object) new List<ScaleValueDefinition>() : new ScaleValueDefinition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/OrganizationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/OrganizationPropertyAccessor.cs
@@ -1,0 +1,157 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="OrganizationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Organization
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/OrganizationalParticipantPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/OrganizationalParticipantPropertyAccessor.cs
@@ -1,0 +1,163 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="OrganizationalParticipantPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class OrganizationalParticipant
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "organization":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Organization;
+                    }
+
+                    if (this.Organization != null)
+                    {
+                        return this.Organization.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelorganization = new Organization(Guid.Empty, null, null);
+                    return sentinelorganization.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "organization":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Organization(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Organization>() : default(Organization);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/OwnedStylePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/OwnedStylePropertyAccessor.cs
@@ -1,0 +1,226 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="OwnedStylePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.DiagramData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class OwnedStyle
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "fillcolor":
+                    return base.QueryValue(pd.Input);
+                case "fillopacity":
+                    return base.QueryValue(pd.Input);
+                case "fontbold":
+                    return base.QueryValue(pd.Input);
+                case "fontcolor":
+                    return base.QueryValue(pd.Input);
+                case "fontitalic":
+                    return base.QueryValue(pd.Input);
+                case "fontname":
+                    return base.QueryValue(pd.Input);
+                case "fontsize":
+                    return base.QueryValue(pd.Input);
+                case "fontstrokethrough":
+                    return base.QueryValue(pd.Input);
+                case "fontunderline":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "strokecolor":
+                    return base.QueryValue(pd.Input);
+                case "strokeopacity":
+                    return base.QueryValue(pd.Input);
+                case "strokewidth":
+                    return base.QueryValue(pd.Input);
+                case "usedcolor":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "fillcolor":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Color(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Color>() : default(Color);
+                case "fillopacity":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                case "fontbold":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "fontcolor":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Color(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Color>() : default(Color);
+                case "fontitalic":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "fontname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "fontsize":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                case "fontstrokethrough":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "fontunderline":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "strokecolor":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Color(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Color>() : default(Color);
+                case "strokeopacity":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                case "strokewidth":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                case "usedcolor":
+                    return pd.Next == null ? (object) new List<Color>() : new Color(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/PagePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/PagePropertyAccessor.cs
@@ -1,0 +1,345 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PagePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Page
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "note":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var noteUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && noteUpperBound == int.MaxValue && !this.Note.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Note>();
+                        }
+
+                        var sentinelNote = new BinaryNote(Guid.Empty, null, null);
+
+                        return sentinelNote.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        noteUpperBound = this.Note.Count - 1;
+                    }
+
+                    if (this.Note.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Note property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Note.Count - 1 < noteUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Note property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Note[pd.Lower.Value];
+                        }
+
+                        return this.Note[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var noteObjects = new List<Note>();
+
+                        for (var i = pd.Lower.Value; i < noteUpperBound + 1; i++)
+                        {
+                            noteObjects.Add(this.Note[i]);
+                        }
+
+                        return noteObjects;
+                    }
+
+                    var noteNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < noteUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Note[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    noteNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                noteNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return noteNextObjects;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "note":
+                    return pd.Next == null ? (object) new List<BinaryNote>() : new BinaryNote(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterBasePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterBasePropertyAccessor.cs
@@ -1,0 +1,170 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterBasePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParameterBase
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "group":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Group;
+                    }
+
+                    if (this.Group != null)
+                    {
+                        return this.Group.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelgroup = new ParameterGroup(Guid.Empty, null, null);
+                    return sentinelgroup.QuerySentinelValue(pd.Next.Input, false);
+                case "isoptiondependent":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsOptionDependent;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ParameterType;
+                    }
+
+                    if (this.ParameterType != null)
+                    {
+                        return this.ParameterType.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelparametertype = new CompoundParameterType(Guid.Empty, null, null);
+                    return sentinelparametertype.QuerySentinelValue(pd.Next.Input, false);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Scale;
+                    }
+
+                    if (this.Scale != null)
+                    {
+                        return this.Scale.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelscale = new IntervalScale(Guid.Empty, null, null);
+                    return sentinelscale.QuerySentinelValue(pd.Next.Input, false);
+                case "statedependence":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.StateDependence;
+                    }
+
+                    if (this.StateDependence != null)
+                    {
+                        return this.StateDependence.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelstatedependence = new ActualFiniteStateList(Guid.Empty, null, null);
+                    return sentinelstatedependence.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterGroupPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterGroupPropertyAccessor.cs
@@ -1,0 +1,169 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterGroupPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParameterGroup
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "containinggroup":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ContainingGroup;
+                    }
+
+                    if (this.ContainingGroup != null)
+                    {
+                        return this.ContainingGroup.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelcontaininggroup = new ParameterGroup(Guid.Empty, null, null);
+                    return sentinelcontaininggroup.QuerySentinelValue(pd.Next.Input, false);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "containinggroup":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ParameterGroup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterGroup>() : default(ParameterGroup);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterOrOverrideBasePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterOrOverrideBasePropertyAccessor.cs
@@ -1,0 +1,184 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterOrOverrideBasePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParameterOrOverrideBase
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "group":
+                    return base.QueryValue(pd.Input);
+                case "isoptiondependent":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "parametersubscription":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var parameterSubscriptionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && parameterSubscriptionUpperBound == int.MaxValue && !this.ParameterSubscription.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ParameterSubscription>();
+                        }
+
+                        var sentinelParameterSubscription = new ParameterSubscription(Guid.Empty, null, null);
+
+                        return sentinelParameterSubscription.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        parameterSubscriptionUpperBound = this.ParameterSubscription.Count - 1;
+                    }
+
+                    if (this.ParameterSubscription.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ParameterSubscription property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ParameterSubscription.Count - 1 < parameterSubscriptionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ParameterSubscription property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ParameterSubscription[pd.Lower.Value];
+                        }
+
+                        return this.ParameterSubscription[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var parameterSubscriptionObjects = new List<ParameterSubscription>();
+
+                        for (var i = pd.Lower.Value; i < parameterSubscriptionUpperBound + 1; i++)
+                        {
+                            parameterSubscriptionObjects.Add(this.ParameterSubscription[i]);
+                        }
+
+                        return parameterSubscriptionObjects;
+                    }
+
+                    var parameterSubscriptionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < parameterSubscriptionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ParameterSubscription[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    parameterSubscriptionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                parameterSubscriptionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return parameterSubscriptionNextObjects;
+                case "parametertype":
+                    return base.QueryValue(pd.Input);
+                case "scale":
+                    return base.QueryValue(pd.Input);
+                case "statedependence":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterOverridePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterOverridePropertyAccessor.cs
@@ -1,0 +1,362 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterOverridePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParameterOverride
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "group":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Group;
+                    }
+
+                    if (this.Group != null)
+                    {
+                        return this.Group.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelgroup = new ParameterGroup(Guid.Empty, null, null);
+                    return sentinelgroup.QuerySentinelValue(pd.Next.Input, false);
+                case "isoptiondependent":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsOptionDependent;
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "parameter":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Parameter;
+                    }
+
+                    if (this.Parameter != null)
+                    {
+                        return this.Parameter.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelparameter = new Parameter(Guid.Empty, null, null);
+                    return sentinelparameter.QuerySentinelValue(pd.Next.Input, false);
+                case "parametersubscription":
+                    return base.QueryValue(pd.Input);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ParameterType;
+                    }
+
+                    if (this.ParameterType != null)
+                    {
+                        return this.ParameterType.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelparametertype = new CompoundParameterType(Guid.Empty, null, null);
+                    return sentinelparametertype.QuerySentinelValue(pd.Next.Input, false);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Scale;
+                    }
+
+                    if (this.Scale != null)
+                    {
+                        return this.Scale.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelscale = new IntervalScale(Guid.Empty, null, null);
+                    return sentinelscale.QuerySentinelValue(pd.Next.Input, false);
+                case "statedependence":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.StateDependence;
+                    }
+
+                    if (this.StateDependence != null)
+                    {
+                        return this.StateDependence.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelstatedependence = new ActualFiniteStateList(Guid.Empty, null, null);
+                    return sentinelstatedependence.QuerySentinelValue(pd.Next.Input, false);
+                case "valueset":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var valueSetUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && valueSetUpperBound == int.MaxValue && !this.ValueSet.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ParameterOverrideValueSet>();
+                        }
+
+                        var sentinelParameterOverrideValueSet = new ParameterOverrideValueSet(Guid.Empty, null, null);
+
+                        return sentinelParameterOverrideValueSet.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        valueSetUpperBound = this.ValueSet.Count - 1;
+                    }
+
+                    if (this.ValueSet.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ValueSet property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ValueSet.Count - 1 < valueSetUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ValueSet property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ValueSet[pd.Lower.Value];
+                        }
+
+                        return this.ValueSet[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var valueSetObjects = new List<ParameterOverrideValueSet>();
+
+                        for (var i = pd.Lower.Value; i < valueSetUpperBound + 1; i++)
+                        {
+                            valueSetObjects.Add(this.ValueSet[i]);
+                        }
+
+                        return valueSetObjects;
+                    }
+
+                    var valueSetNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < valueSetUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ValueSet[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    valueSetNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                valueSetNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return valueSetNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "group":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ParameterGroup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterGroup>() : default(ParameterGroup);
+                case "isoptiondependent":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "parameter":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Parameter(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Parameter>() : default(Parameter);
+                case "parametersubscription":
+                    return pd.Next == null ? (object) new List<ParameterSubscription>() : new ParameterSubscription(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterType>() : default(ParameterType);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "statedependence":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ActualFiniteStateList(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ActualFiniteStateList>() : default(ActualFiniteStateList);
+                case "valueset":
+                    return pd.Next == null ? (object) new List<ParameterOverrideValueSet>() : new ParameterOverrideValueSet(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterOverrideValueSetPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterOverrideValueSetPropertyAccessor.cs
@@ -1,0 +1,257 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterOverrideValueSetPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParameterOverrideValueSet
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "actualoption":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ActualOption;
+                    }
+
+                    if (this.ActualOption != null)
+                    {
+                        return this.ActualOption.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelactualoption = new Option(Guid.Empty, null, null);
+                    return sentinelactualoption.QuerySentinelValue(pd.Next.Input, false);
+                case "actualstate":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ActualState;
+                    }
+
+                    if (this.ActualState != null)
+                    {
+                        return this.ActualState.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelactualstate = new ActualFiniteState(Guid.Empty, null, null);
+                    return sentinelactualstate.QuerySentinelValue(pd.Next.Input, false);
+                case "actualvalue":
+                    return base.QueryValue(pd.Input);
+                case "computed":
+                    return base.QueryValue(pd.Input);
+                case "formula":
+                    return base.QueryValue(pd.Input);
+                case "manual":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "parametervalueset":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ParameterValueSet;
+                    }
+
+                    if (this.ParameterValueSet != null)
+                    {
+                        return this.ParameterValueSet.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelparametervalueset = new ParameterValueSet(Guid.Empty, null, null);
+                    return sentinelparametervalueset.QuerySentinelValue(pd.Next.Input, false);
+                case "published":
+                    return base.QueryValue(pd.Input);
+                case "reference":
+                    return base.QueryValue(pd.Input);
+                case "valueswitch":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "actualoption":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Option(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Option>() : default(Option);
+                case "actualstate":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ActualFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ActualFiniteState>() : default(ActualFiniteState);
+                case "actualvalue":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "computed":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "formula":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "manual":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "parametervalueset":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ParameterValueSet(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterValueSet>() : default(ParameterValueSet);
+                case "published":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "reference":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "valueswitch":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ParameterSwitchKind>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterPropertyAccessor.cs
@@ -1,0 +1,321 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Parameter
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "allowdifferentownerofoverride":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.AllowDifferentOwnerOfOverride;
+                case "expectsoverride":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ExpectsOverride;
+                case "group":
+                    return base.QueryValue(pd.Input);
+                case "isoptiondependent":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "parametersubscription":
+                    return base.QueryValue(pd.Input);
+                case "parametertype":
+                    return base.QueryValue(pd.Input);
+                case "requestedby":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.RequestedBy;
+                    }
+
+                    if (this.RequestedBy != null)
+                    {
+                        return this.RequestedBy.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelrequestedby = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelrequestedby.QuerySentinelValue(pd.Next.Input, false);
+                case "scale":
+                    return base.QueryValue(pd.Input);
+                case "statedependence":
+                    return base.QueryValue(pd.Input);
+                case "valueset":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var valueSetUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && valueSetUpperBound == int.MaxValue && !this.ValueSet.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ParameterValueSet>();
+                        }
+
+                        var sentinelParameterValueSet = new ParameterValueSet(Guid.Empty, null, null);
+
+                        return sentinelParameterValueSet.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        valueSetUpperBound = this.ValueSet.Count - 1;
+                    }
+
+                    if (this.ValueSet.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ValueSet property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ValueSet.Count - 1 < valueSetUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ValueSet property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ValueSet[pd.Lower.Value];
+                        }
+
+                        return this.ValueSet[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var valueSetObjects = new List<ParameterValueSet>();
+
+                        for (var i = pd.Lower.Value; i < valueSetUpperBound + 1; i++)
+                        {
+                            valueSetObjects.Add(this.ValueSet[i]);
+                        }
+
+                        return valueSetObjects;
+                    }
+
+                    var valueSetNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < valueSetUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ValueSet[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    valueSetNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                valueSetNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return valueSetNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "allowdifferentownerofoverride":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "expectsoverride":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "group":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ParameterGroup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterGroup>() : default(ParameterGroup);
+                case "isoptiondependent":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "parametersubscription":
+                    return pd.Next == null ? (object) new List<ParameterSubscription>() : new ParameterSubscription(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterType>() : default(ParameterType);
+                case "requestedby":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "statedependence":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ActualFiniteStateList(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ActualFiniteStateList>() : default(ActualFiniteStateList);
+                case "valueset":
+                    return pd.Next == null ? (object) new List<ParameterValueSet>() : new ParameterValueSet(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterSubscriptionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterSubscriptionPropertyAccessor.cs
@@ -1,0 +1,334 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterSubscriptionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParameterSubscription
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "group":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Group;
+                    }
+
+                    if (this.Group != null)
+                    {
+                        return this.Group.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelgroup = new ParameterGroup(Guid.Empty, null, null);
+                    return sentinelgroup.QuerySentinelValue(pd.Next.Input, false);
+                case "isoptiondependent":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsOptionDependent;
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ParameterType;
+                    }
+
+                    if (this.ParameterType != null)
+                    {
+                        return this.ParameterType.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelparametertype = new CompoundParameterType(Guid.Empty, null, null);
+                    return sentinelparametertype.QuerySentinelValue(pd.Next.Input, false);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Scale;
+                    }
+
+                    if (this.Scale != null)
+                    {
+                        return this.Scale.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelscale = new IntervalScale(Guid.Empty, null, null);
+                    return sentinelscale.QuerySentinelValue(pd.Next.Input, false);
+                case "statedependence":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.StateDependence;
+                    }
+
+                    if (this.StateDependence != null)
+                    {
+                        return this.StateDependence.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelstatedependence = new ActualFiniteStateList(Guid.Empty, null, null);
+                    return sentinelstatedependence.QuerySentinelValue(pd.Next.Input, false);
+                case "valueset":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var valueSetUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && valueSetUpperBound == int.MaxValue && !this.ValueSet.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ParameterSubscriptionValueSet>();
+                        }
+
+                        var sentinelParameterSubscriptionValueSet = new ParameterSubscriptionValueSet(Guid.Empty, null, null);
+
+                        return sentinelParameterSubscriptionValueSet.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        valueSetUpperBound = this.ValueSet.Count - 1;
+                    }
+
+                    if (this.ValueSet.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ValueSet property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ValueSet.Count - 1 < valueSetUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ValueSet property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ValueSet[pd.Lower.Value];
+                        }
+
+                        return this.ValueSet[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var valueSetObjects = new List<ParameterSubscriptionValueSet>();
+
+                        for (var i = pd.Lower.Value; i < valueSetUpperBound + 1; i++)
+                        {
+                            valueSetObjects.Add(this.ValueSet[i]);
+                        }
+
+                        return valueSetObjects;
+                    }
+
+                    var valueSetNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < valueSetUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ValueSet[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    valueSetNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                valueSetNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return valueSetNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "group":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ParameterGroup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterGroup>() : default(ParameterGroup);
+                case "isoptiondependent":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterType>() : default(ParameterType);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "statedependence":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ActualFiniteStateList(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ActualFiniteStateList>() : default(ActualFiniteStateList);
+                case "valueset":
+                    return pd.Next == null ? (object) new List<ParameterSubscriptionValueSet>() : new ParameterSubscriptionValueSet(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterSubscriptionValueSetPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterSubscriptionValueSetPropertyAccessor.cs
@@ -1,0 +1,449 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterSubscriptionValueSetPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParameterSubscriptionValueSet
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "actualoption":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ActualOption;
+                    }
+
+                    if (this.ActualOption != null)
+                    {
+                        return this.ActualOption.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelactualoption = new Option(Guid.Empty, null, null);
+                    return sentinelactualoption.QuerySentinelValue(pd.Next.Input, false);
+                case "actualstate":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ActualState;
+                    }
+
+                    if (this.ActualState != null)
+                    {
+                        return this.ActualState.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelactualstate = new ActualFiniteState(Guid.Empty, null, null);
+                    return sentinelactualstate.QuerySentinelValue(pd.Next.Input, false);
+                case "actualvalue":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for ActualValue property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for ActualValue property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.ActualValue.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.ActualValue.Any())
+                    {
+                        return this.ActualValue.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.ActualValue.Count - 1;
+                    }
+
+                    if (this.ActualValue.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ActualValue property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ActualValue.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ActualValue property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.ActualValue[pd.Lower.Value];
+                    }
+
+                    var actualValueObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        actualValueObjects.Add(this.ActualValue[i]);
+                    }
+
+                    return actualValueObjects;
+                case "computed":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for Computed property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for Computed property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Computed.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.Computed.Any())
+                    {
+                        return this.Computed.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Computed.Count - 1;
+                    }
+
+                    if (this.Computed.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Computed property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Computed.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Computed property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Computed[pd.Lower.Value];
+                    }
+
+                    var computedObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        computedObjects.Add(this.Computed[i]);
+                    }
+
+                    return computedObjects;
+                case "manual":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for Manual property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for Manual property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Manual.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.Manual.Any())
+                    {
+                        return this.Manual.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Manual.Count - 1;
+                    }
+
+                    if (this.Manual.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Manual property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Manual.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Manual property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Manual[pd.Lower.Value];
+                    }
+
+                    var manualObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        manualObjects.Add(this.Manual[i]);
+                    }
+
+                    return manualObjects;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "reference":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for Reference property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for Reference property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Reference.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.Reference.Any())
+                    {
+                        return this.Reference.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Reference.Count - 1;
+                    }
+
+                    if (this.Reference.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Reference property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Reference.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Reference property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Reference[pd.Lower.Value];
+                    }
+
+                    var referenceObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        referenceObjects.Add(this.Reference[i]);
+                    }
+
+                    return referenceObjects;
+                case "subscribedvalueset":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.SubscribedValueSet;
+                    }
+
+                    if (this.SubscribedValueSet != null)
+                    {
+                        return this.SubscribedValueSet.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelsubscribedvalueset = new ParameterOverrideValueSet(Guid.Empty, null, null);
+                    return sentinelsubscribedvalueset.QuerySentinelValue(pd.Next.Input, false);
+                case "valueswitch":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ValueSwitch;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "actualoption":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Option(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Option>() : default(Option);
+                case "actualstate":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ActualFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ActualFiniteState>() : default(ActualFiniteState);
+                case "actualvalue":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "computed":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "manual":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "reference":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "subscribedvalueset":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ParameterOverrideValueSet(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterValueSetBase>() : default(ParameterValueSetBase);
+                case "valueswitch":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ParameterSwitchKind>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterTypeComponentPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterTypeComponentPropertyAccessor.cs
@@ -1,0 +1,193 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterTypeComponentPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParameterTypeComponent
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ParameterType;
+                    }
+
+                    if (this.ParameterType != null)
+                    {
+                        return this.ParameterType.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelparametertype = new CompoundParameterType(Guid.Empty, null, null);
+                    return sentinelparametertype.QuerySentinelValue(pd.Next.Input, false);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Scale;
+                    }
+
+                    if (this.Scale != null)
+                    {
+                        return this.Scale.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelscale = new IntervalScale(Guid.Empty, null, null);
+                    return sentinelscale.QuerySentinelValue(pd.Next.Input, false);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterType>() : default(ParameterType);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterTypePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterTypePropertyAccessor.cs
@@ -1,0 +1,191 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterTypePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParameterType
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.NumberOfValues;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Symbol;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterValuePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterValuePropertyAccessor.cs
@@ -1,0 +1,171 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterValuePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParameterValue
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ParameterType;
+                    }
+
+                    if (this.ParameterType != null)
+                    {
+                        return this.ParameterType.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelparametertype = new CompoundParameterType(Guid.Empty, null, null);
+                    return sentinelparametertype.QuerySentinelValue(pd.Next.Input, false);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Scale;
+                    }
+
+                    if (this.Scale != null)
+                    {
+                        return this.Scale.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelscale = new IntervalScale(Guid.Empty, null, null);
+                    return sentinelscale.QuerySentinelValue(pd.Next.Input, false);
+                case "value":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for Value property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for Value property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Value.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.Value.Any())
+                    {
+                        return this.Value.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Value.Count - 1;
+                    }
+
+                    if (this.Value.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Value property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Value.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Value property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Value[pd.Lower.Value];
+                    }
+
+                    var valueObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        valueObjects.Add(this.Value[i]);
+                    }
+
+                    return valueObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterValueSetBasePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterValueSetBasePropertyAccessor.cs
@@ -1,0 +1,434 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterValueSetBasePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParameterValueSetBase
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "actualoption":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ActualOption;
+                    }
+
+                    if (this.ActualOption != null)
+                    {
+                        return this.ActualOption.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelactualoption = new Option(Guid.Empty, null, null);
+                    return sentinelactualoption.QuerySentinelValue(pd.Next.Input, false);
+                case "actualstate":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ActualState;
+                    }
+
+                    if (this.ActualState != null)
+                    {
+                        return this.ActualState.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelactualstate = new ActualFiniteState(Guid.Empty, null, null);
+                    return sentinelactualstate.QuerySentinelValue(pd.Next.Input, false);
+                case "actualvalue":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for ActualValue property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for ActualValue property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.ActualValue.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.ActualValue.Any())
+                    {
+                        return this.ActualValue.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.ActualValue.Count - 1;
+                    }
+
+                    if (this.ActualValue.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ActualValue property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ActualValue.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ActualValue property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.ActualValue[pd.Lower.Value];
+                    }
+
+                    var actualValueObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        actualValueObjects.Add(this.ActualValue[i]);
+                    }
+
+                    return actualValueObjects;
+                case "computed":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for Computed property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for Computed property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Computed.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.Computed.Any())
+                    {
+                        return this.Computed.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Computed.Count - 1;
+                    }
+
+                    if (this.Computed.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Computed property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Computed.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Computed property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Computed[pd.Lower.Value];
+                    }
+
+                    var computedObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        computedObjects.Add(this.Computed[i]);
+                    }
+
+                    return computedObjects;
+                case "formula":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for Formula property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for Formula property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Formula.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.Formula.Any())
+                    {
+                        return this.Formula.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Formula.Count - 1;
+                    }
+
+                    if (this.Formula.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Formula property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Formula.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Formula property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Formula[pd.Lower.Value];
+                    }
+
+                    var formulaObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        formulaObjects.Add(this.Formula[i]);
+                    }
+
+                    return formulaObjects;
+                case "manual":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for Manual property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for Manual property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Manual.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.Manual.Any())
+                    {
+                        return this.Manual.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Manual.Count - 1;
+                    }
+
+                    if (this.Manual.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Manual property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Manual.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Manual property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Manual[pd.Lower.Value];
+                    }
+
+                    var manualObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        manualObjects.Add(this.Manual[i]);
+                    }
+
+                    return manualObjects;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "published":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for Published property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for Published property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Published.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.Published.Any())
+                    {
+                        return this.Published.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Published.Count - 1;
+                    }
+
+                    if (this.Published.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Published property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Published.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Published property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Published[pd.Lower.Value];
+                    }
+
+                    var publishedObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        publishedObjects.Add(this.Published[i]);
+                    }
+
+                    return publishedObjects;
+                case "reference":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for Reference property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for Reference property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Reference.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.Reference.Any())
+                    {
+                        return this.Reference.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Reference.Count - 1;
+                    }
+
+                    if (this.Reference.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Reference property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Reference.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Reference property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Reference[pd.Lower.Value];
+                    }
+
+                    var referenceObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        referenceObjects.Add(this.Reference[i]);
+                    }
+
+                    return referenceObjects;
+                case "valueswitch":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ValueSwitch;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterValueSetPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterValueSetPropertyAccessor.cs
@@ -1,0 +1,207 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterValueSetPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParameterValueSet
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "actualoption":
+                    return base.QueryValue(pd.Input);
+                case "actualstate":
+                    return base.QueryValue(pd.Input);
+                case "actualvalue":
+                    return base.QueryValue(pd.Input);
+                case "computed":
+                    return base.QueryValue(pd.Input);
+                case "formula":
+                    return base.QueryValue(pd.Input);
+                case "manual":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "published":
+                    return base.QueryValue(pd.Input);
+                case "reference":
+                    return base.QueryValue(pd.Input);
+                case "valueswitch":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "actualoption":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Option(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Option>() : default(Option);
+                case "actualstate":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ActualFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ActualFiniteState>() : default(ActualFiniteState);
+                case "actualvalue":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "computed":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "formula":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "manual":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "published":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "reference":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "valueswitch":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ParameterSwitchKind>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParameterizedCategoryRulePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParameterizedCategoryRulePropertyAccessor.cs
@@ -1,0 +1,272 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParameterizedCategoryRulePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParameterizedCategoryRule
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Category;
+                    }
+
+                    if (this.Category != null)
+                    {
+                        return this.Category.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelcategory = new Category(Guid.Empty, null, null);
+                    return sentinelcategory.QuerySentinelValue(pd.Next.Input, false);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var parameterTypeUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && parameterTypeUpperBound == int.MaxValue && !this.ParameterType.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ParameterType>();
+                        }
+
+                        var sentinelParameterType = new CompoundParameterType(Guid.Empty, null, null);
+
+                        return sentinelParameterType.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        parameterTypeUpperBound = this.ParameterType.Count - 1;
+                    }
+
+                    if (this.ParameterType.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ParameterType property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ParameterType.Count - 1 < parameterTypeUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ParameterType property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ParameterType[pd.Lower.Value];
+                        }
+
+                        return this.ParameterType[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var parameterTypeObjects = new List<ParameterType>();
+
+                        for (var i = pd.Lower.Value; i < parameterTypeUpperBound + 1; i++)
+                        {
+                            parameterTypeObjects.Add(this.ParameterType[i]);
+                        }
+
+                        return parameterTypeObjects;
+                    }
+
+                    var parameterTypeNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < parameterTypeUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ParameterType[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    parameterTypeNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                parameterTypeNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return parameterTypeNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Category>() : default(Category);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "parametertype":
+                    return pd.Next == null ? (object) new List<CompoundParameterType>() : new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParametricConstraintPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParametricConstraintPropertyAccessor.cs
@@ -1,0 +1,269 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParametricConstraintPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParametricConstraint
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "expression":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var expressionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && expressionUpperBound == int.MaxValue && !this.Expression.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<BooleanExpression>();
+                        }
+
+                        var sentinelBooleanExpression = new AndExpression(Guid.Empty, null, null);
+
+                        return sentinelBooleanExpression.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        expressionUpperBound = this.Expression.Count - 1;
+                    }
+
+                    if (this.Expression.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Expression property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Expression.Count - 1 < expressionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Expression property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Expression[pd.Lower.Value];
+                        }
+
+                        return this.Expression[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var expressionObjects = new List<BooleanExpression>();
+
+                        for (var i = pd.Lower.Value; i < expressionUpperBound + 1; i++)
+                        {
+                            expressionObjects.Add(this.Expression[i]);
+                        }
+
+                        return expressionObjects;
+                    }
+
+                    var expressionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < expressionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Expression[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    expressionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                expressionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return expressionNextObjects;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "topexpression":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.TopExpression;
+                    }
+
+                    if (this.TopExpression != null)
+                    {
+                        return this.TopExpression.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineltopexpression = new AndExpression(Guid.Empty, null, null);
+                    return sentineltopexpression.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "expression":
+                    return pd.Next == null ? (object) new List<AndExpression>() : new AndExpression(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "topexpression":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new AndExpression(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<BooleanExpression>() : default(BooleanExpression);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParticipantPermissionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParticipantPermissionPropertyAccessor.cs
@@ -1,0 +1,157 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParticipantPermissionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParticipantPermission
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "accessright":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.AccessRight;
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "objectclass":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ObjectClass;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "accessright":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ParticipantAccessRightKind>() : null;
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "objectclass":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParticipantPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParticipantPropertyAccessor.cs
@@ -1,0 +1,299 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParticipantPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Participant
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "domain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var domainUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && domainUpperBound == int.MaxValue && !this.Domain.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<DomainOfExpertise>();
+                        }
+
+                        var sentinelDomainOfExpertise = new DomainOfExpertise(Guid.Empty, null, null);
+
+                        return sentinelDomainOfExpertise.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        domainUpperBound = this.Domain.Count - 1;
+                    }
+
+                    if (this.Domain.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Domain property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Domain.Count - 1 < domainUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Domain property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Domain[pd.Lower.Value];
+                        }
+
+                        return this.Domain[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var domainObjects = new List<DomainOfExpertise>();
+
+                        for (var i = pd.Lower.Value; i < domainUpperBound + 1; i++)
+                        {
+                            domainObjects.Add(this.Domain[i]);
+                        }
+
+                        return domainObjects;
+                    }
+
+                    var domainNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < domainUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Domain[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    domainNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                domainNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return domainNextObjects;
+                case "isactive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsActive;
+                case "person":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Person;
+                    }
+
+                    if (this.Person != null)
+                    {
+                        return this.Person.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelperson = new Person(Guid.Empty, null, null);
+                    return sentinelperson.QuerySentinelValue(pd.Next.Input, false);
+                case "role":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Role;
+                    }
+
+                    if (this.Role != null)
+                    {
+                        return this.Role.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelrole = new ParticipantRole(Guid.Empty, null, null);
+                    return sentinelrole.QuerySentinelValue(pd.Next.Input, false);
+                case "selecteddomain":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.SelectedDomain;
+                    }
+
+                    if (this.SelectedDomain != null)
+                    {
+                        return this.SelectedDomain.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelselecteddomain = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelselecteddomain.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "domain":
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isactive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "person":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Person(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Person>() : default(Person);
+                case "role":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ParticipantRole(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParticipantRole>() : default(ParticipantRole);
+                case "selecteddomain":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ParticipantRolePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ParticipantRolePropertyAccessor.cs
@@ -1,0 +1,249 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ParticipantRolePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ParticipantRole
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "participantpermission":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var participantPermissionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && participantPermissionUpperBound == int.MaxValue && !this.ParticipantPermission.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ParticipantPermission>();
+                        }
+
+                        var sentinelParticipantPermission = new ParticipantPermission(Guid.Empty, null, null);
+
+                        return sentinelParticipantPermission.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        participantPermissionUpperBound = this.ParticipantPermission.Count - 1;
+                    }
+
+                    if (this.ParticipantPermission.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ParticipantPermission property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ParticipantPermission.Count - 1 < participantPermissionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ParticipantPermission property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ParticipantPermission[pd.Lower.Value];
+                        }
+
+                        return this.ParticipantPermission[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var participantPermissionObjects = new List<ParticipantPermission>();
+
+                        for (var i = pd.Lower.Value; i < participantPermissionUpperBound + 1; i++)
+                        {
+                            participantPermissionObjects.Add(this.ParticipantPermission[i]);
+                        }
+
+                        return participantPermissionObjects;
+                    }
+
+                    var participantPermissionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < participantPermissionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ParticipantPermission[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    participantPermissionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                participantPermissionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return participantPermissionNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "participantpermission":
+                    return pd.Next == null ? (object) new List<ParticipantPermission>() : new ParticipantPermission(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/PersonPermissionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/PersonPermissionPropertyAccessor.cs
@@ -1,0 +1,157 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PersonPermissionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class PersonPermission
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "accessright":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.AccessRight;
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "objectclass":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ObjectClass;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "accessright":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<PersonAccessRightKind>() : null;
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "objectclass":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/PersonPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/PersonPropertyAccessor.cs
@@ -1,0 +1,553 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PersonPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Person
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "defaultdomain":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.DefaultDomain;
+                    }
+
+                    if (this.DefaultDomain != null)
+                    {
+                        return this.DefaultDomain.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineldefaultdomain = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentineldefaultdomain.QuerySentinelValue(pd.Next.Input, false);
+                case "defaultemailaddress":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.DefaultEmailAddress;
+                    }
+
+                    if (this.DefaultEmailAddress != null)
+                    {
+                        return this.DefaultEmailAddress.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineldefaultemailaddress = new EmailAddress(Guid.Empty, null, null);
+                    return sentineldefaultemailaddress.QuerySentinelValue(pd.Next.Input, false);
+                case "defaulttelephonenumber":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.DefaultTelephoneNumber;
+                    }
+
+                    if (this.DefaultTelephoneNumber != null)
+                    {
+                        return this.DefaultTelephoneNumber.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineldefaulttelephonenumber = new TelephoneNumber(Guid.Empty, null, null);
+                    return sentineldefaulttelephonenumber.QuerySentinelValue(pd.Next.Input, false);
+                case "emailaddress":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var emailAddressUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && emailAddressUpperBound == int.MaxValue && !this.EmailAddress.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<EmailAddress>();
+                        }
+
+                        var sentinelEmailAddress = new EmailAddress(Guid.Empty, null, null);
+
+                        return sentinelEmailAddress.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        emailAddressUpperBound = this.EmailAddress.Count - 1;
+                    }
+
+                    if (this.EmailAddress.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for EmailAddress property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.EmailAddress.Count - 1 < emailAddressUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the EmailAddress property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.EmailAddress[pd.Lower.Value];
+                        }
+
+                        return this.EmailAddress[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var emailAddressObjects = new List<EmailAddress>();
+
+                        for (var i = pd.Lower.Value; i < emailAddressUpperBound + 1; i++)
+                        {
+                            emailAddressObjects.Add(this.EmailAddress[i]);
+                        }
+
+                        return emailAddressObjects;
+                    }
+
+                    var emailAddressNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < emailAddressUpperBound + 1; i++)
+                    {
+                        var queryResult = this.EmailAddress[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    emailAddressNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                emailAddressNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return emailAddressNextObjects;
+                case "givenname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.GivenName;
+                case "isactive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsActive;
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "organization":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Organization;
+                    }
+
+                    if (this.Organization != null)
+                    {
+                        return this.Organization.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelorganization = new Organization(Guid.Empty, null, null);
+                    return sentinelorganization.QuerySentinelValue(pd.Next.Input, false);
+                case "organizationalunit":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.OrganizationalUnit;
+                case "password":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Password;
+                case "role":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Role;
+                    }
+
+                    if (this.Role != null)
+                    {
+                        return this.Role.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelrole = new PersonRole(Guid.Empty, null, null);
+                    return sentinelrole.QuerySentinelValue(pd.Next.Input, false);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                case "surname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Surname;
+                case "telephonenumber":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var telephoneNumberUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && telephoneNumberUpperBound == int.MaxValue && !this.TelephoneNumber.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<TelephoneNumber>();
+                        }
+
+                        var sentinelTelephoneNumber = new TelephoneNumber(Guid.Empty, null, null);
+
+                        return sentinelTelephoneNumber.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        telephoneNumberUpperBound = this.TelephoneNumber.Count - 1;
+                    }
+
+                    if (this.TelephoneNumber.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for TelephoneNumber property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.TelephoneNumber.Count - 1 < telephoneNumberUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the TelephoneNumber property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.TelephoneNumber[pd.Lower.Value];
+                        }
+
+                        return this.TelephoneNumber[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var telephoneNumberObjects = new List<TelephoneNumber>();
+
+                        for (var i = pd.Lower.Value; i < telephoneNumberUpperBound + 1; i++)
+                        {
+                            telephoneNumberObjects.Add(this.TelephoneNumber[i]);
+                        }
+
+                        return telephoneNumberObjects;
+                    }
+
+                    var telephoneNumberNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < telephoneNumberUpperBound + 1; i++)
+                    {
+                        var queryResult = this.TelephoneNumber[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    telephoneNumberNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                telephoneNumberNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return telephoneNumberNextObjects;
+                case "userpreference":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var userPreferenceUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && userPreferenceUpperBound == int.MaxValue && !this.UserPreference.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<UserPreference>();
+                        }
+
+                        var sentinelUserPreference = new UserPreference(Guid.Empty, null, null);
+
+                        return sentinelUserPreference.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        userPreferenceUpperBound = this.UserPreference.Count - 1;
+                    }
+
+                    if (this.UserPreference.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for UserPreference property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.UserPreference.Count - 1 < userPreferenceUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the UserPreference property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.UserPreference[pd.Lower.Value];
+                        }
+
+                        return this.UserPreference[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var userPreferenceObjects = new List<UserPreference>();
+
+                        for (var i = pd.Lower.Value; i < userPreferenceUpperBound + 1; i++)
+                        {
+                            userPreferenceObjects.Add(this.UserPreference[i]);
+                        }
+
+                        return userPreferenceObjects;
+                    }
+
+                    var userPreferenceNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < userPreferenceUpperBound + 1; i++)
+                    {
+                        var queryResult = this.UserPreference[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    userPreferenceNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                userPreferenceNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return userPreferenceNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "defaultdomain":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "defaultemailaddress":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new EmailAddress(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<EmailAddress>() : default(EmailAddress);
+                case "defaulttelephonenumber":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new TelephoneNumber(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<TelephoneNumber>() : default(TelephoneNumber);
+                case "emailaddress":
+                    return pd.Next == null ? (object) new List<EmailAddress>() : new EmailAddress(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "givenname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "isactive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "organization":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Organization(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Organization>() : default(Organization);
+                case "organizationalunit":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "password":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "role":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new PersonRole(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<PersonRole>() : default(PersonRole);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "surname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "telephonenumber":
+                    return pd.Next == null ? (object) new List<TelephoneNumber>() : new TelephoneNumber(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "userpreference":
+                    return pd.Next == null ? (object) new List<UserPreference>() : new UserPreference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/PersonRolePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/PersonRolePropertyAccessor.cs
@@ -1,0 +1,249 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PersonRolePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class PersonRole
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "personpermission":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var personPermissionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && personPermissionUpperBound == int.MaxValue && !this.PersonPermission.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<PersonPermission>();
+                        }
+
+                        var sentinelPersonPermission = new PersonPermission(Guid.Empty, null, null);
+
+                        return sentinelPersonPermission.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        personPermissionUpperBound = this.PersonPermission.Count - 1;
+                    }
+
+                    if (this.PersonPermission.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for PersonPermission property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.PersonPermission.Count - 1 < personPermissionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the PersonPermission property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.PersonPermission[pd.Lower.Value];
+                        }
+
+                        return this.PersonPermission[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var personPermissionObjects = new List<PersonPermission>();
+
+                        for (var i = pd.Lower.Value; i < personPermissionUpperBound + 1; i++)
+                        {
+                            personPermissionObjects.Add(this.PersonPermission[i]);
+                        }
+
+                        return personPermissionObjects;
+                    }
+
+                    var personPermissionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < personPermissionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.PersonPermission[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    personPermissionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                personPermissionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return personPermissionNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "personpermission":
+                    return pd.Next == null ? (object) new List<PersonPermission>() : new PersonPermission(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/PointPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/PointPropertyAccessor.cs
@@ -1,0 +1,156 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PointPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.DiagramData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Point
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "x":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.X;
+                case "y":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Y;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "x":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                case "y":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/PossibleFiniteStateListPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/PossibleFiniteStateListPropertyAccessor.cs
@@ -1,0 +1,373 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PossibleFiniteStateListPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class PossibleFiniteStateList
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "defaultstate":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.DefaultState;
+                    }
+
+                    if (this.DefaultState != null)
+                    {
+                        return this.DefaultState.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineldefaultstate = new PossibleFiniteState(Guid.Empty, null, null);
+                    return sentineldefaultstate.QuerySentinelValue(pd.Next.Input, false);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "possiblestate":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var possibleStateUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && possibleStateUpperBound == int.MaxValue && !this.PossibleState.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<PossibleFiniteState>();
+                        }
+
+                        var sentinelPossibleFiniteState = new PossibleFiniteState(Guid.Empty, null, null);
+
+                        return sentinelPossibleFiniteState.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        possibleStateUpperBound = this.PossibleState.Count - 1;
+                    }
+
+                    if (this.PossibleState.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for PossibleState property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.PossibleState.Count - 1 < possibleStateUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the PossibleState property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.PossibleState[pd.Lower.Value];
+                        }
+
+                        return this.PossibleState[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var possibleStateObjects = new List<PossibleFiniteState>();
+
+                        for (var i = pd.Lower.Value; i < possibleStateUpperBound + 1; i++)
+                        {
+                            possibleStateObjects.Add(this.PossibleState[i]);
+                        }
+
+                        return possibleStateObjects;
+                    }
+
+                    var possibleStateNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < possibleStateUpperBound + 1; i++)
+                    {
+                        var queryResult = this.PossibleState[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    possibleStateNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                possibleStateNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return possibleStateNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "defaultstate":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new PossibleFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<PossibleFiniteState>() : default(PossibleFiniteState);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "possiblestate":
+                    return pd.Next == null ? (object) new List<PossibleFiniteState>() : new PossibleFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/PossibleFiniteStatePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/PossibleFiniteStatePropertyAccessor.cs
@@ -1,0 +1,185 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PossibleFiniteStatePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class PossibleFiniteState
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/PrefixedUnitPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/PrefixedUnitPropertyAccessor.cs
@@ -1,0 +1,209 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PrefixedUnitPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class PrefixedUnit
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "conversionfactor":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ConversionFactor;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "prefix":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Prefix;
+                    }
+
+                    if (this.Prefix != null)
+                    {
+                        return this.Prefix.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelprefix = new UnitPrefix(Guid.Empty, null, null);
+                    return sentinelprefix.QuerySentinelValue(pd.Next.Input, false);
+                case "referenceunit":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "conversionfactor":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "prefix":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new UnitPrefix(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<UnitPrefix>() : default(UnitPrefix);
+                case "referenceunit":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DerivedUnit(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementUnit>() : default(MeasurementUnit);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/PublicationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/PublicationPropertyAccessor.cs
@@ -1,0 +1,309 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="PublicationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Publication
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "domain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var domainUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && domainUpperBound == int.MaxValue && !this.Domain.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<DomainOfExpertise>();
+                        }
+
+                        var sentinelDomainOfExpertise = new DomainOfExpertise(Guid.Empty, null, null);
+
+                        return sentinelDomainOfExpertise.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        domainUpperBound = this.Domain.Count - 1;
+                    }
+
+                    if (this.Domain.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Domain property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Domain.Count - 1 < domainUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Domain property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Domain[pd.Lower.Value];
+                        }
+
+                        return this.Domain[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var domainObjects = new List<DomainOfExpertise>();
+
+                        for (var i = pd.Lower.Value; i < domainUpperBound + 1; i++)
+                        {
+                            domainObjects.Add(this.Domain[i]);
+                        }
+
+                        return domainObjects;
+                    }
+
+                    var domainNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < domainUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Domain[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    domainNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                domainNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return domainNextObjects;
+                case "publishedparameter":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var publishedParameterUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && publishedParameterUpperBound == int.MaxValue && !this.PublishedParameter.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ParameterOrOverrideBase>();
+                        }
+
+                        var sentinelParameterOrOverrideBase = new Parameter(Guid.Empty, null, null);
+
+                        return sentinelParameterOrOverrideBase.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        publishedParameterUpperBound = this.PublishedParameter.Count - 1;
+                    }
+
+                    if (this.PublishedParameter.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for PublishedParameter property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.PublishedParameter.Count - 1 < publishedParameterUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the PublishedParameter property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.PublishedParameter[pd.Lower.Value];
+                        }
+
+                        return this.PublishedParameter[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var publishedParameterObjects = new List<ParameterOrOverrideBase>();
+
+                        for (var i = pd.Lower.Value; i < publishedParameterUpperBound + 1; i++)
+                        {
+                            publishedParameterObjects.Add(this.PublishedParameter[i]);
+                        }
+
+                        return publishedParameterObjects;
+                    }
+
+                    var publishedParameterNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < publishedParameterUpperBound + 1; i++)
+                    {
+                        var queryResult = this.PublishedParameter[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    publishedParameterNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                publishedParameterNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return publishedParameterNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "domain":
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "publishedparameter":
+                    return pd.Next == null ? (object) new List<Parameter>() : new Parameter(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/QuantityKindFactorPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/QuantityKindFactorPropertyAccessor.cs
@@ -1,0 +1,169 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="QuantityKindFactorPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class QuantityKindFactor
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "exponent":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Exponent;
+                case "quantitykind":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.QuantityKind;
+                    }
+
+                    if (this.QuantityKind != null)
+                    {
+                        return this.QuantityKind.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelquantitykind = new DerivedQuantityKind(Guid.Empty, null, null);
+                    return sentinelquantitykind.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "exponent":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "quantitykind":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DerivedQuantityKind(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<QuantityKind>() : default(QuantityKind);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/QuantityKindPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/QuantityKindPropertyAccessor.cs
@@ -1,0 +1,330 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="QuantityKindPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class QuantityKind
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "allpossiblescale":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var allPossibleScaleUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && allPossibleScaleUpperBound == int.MaxValue && !this.AllPossibleScale.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<MeasurementScale>();
+                        }
+
+                        var sentinelMeasurementScale = new IntervalScale(Guid.Empty, null, null);
+
+                        return sentinelMeasurementScale.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        allPossibleScaleUpperBound = this.AllPossibleScale.Count - 1;
+                    }
+
+                    if (this.AllPossibleScale.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for AllPossibleScale property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.AllPossibleScale.Count - 1 < allPossibleScaleUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the AllPossibleScale property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.AllPossibleScale[pd.Lower.Value];
+                        }
+
+                        return this.AllPossibleScale[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var allPossibleScaleObjects = new List<MeasurementScale>();
+
+                        for (var i = pd.Lower.Value; i < allPossibleScaleUpperBound + 1; i++)
+                        {
+                            allPossibleScaleObjects.Add(this.AllPossibleScale[i]);
+                        }
+
+                        return allPossibleScaleObjects;
+                    }
+
+                    var allPossibleScaleNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < allPossibleScaleUpperBound + 1; i++)
+                    {
+                        var queryResult = this.AllPossibleScale[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    allPossibleScaleNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                allPossibleScaleNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return allPossibleScaleNextObjects;
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "defaultscale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.DefaultScale;
+                    }
+
+                    if (this.DefaultScale != null)
+                    {
+                        return this.DefaultScale.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineldefaultscale = new IntervalScale(Guid.Empty, null, null);
+                    return sentineldefaultscale.QuerySentinelValue(pd.Next.Input, false);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "possiblescale":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var possibleScaleUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && possibleScaleUpperBound == int.MaxValue && !this.PossibleScale.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<MeasurementScale>();
+                        }
+
+                        var sentinelMeasurementScale = new IntervalScale(Guid.Empty, null, null);
+
+                        return sentinelMeasurementScale.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        possibleScaleUpperBound = this.PossibleScale.Count - 1;
+                    }
+
+                    if (this.PossibleScale.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for PossibleScale property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.PossibleScale.Count - 1 < possibleScaleUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the PossibleScale property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.PossibleScale[pd.Lower.Value];
+                        }
+
+                        return this.PossibleScale[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var possibleScaleObjects = new List<MeasurementScale>();
+
+                        for (var i = pd.Lower.Value; i < possibleScaleUpperBound + 1; i++)
+                        {
+                            possibleScaleObjects.Add(this.PossibleScale[i]);
+                        }
+
+                        return possibleScaleObjects;
+                    }
+
+                    var possibleScaleNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < possibleScaleUpperBound + 1; i++)
+                    {
+                        var queryResult = this.PossibleScale[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    possibleScaleNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                possibleScaleNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return possibleScaleNextObjects;
+                case "quantitydimensionexponent":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for the QuantityDimensionExponent property, the lower and upper bound must be specified");
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.QuantityDimensionExponent.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.QuantityDimensionExponent.Count - 1;
+                    }
+
+                    if (this.QuantityDimensionExponent.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the QuantityDimensionExponent property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.QuantityDimensionExponent.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the QuantityDimensionExponent property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.QuantityDimensionExponent[pd.Lower.Value];
+                    }
+
+                    var quantityDimensionExponentobjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        quantityDimensionExponentobjects.Add(this.QuantityDimensionExponent[i]);
+                    }
+
+                    return quantityDimensionExponentobjects;
+                case "quantitydimensionexpression":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.QuantityDimensionExpression;
+                case "quantitydimensionsymbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.QuantityDimensionSymbol;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RatioScalePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RatioScalePropertyAccessor.cs
@@ -1,0 +1,220 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RatioScalePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class RatioScale
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "ismaximuminclusive":
+                    return base.QueryValue(pd.Input);
+                case "isminimuminclusive":
+                    return base.QueryValue(pd.Input);
+                case "mappingtoreferencescale":
+                    return base.QueryValue(pd.Input);
+                case "maximumpermissiblevalue":
+                    return base.QueryValue(pd.Input);
+                case "minimumpermissiblevalue":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "negativevalueconnotation":
+                    return base.QueryValue(pd.Input);
+                case "numberset":
+                    return base.QueryValue(pd.Input);
+                case "positivevalueconnotation":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "unit":
+                    return base.QueryValue(pd.Input);
+                case "valuedefinition":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "ismaximuminclusive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "isminimuminclusive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "mappingtoreferencescale":
+                    return pd.Next == null ? (object) new List<MappingToReferenceScale>() : new MappingToReferenceScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "maximumpermissiblevalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "minimumpermissiblevalue":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "negativevalueconnotation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberset":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<NumberSetKind>() : null;
+                case "positivevalueconnotation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "unit":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DerivedUnit(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementUnit>() : default(MeasurementUnit);
+                case "valuedefinition":
+                    return pd.Next == null ? (object) new List<ScaleValueDefinition>() : new ScaleValueDefinition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ReferenceDataLibraryPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ReferenceDataLibraryPropertyAccessor.cs
@@ -1,0 +1,1077 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ReferenceDataLibraryPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ReferenceDataLibrary
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "basequantitykind":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var baseQuantityKindUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && baseQuantityKindUpperBound == int.MaxValue && !this.BaseQuantityKind.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<QuantityKind>();
+                        }
+
+                        var sentinelQuantityKind = new DerivedQuantityKind(Guid.Empty, null, null);
+
+                        return sentinelQuantityKind.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        baseQuantityKindUpperBound = this.BaseQuantityKind.Count - 1;
+                    }
+
+                    if (this.BaseQuantityKind.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for BaseQuantityKind property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.BaseQuantityKind.Count - 1 < baseQuantityKindUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the BaseQuantityKind property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.BaseQuantityKind[pd.Lower.Value];
+                        }
+
+                        return this.BaseQuantityKind[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var baseQuantityKindObjects = new List<QuantityKind>();
+
+                        for (var i = pd.Lower.Value; i < baseQuantityKindUpperBound + 1; i++)
+                        {
+                            baseQuantityKindObjects.Add(this.BaseQuantityKind[i]);
+                        }
+
+                        return baseQuantityKindObjects;
+                    }
+
+                    var baseQuantityKindNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < baseQuantityKindUpperBound + 1; i++)
+                    {
+                        var queryResult = this.BaseQuantityKind[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    baseQuantityKindNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                baseQuantityKindNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return baseQuantityKindNextObjects;
+                case "baseunit":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var baseUnitUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && baseUnitUpperBound == int.MaxValue && !this.BaseUnit.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<MeasurementUnit>();
+                        }
+
+                        var sentinelMeasurementUnit = new DerivedUnit(Guid.Empty, null, null);
+
+                        return sentinelMeasurementUnit.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        baseUnitUpperBound = this.BaseUnit.Count - 1;
+                    }
+
+                    if (this.BaseUnit.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for BaseUnit property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.BaseUnit.Count - 1 < baseUnitUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the BaseUnit property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.BaseUnit[pd.Lower.Value];
+                        }
+
+                        return this.BaseUnit[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var baseUnitObjects = new List<MeasurementUnit>();
+
+                        for (var i = pd.Lower.Value; i < baseUnitUpperBound + 1; i++)
+                        {
+                            baseUnitObjects.Add(this.BaseUnit[i]);
+                        }
+
+                        return baseUnitObjects;
+                    }
+
+                    var baseUnitNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < baseUnitUpperBound + 1; i++)
+                    {
+                        var queryResult = this.BaseUnit[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    baseUnitNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                baseUnitNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return baseUnitNextObjects;
+                case "constant":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var constantUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && constantUpperBound == int.MaxValue && !this.Constant.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Constant>();
+                        }
+
+                        var sentinelConstant = new Constant(Guid.Empty, null, null);
+
+                        return sentinelConstant.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        constantUpperBound = this.Constant.Count - 1;
+                    }
+
+                    if (this.Constant.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Constant property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Constant.Count - 1 < constantUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Constant property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Constant[pd.Lower.Value];
+                        }
+
+                        return this.Constant[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var constantObjects = new List<Constant>();
+
+                        for (var i = pd.Lower.Value; i < constantUpperBound + 1; i++)
+                        {
+                            constantObjects.Add(this.Constant[i]);
+                        }
+
+                        return constantObjects;
+                    }
+
+                    var constantNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < constantUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Constant[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    constantNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                constantNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return constantNextObjects;
+                case "definedcategory":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var definedCategoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && definedCategoryUpperBound == int.MaxValue && !this.DefinedCategory.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        definedCategoryUpperBound = this.DefinedCategory.Count - 1;
+                    }
+
+                    if (this.DefinedCategory.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for DefinedCategory property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.DefinedCategory.Count - 1 < definedCategoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the DefinedCategory property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.DefinedCategory[pd.Lower.Value];
+                        }
+
+                        return this.DefinedCategory[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var definedCategoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < definedCategoryUpperBound + 1; i++)
+                        {
+                            definedCategoryObjects.Add(this.DefinedCategory[i]);
+                        }
+
+                        return definedCategoryObjects;
+                    }
+
+                    var definedCategoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < definedCategoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.DefinedCategory[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    definedCategoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                definedCategoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return definedCategoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "filetype":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var fileTypeUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && fileTypeUpperBound == int.MaxValue && !this.FileType.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<FileType>();
+                        }
+
+                        var sentinelFileType = new FileType(Guid.Empty, null, null);
+
+                        return sentinelFileType.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        fileTypeUpperBound = this.FileType.Count - 1;
+                    }
+
+                    if (this.FileType.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for FileType property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.FileType.Count - 1 < fileTypeUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the FileType property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.FileType[pd.Lower.Value];
+                        }
+
+                        return this.FileType[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var fileTypeObjects = new List<FileType>();
+
+                        for (var i = pd.Lower.Value; i < fileTypeUpperBound + 1; i++)
+                        {
+                            fileTypeObjects.Add(this.FileType[i]);
+                        }
+
+                        return fileTypeObjects;
+                    }
+
+                    var fileTypeNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < fileTypeUpperBound + 1; i++)
+                    {
+                        var queryResult = this.FileType[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    fileTypeNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                fileTypeNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return fileTypeNextObjects;
+                case "glossary":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var glossaryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && glossaryUpperBound == int.MaxValue && !this.Glossary.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Glossary>();
+                        }
+
+                        var sentinelGlossary = new Glossary(Guid.Empty, null, null);
+
+                        return sentinelGlossary.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        glossaryUpperBound = this.Glossary.Count - 1;
+                    }
+
+                    if (this.Glossary.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Glossary property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Glossary.Count - 1 < glossaryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Glossary property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Glossary[pd.Lower.Value];
+                        }
+
+                        return this.Glossary[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var glossaryObjects = new List<Glossary>();
+
+                        for (var i = pd.Lower.Value; i < glossaryUpperBound + 1; i++)
+                        {
+                            glossaryObjects.Add(this.Glossary[i]);
+                        }
+
+                        return glossaryObjects;
+                    }
+
+                    var glossaryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < glossaryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Glossary[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    glossaryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                glossaryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return glossaryNextObjects;
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var parameterTypeUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && parameterTypeUpperBound == int.MaxValue && !this.ParameterType.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ParameterType>();
+                        }
+
+                        var sentinelParameterType = new CompoundParameterType(Guid.Empty, null, null);
+
+                        return sentinelParameterType.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        parameterTypeUpperBound = this.ParameterType.Count - 1;
+                    }
+
+                    if (this.ParameterType.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ParameterType property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ParameterType.Count - 1 < parameterTypeUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ParameterType property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ParameterType[pd.Lower.Value];
+                        }
+
+                        return this.ParameterType[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var parameterTypeObjects = new List<ParameterType>();
+
+                        for (var i = pd.Lower.Value; i < parameterTypeUpperBound + 1; i++)
+                        {
+                            parameterTypeObjects.Add(this.ParameterType[i]);
+                        }
+
+                        return parameterTypeObjects;
+                    }
+
+                    var parameterTypeNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < parameterTypeUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ParameterType[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    parameterTypeNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                parameterTypeNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return parameterTypeNextObjects;
+                case "referencesource":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var referenceSourceUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && referenceSourceUpperBound == int.MaxValue && !this.ReferenceSource.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ReferenceSource>();
+                        }
+
+                        var sentinelReferenceSource = new ReferenceSource(Guid.Empty, null, null);
+
+                        return sentinelReferenceSource.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        referenceSourceUpperBound = this.ReferenceSource.Count - 1;
+                    }
+
+                    if (this.ReferenceSource.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ReferenceSource property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ReferenceSource.Count - 1 < referenceSourceUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ReferenceSource property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ReferenceSource[pd.Lower.Value];
+                        }
+
+                        return this.ReferenceSource[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var referenceSourceObjects = new List<ReferenceSource>();
+
+                        for (var i = pd.Lower.Value; i < referenceSourceUpperBound + 1; i++)
+                        {
+                            referenceSourceObjects.Add(this.ReferenceSource[i]);
+                        }
+
+                        return referenceSourceObjects;
+                    }
+
+                    var referenceSourceNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < referenceSourceUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ReferenceSource[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    referenceSourceNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                referenceSourceNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return referenceSourceNextObjects;
+                case "requiredrdl":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.RequiredRdl;
+                    }
+
+                    if (this.RequiredRdl != null)
+                    {
+                        return this.RequiredRdl.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelrequiredrdl = new SiteReferenceDataLibrary(Guid.Empty, null, null);
+                    return sentinelrequiredrdl.QuerySentinelValue(pd.Next.Input, false);
+                case "rule":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var ruleUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && ruleUpperBound == int.MaxValue && !this.Rule.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Rule>();
+                        }
+
+                        var sentinelRule = new BinaryRelationshipRule(Guid.Empty, null, null);
+
+                        return sentinelRule.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        ruleUpperBound = this.Rule.Count - 1;
+                    }
+
+                    if (this.Rule.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Rule property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Rule.Count - 1 < ruleUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Rule property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Rule[pd.Lower.Value];
+                        }
+
+                        return this.Rule[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var ruleObjects = new List<Rule>();
+
+                        for (var i = pd.Lower.Value; i < ruleUpperBound + 1; i++)
+                        {
+                            ruleObjects.Add(this.Rule[i]);
+                        }
+
+                        return ruleObjects;
+                    }
+
+                    var ruleNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < ruleUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Rule[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    ruleNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                ruleNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return ruleNextObjects;
+                case "scale":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var scaleUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && scaleUpperBound == int.MaxValue && !this.Scale.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<MeasurementScale>();
+                        }
+
+                        var sentinelMeasurementScale = new IntervalScale(Guid.Empty, null, null);
+
+                        return sentinelMeasurementScale.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        scaleUpperBound = this.Scale.Count - 1;
+                    }
+
+                    if (this.Scale.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Scale property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Scale.Count - 1 < scaleUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Scale property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Scale[pd.Lower.Value];
+                        }
+
+                        return this.Scale[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var scaleObjects = new List<MeasurementScale>();
+
+                        for (var i = pd.Lower.Value; i < scaleUpperBound + 1; i++)
+                        {
+                            scaleObjects.Add(this.Scale[i]);
+                        }
+
+                        return scaleObjects;
+                    }
+
+                    var scaleNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < scaleUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Scale[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    scaleNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                scaleNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return scaleNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "unit":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var unitUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && unitUpperBound == int.MaxValue && !this.Unit.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<MeasurementUnit>();
+                        }
+
+                        var sentinelMeasurementUnit = new DerivedUnit(Guid.Empty, null, null);
+
+                        return sentinelMeasurementUnit.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        unitUpperBound = this.Unit.Count - 1;
+                    }
+
+                    if (this.Unit.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Unit property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Unit.Count - 1 < unitUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Unit property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Unit[pd.Lower.Value];
+                        }
+
+                        return this.Unit[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var unitObjects = new List<MeasurementUnit>();
+
+                        for (var i = pd.Lower.Value; i < unitUpperBound + 1; i++)
+                        {
+                            unitObjects.Add(this.Unit[i]);
+                        }
+
+                        return unitObjects;
+                    }
+
+                    var unitNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < unitUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Unit[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    unitNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                unitNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return unitNextObjects;
+                case "unitprefix":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var unitPrefixUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && unitPrefixUpperBound == int.MaxValue && !this.UnitPrefix.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<UnitPrefix>();
+                        }
+
+                        var sentinelUnitPrefix = new UnitPrefix(Guid.Empty, null, null);
+
+                        return sentinelUnitPrefix.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        unitPrefixUpperBound = this.UnitPrefix.Count - 1;
+                    }
+
+                    if (this.UnitPrefix.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for UnitPrefix property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.UnitPrefix.Count - 1 < unitPrefixUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the UnitPrefix property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.UnitPrefix[pd.Lower.Value];
+                        }
+
+                        return this.UnitPrefix[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var unitPrefixObjects = new List<UnitPrefix>();
+
+                        for (var i = pd.Lower.Value; i < unitPrefixUpperBound + 1; i++)
+                        {
+                            unitPrefixObjects.Add(this.UnitPrefix[i]);
+                        }
+
+                        return unitPrefixObjects;
+                    }
+
+                    var unitPrefixNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < unitPrefixUpperBound + 1; i++)
+                    {
+                        var queryResult = this.UnitPrefix[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    unitPrefixNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                unitPrefixNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return unitPrefixNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ReferenceSourcePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ReferenceSourcePropertyAccessor.cs
@@ -1,0 +1,327 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ReferenceSourcePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ReferenceSource
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "author":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Author;
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "language":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Language;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "publicationyear":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.PublicationYear;
+                case "publishedin":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.PublishedIn;
+                    }
+
+                    if (this.PublishedIn != null)
+                    {
+                        return this.PublishedIn.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelpublishedin = new ReferenceSource(Guid.Empty, null, null);
+                    return sentinelpublishedin.QuerySentinelValue(pd.Next.Input, false);
+                case "publisher":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Publisher;
+                    }
+
+                    if (this.Publisher != null)
+                    {
+                        return this.Publisher.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelpublisher = new Organization(Guid.Empty, null, null);
+                    return sentinelpublisher.QuerySentinelValue(pd.Next.Input, false);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "versiondate":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.VersionDate;
+                case "versionidentifier":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.VersionIdentifier;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "author":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "language":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "publicationyear":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "publishedin":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ReferenceSource(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ReferenceSource>() : default(ReferenceSource);
+                case "publisher":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Organization(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Organization>() : default(Organization);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "versiondate":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "versionidentifier":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ReferencerRulePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ReferencerRulePropertyAccessor.cs
@@ -1,0 +1,284 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ReferencerRulePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ReferencerRule
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "maxreferenced":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.MaxReferenced;
+                case "minreferenced":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.MinReferenced;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "referencedcategory":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var referencedCategoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && referencedCategoryUpperBound == int.MaxValue && !this.ReferencedCategory.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        referencedCategoryUpperBound = this.ReferencedCategory.Count - 1;
+                    }
+
+                    if (this.ReferencedCategory.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ReferencedCategory property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ReferencedCategory.Count - 1 < referencedCategoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ReferencedCategory property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ReferencedCategory[pd.Lower.Value];
+                        }
+
+                        return this.ReferencedCategory[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var referencedCategoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < referencedCategoryUpperBound + 1; i++)
+                        {
+                            referencedCategoryObjects.Add(this.ReferencedCategory[i]);
+                        }
+
+                        return referencedCategoryObjects;
+                    }
+
+                    var referencedCategoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < referencedCategoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ReferencedCategory[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    referencedCategoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                referencedCategoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return referencedCategoryNextObjects;
+                case "referencingcategory":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ReferencingCategory;
+                    }
+
+                    if (this.ReferencingCategory != null)
+                    {
+                        return this.ReferencingCategory.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelreferencingcategory = new Category(Guid.Empty, null, null);
+                    return sentinelreferencingcategory.QuerySentinelValue(pd.Next.Input, false);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "maxreferenced":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "minreferenced":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "referencedcategory":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "referencingcategory":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Category>() : default(Category);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RelationalExpressionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RelationalExpressionPropertyAccessor.cs
@@ -1,0 +1,245 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RelationalExpressionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class RelationalExpression
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ParameterType;
+                    }
+
+                    if (this.ParameterType != null)
+                    {
+                        return this.ParameterType.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelparametertype = new CompoundParameterType(Guid.Empty, null, null);
+                    return sentinelparametertype.QuerySentinelValue(pd.Next.Input, false);
+                case "relationaloperator":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.RelationalOperator;
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Scale;
+                    }
+
+                    if (this.Scale != null)
+                    {
+                        return this.Scale.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelscale = new IntervalScale(Guid.Empty, null, null);
+                    return sentinelscale.QuerySentinelValue(pd.Next.Input, false);
+                case "value":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for Value property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for Value property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Value.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.Value.Any())
+                    {
+                        return this.Value.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Value.Count - 1;
+                    }
+
+                    if (this.Value.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Value property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Value.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Value property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Value[pd.Lower.Value];
+                    }
+
+                    var valueObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        valueObjects.Add(this.Value[i]);
+                    }
+
+                    return valueObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterType>() : default(ParameterType);
+                case "relationaloperator":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<RelationalOperatorKind>() : null;
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "value":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RelationshipParameterValuePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RelationshipParameterValuePropertyAccessor.cs
@@ -1,0 +1,166 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipParameterValuePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class RelationshipParameterValue
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "parametertype":
+                    return base.QueryValue(pd.Input);
+                case "scale":
+                    return base.QueryValue(pd.Input);
+                case "value":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterType>() : default(ParameterType);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "value":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RelationshipPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RelationshipPropertyAccessor.cs
@@ -1,0 +1,270 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Relationship
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "parametervalue":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var parameterValueUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && parameterValueUpperBound == int.MaxValue && !this.ParameterValue.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<RelationshipParameterValue>();
+                        }
+
+                        var sentinelRelationshipParameterValue = new RelationshipParameterValue(Guid.Empty, null, null);
+
+                        return sentinelRelationshipParameterValue.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        parameterValueUpperBound = this.ParameterValue.Count - 1;
+                    }
+
+                    if (this.ParameterValue.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ParameterValue property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ParameterValue.Count - 1 < parameterValueUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ParameterValue property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ParameterValue[pd.Lower.Value];
+                        }
+
+                        return this.ParameterValue[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var parameterValueObjects = new List<RelationshipParameterValue>();
+
+                        for (var i = pd.Lower.Value; i < parameterValueUpperBound + 1; i++)
+                        {
+                            parameterValueObjects.Add(this.ParameterValue[i]);
+                        }
+
+                        return parameterValueObjects;
+                    }
+
+                    var parameterValueNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < parameterValueUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ParameterValue[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    parameterValueNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                parameterValueNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return parameterValueNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RequestForDeviationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RequestForDeviationPropertyAccessor.cs
@@ -1,0 +1,227 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RequestForDeviationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class RequestForDeviation
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "approvedby":
+                    return base.QueryValue(pd.Input);
+                case "author":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "classification":
+                    return base.QueryValue(pd.Input);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "discussion":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "primaryannotatedthing":
+                    return base.QueryValue(pd.Input);
+                case "relatedthing":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "sourceannotation":
+                    return base.QueryValue(pd.Input);
+                case "status":
+                    return base.QueryValue(pd.Input);
+                case "title":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "approvedby":
+                    return pd.Next == null ? (object) new List<Approval>() : new Approval(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "classification":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationClassificationKind>() : null;
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "discussion":
+                    return pd.Next == null ? (object) new List<EngineeringModelDataDiscussionItem>() : new EngineeringModelDataDiscussionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "primaryannotatedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ModellingThingReference>() : default(ModellingThingReference);
+                case "relatedthing":
+                    return pd.Next == null ? (object) new List<ModellingThingReference>() : new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "sourceannotation":
+                    return pd.Next == null ? (object) new List<ActionItem>() : new ActionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "status":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationStatusKind>() : null;
+                case "title":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RequestForWaiverPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RequestForWaiverPropertyAccessor.cs
@@ -1,0 +1,227 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RequestForWaiverPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class RequestForWaiver
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "approvedby":
+                    return base.QueryValue(pd.Input);
+                case "author":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "classification":
+                    return base.QueryValue(pd.Input);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "discussion":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "primaryannotatedthing":
+                    return base.QueryValue(pd.Input);
+                case "relatedthing":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "sourceannotation":
+                    return base.QueryValue(pd.Input);
+                case "status":
+                    return base.QueryValue(pd.Input);
+                case "title":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "approvedby":
+                    return pd.Next == null ? (object) new List<Approval>() : new Approval(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "classification":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationClassificationKind>() : null;
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "discussion":
+                    return pd.Next == null ? (object) new List<EngineeringModelDataDiscussionItem>() : new EngineeringModelDataDiscussionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "primaryannotatedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ModellingThingReference>() : default(ModellingThingReference);
+                case "relatedthing":
+                    return pd.Next == null ? (object) new List<ModellingThingReference>() : new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "sourceannotation":
+                    return pd.Next == null ? (object) new List<ActionItem>() : new ActionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "status":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationStatusKind>() : null;
+                case "title":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RequirementPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RequirementPropertyAccessor.cs
@@ -1,0 +1,370 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RequirementPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Requirement
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "group":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Group;
+                    }
+
+                    if (this.Group != null)
+                    {
+                        return this.Group.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelgroup = new RequirementsGroup(Guid.Empty, null, null);
+                    return sentinelgroup.QuerySentinelValue(pd.Next.Input, false);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "parametervalue":
+                    return base.QueryValue(pd.Input);
+                case "parametricconstraint":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var parametricConstraintUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && parametricConstraintUpperBound == int.MaxValue && !this.ParametricConstraint.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ParametricConstraint>();
+                        }
+
+                        var sentinelParametricConstraint = new ParametricConstraint(Guid.Empty, null, null);
+
+                        return sentinelParametricConstraint.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        parametricConstraintUpperBound = this.ParametricConstraint.Count - 1;
+                    }
+
+                    if (this.ParametricConstraint.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ParametricConstraint property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ParametricConstraint.Count - 1 < parametricConstraintUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ParametricConstraint property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ParametricConstraint[pd.Lower.Value];
+                        }
+
+                        return this.ParametricConstraint[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var parametricConstraintObjects = new List<ParametricConstraint>();
+
+                        for (var i = pd.Lower.Value; i < parametricConstraintUpperBound + 1; i++)
+                        {
+                            parametricConstraintObjects.Add(this.ParametricConstraint[i]);
+                        }
+
+                        return parametricConstraintObjects;
+                    }
+
+                    var parametricConstraintNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < parametricConstraintUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ParametricConstraint[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    parametricConstraintNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                parametricConstraintNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return parametricConstraintNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "group":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new RequirementsGroup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<RequirementsGroup>() : default(RequirementsGroup);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "parametervalue":
+                    return pd.Next == null ? (object) new List<SimpleParameterValue>() : new SimpleParameterValue(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "parametricconstraint":
+                    return pd.Next == null ? (object) new List<ParametricConstraint>() : new ParametricConstraint(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RequirementsContainerParameterValuePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RequirementsContainerParameterValuePropertyAccessor.cs
@@ -1,0 +1,166 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RequirementsContainerParameterValuePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class RequirementsContainerParameterValue
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "parametertype":
+                    return base.QueryValue(pd.Input);
+                case "scale":
+                    return base.QueryValue(pd.Input);
+                case "value":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterType>() : default(ParameterType);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "value":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RequirementsContainerPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RequirementsContainerPropertyAccessor.cs
@@ -1,0 +1,357 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RequirementsContainerPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class RequirementsContainer
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "group":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var groupUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && groupUpperBound == int.MaxValue && !this.Group.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<RequirementsGroup>();
+                        }
+
+                        var sentinelRequirementsGroup = new RequirementsGroup(Guid.Empty, null, null);
+
+                        return sentinelRequirementsGroup.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        groupUpperBound = this.Group.Count - 1;
+                    }
+
+                    if (this.Group.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Group property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Group.Count - 1 < groupUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Group property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Group[pd.Lower.Value];
+                        }
+
+                        return this.Group[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var groupObjects = new List<RequirementsGroup>();
+
+                        for (var i = pd.Lower.Value; i < groupUpperBound + 1; i++)
+                        {
+                            groupObjects.Add(this.Group[i]);
+                        }
+
+                        return groupObjects;
+                    }
+
+                    var groupNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < groupUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Group[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    groupNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                groupNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return groupNextObjects;
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "parametervalue":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var parameterValueUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && parameterValueUpperBound == int.MaxValue && !this.ParameterValue.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<RequirementsContainerParameterValue>();
+                        }
+
+                        var sentinelRequirementsContainerParameterValue = new RequirementsContainerParameterValue(Guid.Empty, null, null);
+
+                        return sentinelRequirementsContainerParameterValue.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        parameterValueUpperBound = this.ParameterValue.Count - 1;
+                    }
+
+                    if (this.ParameterValue.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ParameterValue property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ParameterValue.Count - 1 < parameterValueUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ParameterValue property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ParameterValue[pd.Lower.Value];
+                        }
+
+                        return this.ParameterValue[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var parameterValueObjects = new List<RequirementsContainerParameterValue>();
+
+                        for (var i = pd.Lower.Value; i < parameterValueUpperBound + 1; i++)
+                        {
+                            parameterValueObjects.Add(this.ParameterValue[i]);
+                        }
+
+                        return parameterValueObjects;
+                    }
+
+                    var parameterValueNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < parameterValueUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ParameterValue[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    parameterValueNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                parameterValueNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return parameterValueNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RequirementsGroupPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RequirementsGroupPropertyAccessor.cs
@@ -1,0 +1,184 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RequirementsGroupPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class RequirementsGroup
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "group":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "parametervalue":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "group":
+                    return pd.Next == null ? (object) new List<RequirementsGroup>() : new RequirementsGroup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "parametervalue":
+                    return pd.Next == null ? (object) new List<RequirementsContainerParameterValue>() : new RequirementsContainerParameterValue(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RequirementsSpecificationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RequirementsSpecificationPropertyAccessor.cs
@@ -1,0 +1,272 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RequirementsSpecificationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class RequirementsSpecification
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "group":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "parametervalue":
+                    return base.QueryValue(pd.Input);
+                case "requirement":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var requirementUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && requirementUpperBound == int.MaxValue && !this.Requirement.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Requirement>();
+                        }
+
+                        var sentinelRequirement = new Requirement(Guid.Empty, null, null);
+
+                        return sentinelRequirement.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        requirementUpperBound = this.Requirement.Count - 1;
+                    }
+
+                    if (this.Requirement.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Requirement property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Requirement.Count - 1 < requirementUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Requirement property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Requirement[pd.Lower.Value];
+                        }
+
+                        return this.Requirement[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var requirementObjects = new List<Requirement>();
+
+                        for (var i = pd.Lower.Value; i < requirementUpperBound + 1; i++)
+                        {
+                            requirementObjects.Add(this.Requirement[i]);
+                        }
+
+                        return requirementObjects;
+                    }
+
+                    var requirementNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < requirementUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Requirement[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    requirementNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                requirementNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return requirementNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "group":
+                    return pd.Next == null ? (object) new List<RequirementsGroup>() : new RequirementsGroup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "parametervalue":
+                    return pd.Next == null ? (object) new List<RequirementsContainerParameterValue>() : new RequirementsContainerParameterValue(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "requirement":
+                    return pd.Next == null ? (object) new List<Requirement>() : new Requirement(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ReviewItemDiscrepancyPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ReviewItemDiscrepancyPropertyAccessor.cs
@@ -1,0 +1,309 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ReviewItemDiscrepancyPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ReviewItemDiscrepancy
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "approvedby":
+                    return base.QueryValue(pd.Input);
+                case "author":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "classification":
+                    return base.QueryValue(pd.Input);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "discussion":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "primaryannotatedthing":
+                    return base.QueryValue(pd.Input);
+                case "relatedthing":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "solution":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var solutionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && solutionUpperBound == int.MaxValue && !this.Solution.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Solution>();
+                        }
+
+                        var sentinelSolution = new Solution(Guid.Empty, null, null);
+
+                        return sentinelSolution.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        solutionUpperBound = this.Solution.Count - 1;
+                    }
+
+                    if (this.Solution.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Solution property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Solution.Count - 1 < solutionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Solution property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Solution[pd.Lower.Value];
+                        }
+
+                        return this.Solution[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var solutionObjects = new List<Solution>();
+
+                        for (var i = pd.Lower.Value; i < solutionUpperBound + 1; i++)
+                        {
+                            solutionObjects.Add(this.Solution[i]);
+                        }
+
+                        return solutionObjects;
+                    }
+
+                    var solutionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < solutionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Solution[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    solutionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                solutionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return solutionNextObjects;
+                case "sourceannotation":
+                    return base.QueryValue(pd.Input);
+                case "status":
+                    return base.QueryValue(pd.Input);
+                case "title":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "approvedby":
+                    return pd.Next == null ? (object) new List<Approval>() : new Approval(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "classification":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationClassificationKind>() : null;
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "discussion":
+                    return pd.Next == null ? (object) new List<EngineeringModelDataDiscussionItem>() : new EngineeringModelDataDiscussionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "primaryannotatedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ModellingThingReference>() : default(ModellingThingReference);
+                case "relatedthing":
+                    return pd.Next == null ? (object) new List<ModellingThingReference>() : new ModellingThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "solution":
+                    return pd.Next == null ? (object) new List<Solution>() : new Solution(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "sourceannotation":
+                    return pd.Next == null ? (object) new List<ActionItem>() : new ActionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "status":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<AnnotationStatusKind>() : null;
+                case "title":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RulePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RulePropertyAccessor.cs
@@ -1,0 +1,105 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RulePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Rule
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RuleVerificationListPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RuleVerificationListPropertyAccessor.cs
@@ -1,0 +1,267 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RuleVerificationListPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class RuleVerificationList
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "ruleverification":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var ruleVerificationUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && ruleVerificationUpperBound == int.MaxValue && !this.RuleVerification.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<RuleVerification>();
+                        }
+
+                        var sentinelRuleVerification = new BuiltInRuleVerification(Guid.Empty, null, null);
+
+                        return sentinelRuleVerification.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        ruleVerificationUpperBound = this.RuleVerification.Count - 1;
+                    }
+
+                    if (this.RuleVerification.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for RuleVerification property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.RuleVerification.Count - 1 < ruleVerificationUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the RuleVerification property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.RuleVerification[pd.Lower.Value];
+                        }
+
+                        return this.RuleVerification[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var ruleVerificationObjects = new List<RuleVerification>();
+
+                        for (var i = pd.Lower.Value; i < ruleVerificationUpperBound + 1; i++)
+                        {
+                            ruleVerificationObjects.Add(this.RuleVerification[i]);
+                        }
+
+                        return ruleVerificationObjects;
+                    }
+
+                    var ruleVerificationNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < ruleVerificationUpperBound + 1; i++)
+                    {
+                        var queryResult = this.RuleVerification[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    ruleVerificationNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                ruleVerificationNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return ruleVerificationNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "ruleverification":
+                    return pd.Next == null ? (object) new List<BuiltInRuleVerification>() : new BuiltInRuleVerification(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RuleVerificationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RuleVerificationPropertyAccessor.cs
@@ -1,0 +1,199 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RuleVerificationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class RuleVerification
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "executedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ExecutedOn;
+                case "isactive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsActive;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "status":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Status;
+                case "violation":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var violationUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && violationUpperBound == int.MaxValue && !this.Violation.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<RuleViolation>();
+                        }
+
+                        var sentinelRuleViolation = new RuleViolation(Guid.Empty, null, null);
+
+                        return sentinelRuleViolation.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        violationUpperBound = this.Violation.Count - 1;
+                    }
+
+                    if (this.Violation.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Violation property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Violation.Count - 1 < violationUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Violation property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Violation[pd.Lower.Value];
+                        }
+
+                        return this.Violation[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var violationObjects = new List<RuleViolation>();
+
+                        for (var i = pd.Lower.Value; i < violationUpperBound + 1; i++)
+                        {
+                            violationObjects.Add(this.Violation[i]);
+                        }
+
+                        return violationObjects;
+                    }
+
+                    var violationNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < violationUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Violation[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    violationNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                violationNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return violationNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/RuleViolationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/RuleViolationPropertyAccessor.cs
@@ -1,0 +1,187 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="RuleViolationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class RuleViolation
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "description":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Description;
+                case "violatingthing":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for the ViolatingThing property, the lower and upper bound must be specified");
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.ViolatingThing.Any())
+                    {
+                        return new List<Guid>();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.ViolatingThing.Count - 1;
+                    }
+
+                    if (this.ViolatingThing.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ViolatingThing property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ViolatingThing.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ViolatingThing property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.ViolatingThing[pd.Lower.Value];
+                    }
+
+                    var violatingThingobjects = new List<Guid>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        violatingThingobjects.Add(this.ViolatingThing[i]);
+                    }
+
+                    return violatingThingobjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "description":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "violatingthing":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<Guid>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SampledFunctionParameterTypePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SampledFunctionParameterTypePropertyAccessor.cs
@@ -1,0 +1,402 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SampledFunctionParameterTypePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class SampledFunctionParameterType
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "degreeofinterpolation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.DegreeOfInterpolation;
+                case "dependentparametertype":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var dependentParameterTypeUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && dependentParameterTypeUpperBound == int.MaxValue && !this.DependentParameterType.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<DependentParameterTypeAssignment>();
+                        }
+
+                        var sentinelDependentParameterTypeAssignment = new DependentParameterTypeAssignment(Guid.Empty, null, null);
+
+                        return sentinelDependentParameterTypeAssignment.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        dependentParameterTypeUpperBound = this.DependentParameterType.Count - 1;
+                    }
+
+                    if (this.DependentParameterType.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for DependentParameterType property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.DependentParameterType.Count - 1 < dependentParameterTypeUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the DependentParameterType property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.DependentParameterType[pd.Lower.Value];
+                        }
+
+                        return this.DependentParameterType[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var dependentParameterTypeObjects = new List<DependentParameterTypeAssignment>();
+
+                        for (var i = pd.Lower.Value; i < dependentParameterTypeUpperBound + 1; i++)
+                        {
+                            dependentParameterTypeObjects.Add(this.DependentParameterType[i]);
+                        }
+
+                        return dependentParameterTypeObjects;
+                    }
+
+                    var dependentParameterTypeNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < dependentParameterTypeUpperBound + 1; i++)
+                    {
+                        var queryResult = this.DependentParameterType[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    dependentParameterTypeNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                dependentParameterTypeNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return dependentParameterTypeNextObjects;
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "independentparametertype":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var independentParameterTypeUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && independentParameterTypeUpperBound == int.MaxValue && !this.IndependentParameterType.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<IndependentParameterTypeAssignment>();
+                        }
+
+                        var sentinelIndependentParameterTypeAssignment = new IndependentParameterTypeAssignment(Guid.Empty, null, null);
+
+                        return sentinelIndependentParameterTypeAssignment.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        independentParameterTypeUpperBound = this.IndependentParameterType.Count - 1;
+                    }
+
+                    if (this.IndependentParameterType.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for IndependentParameterType property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.IndependentParameterType.Count - 1 < independentParameterTypeUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the IndependentParameterType property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.IndependentParameterType[pd.Lower.Value];
+                        }
+
+                        return this.IndependentParameterType[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var independentParameterTypeObjects = new List<IndependentParameterTypeAssignment>();
+
+                        for (var i = pd.Lower.Value; i < independentParameterTypeUpperBound + 1; i++)
+                        {
+                            independentParameterTypeObjects.Add(this.IndependentParameterType[i]);
+                        }
+
+                        return independentParameterTypeObjects;
+                    }
+
+                    var independentParameterTypeNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < independentParameterTypeUpperBound + 1; i++)
+                    {
+                        var queryResult = this.IndependentParameterType[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    independentParameterTypeNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                independentParameterTypeNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return independentParameterTypeNextObjects;
+                case "interpolationperiod":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for InterpolationPeriod property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for InterpolationPeriod property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.InterpolationPeriod.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.InterpolationPeriod.Any())
+                    {
+                        return this.InterpolationPeriod.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.InterpolationPeriod.Count - 1;
+                    }
+
+                    if (this.InterpolationPeriod.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the InterpolationPeriod property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.InterpolationPeriod.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the InterpolationPeriod property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.InterpolationPeriod[pd.Lower.Value];
+                    }
+
+                    var interpolationPeriodObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        interpolationPeriodObjects.Add(this.InterpolationPeriod[i]);
+                    }
+
+                    return interpolationPeriodObjects;
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "degreeofinterpolation":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "dependentparametertype":
+                    return pd.Next == null ? (object) new List<DependentParameterTypeAssignment>() : new DependentParameterTypeAssignment(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "independentparametertype":
+                    return pd.Next == null ? (object) new List<IndependentParameterTypeAssignment>() : new IndependentParameterTypeAssignment(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "interpolationperiod":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberofvalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "symbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ScalarParameterTypePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ScalarParameterTypePropertyAccessor.cs
@@ -1,0 +1,110 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ScalarParameterTypePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ScalarParameterType
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ScaleReferenceQuantityValuePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ScaleReferenceQuantityValuePropertyAccessor.cs
@@ -1,0 +1,169 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ScaleReferenceQuantityValuePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ScaleReferenceQuantityValue
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Scale;
+                    }
+
+                    if (this.Scale != null)
+                    {
+                        return this.Scale.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelscale = new IntervalScale(Guid.Empty, null, null);
+                    return sentinelscale.QuerySentinelValue(pd.Next.Input, false);
+                case "value":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Value;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "value":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ScaleValueDefinitionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ScaleValueDefinitionPropertyAccessor.cs
@@ -1,0 +1,167 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ScaleValueDefinitionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ScaleValueDefinition
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "value":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Value;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "value":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SectionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SectionPropertyAccessor.cs
@@ -1,0 +1,345 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SectionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Section
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "page":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var pageUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && pageUpperBound == int.MaxValue && !this.Page.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Page>();
+                        }
+
+                        var sentinelPage = new Page(Guid.Empty, null, null);
+
+                        return sentinelPage.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pageUpperBound = this.Page.Count - 1;
+                    }
+
+                    if (this.Page.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Page property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Page.Count - 1 < pageUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Page property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Page[pd.Lower.Value];
+                        }
+
+                        return this.Page[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var pageObjects = new List<Page>();
+
+                        for (var i = pd.Lower.Value; i < pageUpperBound + 1; i++)
+                        {
+                            pageObjects.Add(this.Page[i]);
+                        }
+
+                        return pageObjects;
+                    }
+
+                    var pageNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < pageUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Page[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    pageNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                pageNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return pageNextObjects;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "page":
+                    return pd.Next == null ? (object) new List<Page>() : new Page(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SharedStylePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SharedStylePropertyAccessor.cs
@@ -1,0 +1,226 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SharedStylePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.DiagramData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class SharedStyle
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "fillcolor":
+                    return base.QueryValue(pd.Input);
+                case "fillopacity":
+                    return base.QueryValue(pd.Input);
+                case "fontbold":
+                    return base.QueryValue(pd.Input);
+                case "fontcolor":
+                    return base.QueryValue(pd.Input);
+                case "fontitalic":
+                    return base.QueryValue(pd.Input);
+                case "fontname":
+                    return base.QueryValue(pd.Input);
+                case "fontsize":
+                    return base.QueryValue(pd.Input);
+                case "fontstrokethrough":
+                    return base.QueryValue(pd.Input);
+                case "fontunderline":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "strokecolor":
+                    return base.QueryValue(pd.Input);
+                case "strokeopacity":
+                    return base.QueryValue(pd.Input);
+                case "strokewidth":
+                    return base.QueryValue(pd.Input);
+                case "usedcolor":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "fillcolor":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Color(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Color>() : default(Color);
+                case "fillopacity":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                case "fontbold":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "fontcolor":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Color(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Color>() : default(Color);
+                case "fontitalic":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "fontname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "fontsize":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                case "fontstrokethrough":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "fontunderline":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "strokecolor":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Color(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Color>() : default(Color);
+                case "strokeopacity":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                case "strokewidth":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<float>() : null;
+                case "usedcolor":
+                    return pd.Next == null ? (object) new List<Color>() : new Color(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SimpleParameterValuePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SimpleParameterValuePropertyAccessor.cs
@@ -1,0 +1,263 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SimpleParameterValuePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class SimpleParameterValue
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ParameterType;
+                    }
+
+                    if (this.ParameterType != null)
+                    {
+                        return this.ParameterType.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelparametertype = new CompoundParameterType(Guid.Empty, null, null);
+                    return sentinelparametertype.QuerySentinelValue(pd.Next.Input, false);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Scale;
+                    }
+
+                    if (this.Scale != null)
+                    {
+                        return this.Scale.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelscale = new IntervalScale(Guid.Empty, null, null);
+                    return sentinelscale.QuerySentinelValue(pd.Next.Input, false);
+                case "value":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for Value property, the lower and upper bound must be specified");
+                    }
+                    
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for Value property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.Value.Any())
+                    {
+                        return new List<string>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.Value.Any())
+                    {
+                        return this.Value.ToList();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.Value.Count - 1;
+                    }
+
+                    if (this.Value.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Value property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Value.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Value property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.Value[pd.Lower.Value];
+                    }
+
+                    var valueObjects = new List<string>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        valueObjects.Add(this.Value[i]);
+                    }
+
+                    return valueObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "parametertype":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParameterType>() : default(ParameterType);
+                case "scale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "value":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SimpleParameterizableThingPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SimpleParameterizableThingPropertyAccessor.cs
@@ -1,0 +1,197 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SimpleParameterizableThingPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class SimpleParameterizableThing
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                case "parametervalue":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var parameterValueUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && parameterValueUpperBound == int.MaxValue && !this.ParameterValue.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<SimpleParameterValue>();
+                        }
+
+                        var sentinelSimpleParameterValue = new SimpleParameterValue(Guid.Empty, null, null);
+
+                        return sentinelSimpleParameterValue.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        parameterValueUpperBound = this.ParameterValue.Count - 1;
+                    }
+
+                    if (this.ParameterValue.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ParameterValue property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ParameterValue.Count - 1 < parameterValueUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ParameterValue property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ParameterValue[pd.Lower.Value];
+                        }
+
+                        return this.ParameterValue[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var parameterValueObjects = new List<SimpleParameterValue>();
+
+                        for (var i = pd.Lower.Value; i < parameterValueUpperBound + 1; i++)
+                        {
+                            parameterValueObjects.Add(this.ParameterValue[i]);
+                        }
+
+                        return parameterValueObjects;
+                    }
+
+                    var parameterValueNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < parameterValueUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ParameterValue[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    parameterValueNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                parameterValueNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return parameterValueNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SimpleQuantityKindPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SimpleQuantityKindPropertyAccessor.cs
@@ -1,0 +1,214 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SimpleQuantityKindPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class SimpleQuantityKind
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "allpossiblescale":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "defaultscale":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "possiblescale":
+                    return base.QueryValue(pd.Input);
+                case "quantitydimensionexponent":
+                    return base.QueryValue(pd.Input);
+                case "quantitydimensionexpression":
+                    return base.QueryValue(pd.Input);
+                case "quantitydimensionsymbol":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "allpossiblescale":
+                    return pd.Next == null ? (object) new List<IntervalScale>() : new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "defaultscale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberofvalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "possiblescale":
+                    return pd.Next == null ? (object) new List<IntervalScale>() : new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "quantitydimensionexponent":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "quantitydimensionexpression":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "quantitydimensionsymbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "symbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SimpleUnitPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SimpleUnitPropertyAccessor.cs
@@ -1,0 +1,166 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SimpleUnitPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class SimpleUnit
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SiteDirectoryDataAnnotationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SiteDirectoryDataAnnotationPropertyAccessor.cs
@@ -1,0 +1,366 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SiteDirectoryDataAnnotationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class SiteDirectoryDataAnnotation
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Author;
+                    }
+
+                    if (this.Author != null)
+                    {
+                        return this.Author.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelauthor = new Person(Guid.Empty, null, null);
+                    return sentinelauthor.QuerySentinelValue(pd.Next.Input, false);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "discussion":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var discussionUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && discussionUpperBound == int.MaxValue && !this.Discussion.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<SiteDirectoryDataDiscussionItem>();
+                        }
+
+                        var sentinelSiteDirectoryDataDiscussionItem = new SiteDirectoryDataDiscussionItem(Guid.Empty, null, null);
+
+                        return sentinelSiteDirectoryDataDiscussionItem.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        discussionUpperBound = this.Discussion.Count - 1;
+                    }
+
+                    if (this.Discussion.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Discussion property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Discussion.Count - 1 < discussionUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Discussion property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Discussion[pd.Lower.Value];
+                        }
+
+                        return this.Discussion[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var discussionObjects = new List<SiteDirectoryDataDiscussionItem>();
+
+                        for (var i = pd.Lower.Value; i < discussionUpperBound + 1; i++)
+                        {
+                            discussionObjects.Add(this.Discussion[i]);
+                        }
+
+                        return discussionObjects;
+                    }
+
+                    var discussionNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < discussionUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Discussion[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    discussionNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                discussionNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return discussionNextObjects;
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "primaryannotatedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.PrimaryAnnotatedThing;
+                    }
+
+                    if (this.PrimaryAnnotatedThing != null)
+                    {
+                        return this.PrimaryAnnotatedThing.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelprimaryannotatedthing = new SiteDirectoryThingReference(Guid.Empty, null, null);
+                    return sentinelprimaryannotatedthing.QuerySentinelValue(pd.Next.Input, false);
+                case "relatedthing":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var relatedThingUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && relatedThingUpperBound == int.MaxValue && !this.RelatedThing.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<SiteDirectoryThingReference>();
+                        }
+
+                        var sentinelSiteDirectoryThingReference = new SiteDirectoryThingReference(Guid.Empty, null, null);
+
+                        return sentinelSiteDirectoryThingReference.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        relatedThingUpperBound = this.RelatedThing.Count - 1;
+                    }
+
+                    if (this.RelatedThing.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for RelatedThing property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.RelatedThing.Count - 1 < relatedThingUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the RelatedThing property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.RelatedThing[pd.Lower.Value];
+                        }
+
+                        return this.RelatedThing[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var relatedThingObjects = new List<SiteDirectoryThingReference>();
+
+                        for (var i = pd.Lower.Value; i < relatedThingUpperBound + 1; i++)
+                        {
+                            relatedThingObjects.Add(this.RelatedThing[i]);
+                        }
+
+                        return relatedThingObjects;
+                    }
+
+                    var relatedThingNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < relatedThingUpperBound + 1; i++)
+                    {
+                        var queryResult = this.RelatedThing[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    relatedThingNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                relatedThingNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return relatedThingNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Person(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Person>() : default(Person);
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "discussion":
+                    return pd.Next == null ? (object) new List<SiteDirectoryDataDiscussionItem>() : new SiteDirectoryDataDiscussionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "primaryannotatedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new SiteDirectoryThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<SiteDirectoryThingReference>() : default(SiteDirectoryThingReference);
+                case "relatedthing":
+                    return pd.Next == null ? (object) new List<SiteDirectoryThingReference>() : new SiteDirectoryThingReference(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SiteDirectoryDataDiscussionItemPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SiteDirectoryDataDiscussionItemPropertyAccessor.cs
@@ -1,0 +1,189 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SiteDirectoryDataDiscussionItemPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class SiteDirectoryDataDiscussionItem
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Author;
+                    }
+
+                    if (this.Author != null)
+                    {
+                        return this.Author.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelauthor = new Person(Guid.Empty, null, null);
+                    return sentinelauthor.QuerySentinelValue(pd.Next.Input, false);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "replyto":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Person(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Person>() : default(Person);
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "replyto":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new EngineeringModelDataDiscussionItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DiscussionItem>() : default(DiscussionItem);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SiteDirectoryPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SiteDirectoryPropertyAccessor.cs
@@ -1,0 +1,1112 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SiteDirectoryPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class SiteDirectory
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "annotation":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var annotationUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && annotationUpperBound == int.MaxValue && !this.Annotation.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<SiteDirectoryDataAnnotation>();
+                        }
+
+                        var sentinelSiteDirectoryDataAnnotation = new SiteDirectoryDataAnnotation(Guid.Empty, null, null);
+
+                        return sentinelSiteDirectoryDataAnnotation.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        annotationUpperBound = this.Annotation.Count - 1;
+                    }
+
+                    if (this.Annotation.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Annotation property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Annotation.Count - 1 < annotationUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Annotation property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Annotation[pd.Lower.Value];
+                        }
+
+                        return this.Annotation[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var annotationObjects = new List<SiteDirectoryDataAnnotation>();
+
+                        for (var i = pd.Lower.Value; i < annotationUpperBound + 1; i++)
+                        {
+                            annotationObjects.Add(this.Annotation[i]);
+                        }
+
+                        return annotationObjects;
+                    }
+
+                    var annotationNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < annotationUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Annotation[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    annotationNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                annotationNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return annotationNextObjects;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "defaultparticipantrole":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.DefaultParticipantRole;
+                    }
+
+                    if (this.DefaultParticipantRole != null)
+                    {
+                        return this.DefaultParticipantRole.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineldefaultparticipantrole = new ParticipantRole(Guid.Empty, null, null);
+                    return sentineldefaultparticipantrole.QuerySentinelValue(pd.Next.Input, false);
+                case "defaultpersonrole":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.DefaultPersonRole;
+                    }
+
+                    if (this.DefaultPersonRole != null)
+                    {
+                        return this.DefaultPersonRole.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentineldefaultpersonrole = new PersonRole(Guid.Empty, null, null);
+                    return sentineldefaultpersonrole.QuerySentinelValue(pd.Next.Input, false);
+                case "domain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var domainUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && domainUpperBound == int.MaxValue && !this.Domain.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<DomainOfExpertise>();
+                        }
+
+                        var sentinelDomainOfExpertise = new DomainOfExpertise(Guid.Empty, null, null);
+
+                        return sentinelDomainOfExpertise.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        domainUpperBound = this.Domain.Count - 1;
+                    }
+
+                    if (this.Domain.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Domain property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Domain.Count - 1 < domainUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Domain property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Domain[pd.Lower.Value];
+                        }
+
+                        return this.Domain[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var domainObjects = new List<DomainOfExpertise>();
+
+                        for (var i = pd.Lower.Value; i < domainUpperBound + 1; i++)
+                        {
+                            domainObjects.Add(this.Domain[i]);
+                        }
+
+                        return domainObjects;
+                    }
+
+                    var domainNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < domainUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Domain[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    domainNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                domainNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return domainNextObjects;
+                case "domaingroup":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var domainGroupUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && domainGroupUpperBound == int.MaxValue && !this.DomainGroup.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<DomainOfExpertiseGroup>();
+                        }
+
+                        var sentinelDomainOfExpertiseGroup = new DomainOfExpertiseGroup(Guid.Empty, null, null);
+
+                        return sentinelDomainOfExpertiseGroup.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        domainGroupUpperBound = this.DomainGroup.Count - 1;
+                    }
+
+                    if (this.DomainGroup.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for DomainGroup property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.DomainGroup.Count - 1 < domainGroupUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the DomainGroup property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.DomainGroup[pd.Lower.Value];
+                        }
+
+                        return this.DomainGroup[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var domainGroupObjects = new List<DomainOfExpertiseGroup>();
+
+                        for (var i = pd.Lower.Value; i < domainGroupUpperBound + 1; i++)
+                        {
+                            domainGroupObjects.Add(this.DomainGroup[i]);
+                        }
+
+                        return domainGroupObjects;
+                    }
+
+                    var domainGroupNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < domainGroupUpperBound + 1; i++)
+                    {
+                        var queryResult = this.DomainGroup[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    domainGroupNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                domainGroupNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return domainGroupNextObjects;
+                case "lastmodifiedon":
+                    return base.QueryValue(pd.Input);
+                case "logentry":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var logEntryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && logEntryUpperBound == int.MaxValue && !this.LogEntry.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<SiteLogEntry>();
+                        }
+
+                        var sentinelSiteLogEntry = new SiteLogEntry(Guid.Empty, null, null);
+
+                        return sentinelSiteLogEntry.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        logEntryUpperBound = this.LogEntry.Count - 1;
+                    }
+
+                    if (this.LogEntry.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for LogEntry property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.LogEntry.Count - 1 < logEntryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the LogEntry property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.LogEntry[pd.Lower.Value];
+                        }
+
+                        return this.LogEntry[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var logEntryObjects = new List<SiteLogEntry>();
+
+                        for (var i = pd.Lower.Value; i < logEntryUpperBound + 1; i++)
+                        {
+                            logEntryObjects.Add(this.LogEntry[i]);
+                        }
+
+                        return logEntryObjects;
+                    }
+
+                    var logEntryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < logEntryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.LogEntry[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    logEntryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                logEntryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return logEntryNextObjects;
+                case "model":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var modelUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && modelUpperBound == int.MaxValue && !this.Model.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<EngineeringModelSetup>();
+                        }
+
+                        var sentinelEngineeringModelSetup = new EngineeringModelSetup(Guid.Empty, null, null);
+
+                        return sentinelEngineeringModelSetup.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        modelUpperBound = this.Model.Count - 1;
+                    }
+
+                    if (this.Model.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Model property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Model.Count - 1 < modelUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Model property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Model[pd.Lower.Value];
+                        }
+
+                        return this.Model[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var modelObjects = new List<EngineeringModelSetup>();
+
+                        for (var i = pd.Lower.Value; i < modelUpperBound + 1; i++)
+                        {
+                            modelObjects.Add(this.Model[i]);
+                        }
+
+                        return modelObjects;
+                    }
+
+                    var modelNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < modelUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Model[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    modelNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                modelNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return modelNextObjects;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "naturallanguage":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var naturalLanguageUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && naturalLanguageUpperBound == int.MaxValue && !this.NaturalLanguage.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<NaturalLanguage>();
+                        }
+
+                        var sentinelNaturalLanguage = new NaturalLanguage(Guid.Empty, null, null);
+
+                        return sentinelNaturalLanguage.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        naturalLanguageUpperBound = this.NaturalLanguage.Count - 1;
+                    }
+
+                    if (this.NaturalLanguage.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for NaturalLanguage property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.NaturalLanguage.Count - 1 < naturalLanguageUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the NaturalLanguage property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.NaturalLanguage[pd.Lower.Value];
+                        }
+
+                        return this.NaturalLanguage[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var naturalLanguageObjects = new List<NaturalLanguage>();
+
+                        for (var i = pd.Lower.Value; i < naturalLanguageUpperBound + 1; i++)
+                        {
+                            naturalLanguageObjects.Add(this.NaturalLanguage[i]);
+                        }
+
+                        return naturalLanguageObjects;
+                    }
+
+                    var naturalLanguageNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < naturalLanguageUpperBound + 1; i++)
+                    {
+                        var queryResult = this.NaturalLanguage[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    naturalLanguageNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                naturalLanguageNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return naturalLanguageNextObjects;
+                case "organization":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var organizationUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && organizationUpperBound == int.MaxValue && !this.Organization.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Organization>();
+                        }
+
+                        var sentinelOrganization = new Organization(Guid.Empty, null, null);
+
+                        return sentinelOrganization.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        organizationUpperBound = this.Organization.Count - 1;
+                    }
+
+                    if (this.Organization.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Organization property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Organization.Count - 1 < organizationUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Organization property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Organization[pd.Lower.Value];
+                        }
+
+                        return this.Organization[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var organizationObjects = new List<Organization>();
+
+                        for (var i = pd.Lower.Value; i < organizationUpperBound + 1; i++)
+                        {
+                            organizationObjects.Add(this.Organization[i]);
+                        }
+
+                        return organizationObjects;
+                    }
+
+                    var organizationNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < organizationUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Organization[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    organizationNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                organizationNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return organizationNextObjects;
+                case "participantrole":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var participantRoleUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && participantRoleUpperBound == int.MaxValue && !this.ParticipantRole.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ParticipantRole>();
+                        }
+
+                        var sentinelParticipantRole = new ParticipantRole(Guid.Empty, null, null);
+
+                        return sentinelParticipantRole.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        participantRoleUpperBound = this.ParticipantRole.Count - 1;
+                    }
+
+                    if (this.ParticipantRole.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ParticipantRole property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ParticipantRole.Count - 1 < participantRoleUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ParticipantRole property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ParticipantRole[pd.Lower.Value];
+                        }
+
+                        return this.ParticipantRole[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var participantRoleObjects = new List<ParticipantRole>();
+
+                        for (var i = pd.Lower.Value; i < participantRoleUpperBound + 1; i++)
+                        {
+                            participantRoleObjects.Add(this.ParticipantRole[i]);
+                        }
+
+                        return participantRoleObjects;
+                    }
+
+                    var participantRoleNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < participantRoleUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ParticipantRole[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    participantRoleNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                participantRoleNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return participantRoleNextObjects;
+                case "person":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var personUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && personUpperBound == int.MaxValue && !this.Person.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Person>();
+                        }
+
+                        var sentinelPerson = new Person(Guid.Empty, null, null);
+
+                        return sentinelPerson.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        personUpperBound = this.Person.Count - 1;
+                    }
+
+                    if (this.Person.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Person property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Person.Count - 1 < personUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Person property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Person[pd.Lower.Value];
+                        }
+
+                        return this.Person[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var personObjects = new List<Person>();
+
+                        for (var i = pd.Lower.Value; i < personUpperBound + 1; i++)
+                        {
+                            personObjects.Add(this.Person[i]);
+                        }
+
+                        return personObjects;
+                    }
+
+                    var personNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < personUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Person[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    personNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                personNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return personNextObjects;
+                case "personrole":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var personRoleUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && personRoleUpperBound == int.MaxValue && !this.PersonRole.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<PersonRole>();
+                        }
+
+                        var sentinelPersonRole = new PersonRole(Guid.Empty, null, null);
+
+                        return sentinelPersonRole.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        personRoleUpperBound = this.PersonRole.Count - 1;
+                    }
+
+                    if (this.PersonRole.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for PersonRole property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.PersonRole.Count - 1 < personRoleUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the PersonRole property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.PersonRole[pd.Lower.Value];
+                        }
+
+                        return this.PersonRole[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var personRoleObjects = new List<PersonRole>();
+
+                        for (var i = pd.Lower.Value; i < personRoleUpperBound + 1; i++)
+                        {
+                            personRoleObjects.Add(this.PersonRole[i]);
+                        }
+
+                        return personRoleObjects;
+                    }
+
+                    var personRoleNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < personRoleUpperBound + 1; i++)
+                    {
+                        var queryResult = this.PersonRole[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    personRoleNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                personRoleNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return personRoleNextObjects;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                case "sitereferencedatalibrary":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var siteReferenceDataLibraryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && siteReferenceDataLibraryUpperBound == int.MaxValue && !this.SiteReferenceDataLibrary.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<SiteReferenceDataLibrary>();
+                        }
+
+                        var sentinelSiteReferenceDataLibrary = new SiteReferenceDataLibrary(Guid.Empty, null, null);
+
+                        return sentinelSiteReferenceDataLibrary.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        siteReferenceDataLibraryUpperBound = this.SiteReferenceDataLibrary.Count - 1;
+                    }
+
+                    if (this.SiteReferenceDataLibrary.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for SiteReferenceDataLibrary property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.SiteReferenceDataLibrary.Count - 1 < siteReferenceDataLibraryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the SiteReferenceDataLibrary property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.SiteReferenceDataLibrary[pd.Lower.Value];
+                        }
+
+                        return this.SiteReferenceDataLibrary[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var siteReferenceDataLibraryObjects = new List<SiteReferenceDataLibrary>();
+
+                        for (var i = pd.Lower.Value; i < siteReferenceDataLibraryUpperBound + 1; i++)
+                        {
+                            siteReferenceDataLibraryObjects.Add(this.SiteReferenceDataLibrary[i]);
+                        }
+
+                        return siteReferenceDataLibraryObjects;
+                    }
+
+                    var siteReferenceDataLibraryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < siteReferenceDataLibraryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.SiteReferenceDataLibrary[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    siteReferenceDataLibraryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                siteReferenceDataLibraryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return siteReferenceDataLibraryNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "annotation":
+                    return pd.Next == null ? (object) new List<SiteDirectoryDataAnnotation>() : new SiteDirectoryDataAnnotation(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "defaultparticipantrole":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ParticipantRole(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<ParticipantRole>() : default(ParticipantRole);
+                case "defaultpersonrole":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new PersonRole(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<PersonRole>() : default(PersonRole);
+                case "domain":
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "domaingroup":
+                    return pd.Next == null ? (object) new List<DomainOfExpertiseGroup>() : new DomainOfExpertiseGroup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "lastmodifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "logentry":
+                    return pd.Next == null ? (object) new List<SiteLogEntry>() : new SiteLogEntry(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "model":
+                    return pd.Next == null ? (object) new List<EngineeringModelSetup>() : new EngineeringModelSetup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "naturallanguage":
+                    return pd.Next == null ? (object) new List<NaturalLanguage>() : new NaturalLanguage(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "organization":
+                    return pd.Next == null ? (object) new List<Organization>() : new Organization(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "participantrole":
+                    return pd.Next == null ? (object) new List<ParticipantRole>() : new ParticipantRole(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "person":
+                    return pd.Next == null ? (object) new List<Person>() : new Person(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "personrole":
+                    return pd.Next == null ? (object) new List<PersonRole>() : new PersonRole(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "sitereferencedatalibrary":
+                    return pd.Next == null ? (object) new List<SiteReferenceDataLibrary>() : new SiteReferenceDataLibrary(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SiteDirectoryThingReferencePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SiteDirectoryThingReferencePropertyAccessor.cs
@@ -1,0 +1,155 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SiteDirectoryThingReferencePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class SiteDirectoryThingReference
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "referencedrevisionnumber":
+                    return base.QueryValue(pd.Input);
+                case "referencedthing":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "referencedrevisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "referencedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new ActualFiniteState(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Thing>() : default(Thing);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SiteLogEntryPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SiteLogEntryPropertyAccessor.cs
@@ -1,0 +1,435 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SiteLogEntryPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class SiteLogEntry
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "affecteddomainiid":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for the AffectedDomainIid property, the lower and upper bound must be specified");
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.AffectedDomainIid.Any())
+                    {
+                        return new List<Guid>();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.AffectedDomainIid.Count - 1;
+                    }
+
+                    if (this.AffectedDomainIid.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the AffectedDomainIid property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.AffectedDomainIid.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the AffectedDomainIid property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.AffectedDomainIid[pd.Lower.Value];
+                    }
+
+                    var affectedDomainIidobjects = new List<Guid>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        affectedDomainIidobjects.Add(this.AffectedDomainIid[i]);
+                    }
+
+                    return affectedDomainIidobjects;
+                case "affecteditemiid":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new Exception("Invalid Multiplicity for the AffectedItemIid property, the lower and upper bound must be specified");
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.AffectedItemIid.Any())
+                    {
+                        return new List<Guid>();
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        pd.Upper = this.AffectedItemIid.Count - 1;
+                    }
+
+                    if (this.AffectedItemIid.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the AffectedItemIid property, the lower bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.AffectedItemIid.Count - 1 < pd.Upper.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the AffectedItemIid property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        return this.AffectedItemIid[pd.Lower.Value];
+                    }
+
+                    var affectedItemIidobjects = new List<Guid>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        affectedItemIidobjects.Add(this.AffectedItemIid[i]);
+                    }
+
+                    return affectedItemIidobjects;
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Author;
+                    }
+
+                    if (this.Author != null)
+                    {
+                        return this.Author.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelauthor = new Person(Guid.Empty, null, null);
+                    return sentinelauthor.QuerySentinelValue(pd.Next.Input, false);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Content;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.CreatedOn;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.LanguageCode;
+                case "level":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Level;
+                case "logentrychangelogitem":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var logEntryChangelogItemUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && logEntryChangelogItemUpperBound == int.MaxValue && !this.LogEntryChangelogItem.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<LogEntryChangelogItem>();
+                        }
+
+                        var sentinelLogEntryChangelogItem = new LogEntryChangelogItem(Guid.Empty, null, null);
+
+                        return sentinelLogEntryChangelogItem.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        logEntryChangelogItemUpperBound = this.LogEntryChangelogItem.Count - 1;
+                    }
+
+                    if (this.LogEntryChangelogItem.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for LogEntryChangelogItem property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.LogEntryChangelogItem.Count - 1 < logEntryChangelogItemUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the LogEntryChangelogItem property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.LogEntryChangelogItem[pd.Lower.Value];
+                        }
+
+                        return this.LogEntryChangelogItem[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var logEntryChangelogItemObjects = new List<LogEntryChangelogItem>();
+
+                        for (var i = pd.Lower.Value; i < logEntryChangelogItemUpperBound + 1; i++)
+                        {
+                            logEntryChangelogItemObjects.Add(this.LogEntryChangelogItem[i]);
+                        }
+
+                        return logEntryChangelogItemObjects;
+                    }
+
+                    var logEntryChangelogItemNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < logEntryChangelogItemUpperBound + 1; i++)
+                    {
+                        var queryResult = this.LogEntryChangelogItem[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    logEntryChangelogItemNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                logEntryChangelogItemNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return logEntryChangelogItemNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "affecteddomainiid":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<Guid>() : null;
+                case "affecteditemiid":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<Guid>() : null;
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Person(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Person>() : default(Person);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "level":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<LogLevelKind>() : null;
+                case "logentrychangelogitem":
+                    return pd.Next == null ? (object) new List<LogEntryChangelogItem>() : new LogEntryChangelogItem(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SiteReferenceDataLibraryPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SiteReferenceDataLibraryPropertyAccessor.cs
@@ -1,0 +1,226 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SiteReferenceDataLibraryPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class SiteReferenceDataLibrary
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "basequantitykind":
+                    return base.QueryValue(pd.Input);
+                case "baseunit":
+                    return base.QueryValue(pd.Input);
+                case "constant":
+                    return base.QueryValue(pd.Input);
+                case "definedcategory":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "filetype":
+                    return base.QueryValue(pd.Input);
+                case "glossary":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "parametertype":
+                    return base.QueryValue(pd.Input);
+                case "referencesource":
+                    return base.QueryValue(pd.Input);
+                case "requiredrdl":
+                    return base.QueryValue(pd.Input);
+                case "rule":
+                    return base.QueryValue(pd.Input);
+                case "scale":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "unit":
+                    return base.QueryValue(pd.Input);
+                case "unitprefix":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "basequantitykind":
+                    return pd.Next == null ? (object) new List<DerivedQuantityKind>() : new DerivedQuantityKind(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "baseunit":
+                    return pd.Next == null ? (object) new List<DerivedUnit>() : new DerivedUnit(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "constant":
+                    return pd.Next == null ? (object) new List<Constant>() : new Constant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definedcategory":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "filetype":
+                    return pd.Next == null ? (object) new List<FileType>() : new FileType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "glossary":
+                    return pd.Next == null ? (object) new List<Glossary>() : new Glossary(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "parametertype":
+                    return pd.Next == null ? (object) new List<CompoundParameterType>() : new CompoundParameterType(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "referencesource":
+                    return pd.Next == null ? (object) new List<ReferenceSource>() : new ReferenceSource(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "requiredrdl":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new SiteReferenceDataLibrary(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<SiteReferenceDataLibrary>() : default(SiteReferenceDataLibrary);
+                case "rule":
+                    return pd.Next == null ? (object) new List<BinaryRelationshipRule>() : new BinaryRelationshipRule(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "scale":
+                    return pd.Next == null ? (object) new List<IntervalScale>() : new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "unit":
+                    return pd.Next == null ? (object) new List<DerivedUnit>() : new DerivedUnit(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "unitprefix":
+                    return pd.Next == null ? (object) new List<UnitPrefix>() : new UnitPrefix(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SolutionPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SolutionPropertyAccessor.cs
@@ -1,0 +1,202 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SolutionPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Solution
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Author;
+                    }
+
+                    if (this.Author != null)
+                    {
+                        return this.Author.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelauthor = new Participant(Guid.Empty, null, null);
+                    return sentinelauthor.QuerySentinelValue(pd.Next.Input, false);
+                case "content":
+                    return base.QueryValue(pd.Input);
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Owner;
+                    }
+
+                    if (this.Owner != null)
+                    {
+                        return this.Owner.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelowner = new DomainOfExpertise(Guid.Empty, null, null);
+                    return sentinelowner.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "author":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new Participant(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Participant>() : default(Participant);
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/SpecializedQuantityKindPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/SpecializedQuantityKindPropertyAccessor.cs
@@ -1,0 +1,238 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="SpecializedQuantityKindPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class SpecializedQuantityKind
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "allpossiblescale":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "defaultscale":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "general":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.General;
+                    }
+
+                    if (this.General != null)
+                    {
+                        return this.General.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelgeneral = new DerivedQuantityKind(Guid.Empty, null, null);
+                    return sentinelgeneral.QuerySentinelValue(pd.Next.Input, false);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "possiblescale":
+                    return base.QueryValue(pd.Input);
+                case "quantitydimensionexponent":
+                    return base.QueryValue(pd.Input);
+                case "quantitydimensionexpression":
+                    return base.QueryValue(pd.Input);
+                case "quantitydimensionsymbol":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "allpossiblescale":
+                    return pd.Next == null ? (object) new List<IntervalScale>() : new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "defaultscale":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementScale>() : default(MeasurementScale);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "general":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DerivedQuantityKind(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<QuantityKind>() : default(QuantityKind);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberofvalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "possiblescale":
+                    return pd.Next == null ? (object) new List<IntervalScale>() : new IntervalScale(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "quantitydimensionexponent":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<string>() : null;
+                case "quantitydimensionexpression":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "quantitydimensionsymbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "symbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/StakeHolderValueMapPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/StakeHolderValueMapPropertyAccessor.cs
@@ -1,0 +1,653 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="StakeHolderValueMapPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class StakeHolderValueMap
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "goal":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var goalUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && goalUpperBound == int.MaxValue && !this.Goal.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Goal>();
+                        }
+
+                        var sentinelGoal = new Goal(Guid.Empty, null, null);
+
+                        return sentinelGoal.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        goalUpperBound = this.Goal.Count - 1;
+                    }
+
+                    if (this.Goal.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Goal property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Goal.Count - 1 < goalUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Goal property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Goal[pd.Lower.Value];
+                        }
+
+                        return this.Goal[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var goalObjects = new List<Goal>();
+
+                        for (var i = pd.Lower.Value; i < goalUpperBound + 1; i++)
+                        {
+                            goalObjects.Add(this.Goal[i]);
+                        }
+
+                        return goalObjects;
+                    }
+
+                    var goalNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < goalUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Goal[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    goalNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                goalNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return goalNextObjects;
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "requirement":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var requirementUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && requirementUpperBound == int.MaxValue && !this.Requirement.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Requirement>();
+                        }
+
+                        var sentinelRequirement = new Requirement(Guid.Empty, null, null);
+
+                        return sentinelRequirement.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        requirementUpperBound = this.Requirement.Count - 1;
+                    }
+
+                    if (this.Requirement.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Requirement property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Requirement.Count - 1 < requirementUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Requirement property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Requirement[pd.Lower.Value];
+                        }
+
+                        return this.Requirement[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var requirementObjects = new List<Requirement>();
+
+                        for (var i = pd.Lower.Value; i < requirementUpperBound + 1; i++)
+                        {
+                            requirementObjects.Add(this.Requirement[i]);
+                        }
+
+                        return requirementObjects;
+                    }
+
+                    var requirementNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < requirementUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Requirement[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    requirementNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                requirementNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return requirementNextObjects;
+                case "settings":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var settingsUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && settingsUpperBound == int.MaxValue && !this.Settings.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<StakeHolderValueMapSettings>();
+                        }
+
+                        var sentinelStakeHolderValueMapSettings = new StakeHolderValueMapSettings(Guid.Empty, null, null);
+
+                        return sentinelStakeHolderValueMapSettings.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        settingsUpperBound = this.Settings.Count - 1;
+                    }
+
+                    if (this.Settings.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Settings property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Settings.Count - 1 < settingsUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Settings property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Settings[pd.Lower.Value];
+                        }
+
+                        return this.Settings[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var settingsObjects = new List<StakeHolderValueMapSettings>();
+
+                        for (var i = pd.Lower.Value; i < settingsUpperBound + 1; i++)
+                        {
+                            settingsObjects.Add(this.Settings[i]);
+                        }
+
+                        return settingsObjects;
+                    }
+
+                    var settingsNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < settingsUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Settings[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    settingsNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                settingsNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return settingsNextObjects;
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "stakeholdervalue":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var stakeholderValueUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && stakeholderValueUpperBound == int.MaxValue && !this.StakeholderValue.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<StakeholderValue>();
+                        }
+
+                        var sentinelStakeholderValue = new StakeholderValue(Guid.Empty, null, null);
+
+                        return sentinelStakeholderValue.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        stakeholderValueUpperBound = this.StakeholderValue.Count - 1;
+                    }
+
+                    if (this.StakeholderValue.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for StakeholderValue property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.StakeholderValue.Count - 1 < stakeholderValueUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the StakeholderValue property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.StakeholderValue[pd.Lower.Value];
+                        }
+
+                        return this.StakeholderValue[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var stakeholderValueObjects = new List<StakeholderValue>();
+
+                        for (var i = pd.Lower.Value; i < stakeholderValueUpperBound + 1; i++)
+                        {
+                            stakeholderValueObjects.Add(this.StakeholderValue[i]);
+                        }
+
+                        return stakeholderValueObjects;
+                    }
+
+                    var stakeholderValueNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < stakeholderValueUpperBound + 1; i++)
+                    {
+                        var queryResult = this.StakeholderValue[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    stakeholderValueNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                stakeholderValueNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return stakeholderValueNextObjects;
+                case "valuegroup":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var valueGroupUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && valueGroupUpperBound == int.MaxValue && !this.ValueGroup.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<ValueGroup>();
+                        }
+
+                        var sentinelValueGroup = new ValueGroup(Guid.Empty, null, null);
+
+                        return sentinelValueGroup.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        valueGroupUpperBound = this.ValueGroup.Count - 1;
+                    }
+
+                    if (this.ValueGroup.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ValueGroup property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ValueGroup.Count - 1 < valueGroupUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the ValueGroup property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ValueGroup[pd.Lower.Value];
+                        }
+
+                        return this.ValueGroup[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var valueGroupObjects = new List<ValueGroup>();
+
+                        for (var i = pd.Lower.Value; i < valueGroupUpperBound + 1; i++)
+                        {
+                            valueGroupObjects.Add(this.ValueGroup[i]);
+                        }
+
+                        return valueGroupObjects;
+                    }
+
+                    var valueGroupNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < valueGroupUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ValueGroup[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    valueGroupNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                valueGroupNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return valueGroupNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "goal":
+                    return pd.Next == null ? (object) new List<Goal>() : new Goal(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "requirement":
+                    return pd.Next == null ? (object) new List<Requirement>() : new Requirement(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "settings":
+                    return pd.Next == null ? (object) new List<StakeHolderValueMapSettings>() : new StakeHolderValueMapSettings(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "stakeholdervalue":
+                    return pd.Next == null ? (object) new List<StakeholderValue>() : new StakeholderValue(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "valuegroup":
+                    return pd.Next == null ? (object) new List<ValueGroup>() : new ValueGroup(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/StakeHolderValueMapSettingsPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/StakeHolderValueMapSettingsPropertyAccessor.cs
@@ -1,0 +1,211 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="StakeHolderValueMapSettingsPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class StakeHolderValueMapSettings
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "goaltovaluegrouprelationship":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.GoalToValueGroupRelationship;
+                    }
+
+                    if (this.GoalToValueGroupRelationship != null)
+                    {
+                        return this.GoalToValueGroupRelationship.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelgoaltovaluegrouprelationship = new BinaryRelationshipRule(Guid.Empty, null, null);
+                    return sentinelgoaltovaluegrouprelationship.QuerySentinelValue(pd.Next.Input, false);
+                case "stakeholdervaluetorequirementrelationship":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.StakeholderValueToRequirementRelationship;
+                    }
+
+                    if (this.StakeholderValueToRequirementRelationship != null)
+                    {
+                        return this.StakeholderValueToRequirementRelationship.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelstakeholdervaluetorequirementrelationship = new BinaryRelationshipRule(Guid.Empty, null, null);
+                    return sentinelstakeholdervaluetorequirementrelationship.QuerySentinelValue(pd.Next.Input, false);
+                case "valuegrouptostakeholdervaluerelationship":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ValueGroupToStakeholderValueRelationship;
+                    }
+
+                    if (this.ValueGroupToStakeholderValueRelationship != null)
+                    {
+                        return this.ValueGroupToStakeholderValueRelationship.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelvaluegrouptostakeholdervaluerelationship = new BinaryRelationshipRule(Guid.Empty, null, null);
+                    return sentinelvaluegrouptostakeholdervaluerelationship.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "goaltovaluegrouprelationship":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new BinaryRelationshipRule(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<BinaryRelationshipRule>() : default(BinaryRelationshipRule);
+                case "stakeholdervaluetorequirementrelationship":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new BinaryRelationshipRule(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<BinaryRelationshipRule>() : default(BinaryRelationshipRule);
+                case "valuegrouptostakeholdervaluerelationship":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new BinaryRelationshipRule(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<BinaryRelationshipRule>() : default(BinaryRelationshipRule);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/StakeholderPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/StakeholderPropertyAccessor.cs
@@ -1,0 +1,325 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="StakeholderPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Stakeholder
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "stakeholdervalue":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var stakeholderValueUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && stakeholderValueUpperBound == int.MaxValue && !this.StakeholderValue.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<StakeholderValue>();
+                        }
+
+                        var sentinelStakeholderValue = new StakeholderValue(Guid.Empty, null, null);
+
+                        return sentinelStakeholderValue.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        stakeholderValueUpperBound = this.StakeholderValue.Count - 1;
+                    }
+
+                    if (this.StakeholderValue.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for StakeholderValue property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.StakeholderValue.Count - 1 < stakeholderValueUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the StakeholderValue property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.StakeholderValue[pd.Lower.Value];
+                        }
+
+                        return this.StakeholderValue[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var stakeholderValueObjects = new List<StakeholderValue>();
+
+                        for (var i = pd.Lower.Value; i < stakeholderValueUpperBound + 1; i++)
+                        {
+                            stakeholderValueObjects.Add(this.StakeholderValue[i]);
+                        }
+
+                        return stakeholderValueObjects;
+                    }
+
+                    var stakeholderValueNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < stakeholderValueUpperBound + 1; i++)
+                    {
+                        var queryResult = this.StakeholderValue[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    stakeholderValueNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                stakeholderValueNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return stakeholderValueNextObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "stakeholdervalue":
+                    return pd.Next == null ? (object) new List<StakeholderValue>() : new StakeholderValue(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/StakeholderValuePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/StakeholderValuePropertyAccessor.cs
@@ -1,0 +1,243 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="StakeholderValuePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class StakeholderValue
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/TelephoneNumberPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/TelephoneNumberPropertyAccessor.cs
@@ -1,0 +1,199 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="TelephoneNumberPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class TelephoneNumber
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "value":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Value;
+                case "vcardtype":
+                    if (!pd.Lower.HasValue || !pd.Upper.HasValue)
+                    {
+                        throw new ArgumentException("Invalid Multiplicity for the VcardType property, the lower and upper bound must be specified");
+                    }
+
+                    if (!string.IsNullOrEmpty(pd.NextPath))
+                    {
+                        throw new ArgumentException($"Invalid nesting for the VcardType property");
+                    }
+                    
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && !this.VcardType.Any())
+                    {
+                        return new List<VcardTelephoneNumberKind>();
+                    }
+
+                    if (pd.Lower.Value == 0 && pd.Upper.Value == int.MaxValue && this.VcardType.Any())
+                    {
+                        return this.VcardType.ToList();
+                    }
+
+                    var vcardTypeUpperBound = pd.Upper.Value;
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        vcardTypeUpperBound = this.VcardType.Count - 1;
+                    }
+
+                    if (this.VcardType.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the VcardType property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.VcardType.Count - 1 < vcardTypeUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the VcardType property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == vcardTypeUpperBound)
+                    {
+                        return this.VcardType[pd.Lower.Value];
+                    }
+
+                    var vcardTypeObjects = new List<VcardTelephoneNumberKind>();
+
+                    for (var i = pd.Lower.Value; i < pd.Upper.Value + 1; i++)
+                    {
+                        vcardTypeObjects.Add(this.VcardType[i]);
+                    }
+
+                    return vcardTypeObjects;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "value":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "vcardtype":
+                    pd.VerifyPropertyDescriptorForEnumerableValueProperty();
+                    return isCallerEmunerable ? (object)new List<VcardTelephoneNumberKind>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/TermPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/TermPropertyAccessor.cs
@@ -1,0 +1,167 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="TermPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class Term
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/TextParameterTypePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/TextParameterTypePropertyAccessor.cs
@@ -1,0 +1,180 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="TextParameterTypePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class TextParameterType
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberofvalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "symbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/TextualNotePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/TextualNotePropertyAccessor.cs
@@ -1,0 +1,181 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="TextualNotePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class TextualNote
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Content;
+                case "createdon":
+                    return base.QueryValue(pd.Input);
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.LanguageCode;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "content":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "createdon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "languagecode":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ThingReferencePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ThingReferencePropertyAccessor.cs
@@ -1,0 +1,110 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ThingReferencePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.ReportingData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ThingReference
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "referencedrevisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ReferencedRevisionNumber;
+                case "referencedthing":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.ReferencedThing;
+                    }
+
+                    if (this.ReferencedThing != null)
+                    {
+                        return this.ReferencedThing.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelreferencedthing = new ActualFiniteState(Guid.Empty, null, null);
+                    return sentinelreferencedthing.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/TimeOfDayParameterTypePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/TimeOfDayParameterTypePropertyAccessor.cs
@@ -1,0 +1,180 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="TimeOfDayParameterTypePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class TimeOfDayParameterType
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    return base.QueryValue(pd.Input);
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "numberofvalues":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                case "symbol":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "numberofvalues":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "symbol":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/TopContainerPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/TopContainerPropertyAccessor.cs
@@ -1,0 +1,95 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="TopContainerPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.CommonData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class TopContainer
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "lastmodifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.LastModifiedOn;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/UnitFactorPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/UnitFactorPropertyAccessor.cs
@@ -1,0 +1,169 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="UnitFactorPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class UnitFactor
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "exponent":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Exponent;
+                case "unit":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Unit;
+                    }
+
+                    if (this.Unit != null)
+                    {
+                        return this.Unit.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelunit = new DerivedUnit(Guid.Empty, null, null);
+                    return sentinelunit.QuerySentinelValue(pd.Next.Input, false);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "exponent":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "unit":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DerivedUnit(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<MeasurementUnit>() : default(MeasurementUnit);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/UnitPrefixPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/UnitPrefixPropertyAccessor.cs
@@ -1,0 +1,173 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="UnitPrefixPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class UnitPrefix
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "conversionfactor":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ConversionFactor;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.IsDeprecated;
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "conversionfactor":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "isdeprecated":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/UserPreferencePropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/UserPreferencePropertyAccessor.cs
@@ -1,0 +1,151 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="UserPreferencePropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.SiteDirectoryData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class UserPreference
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ShortName;
+                case "value":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Value;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "value":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/UserRuleVerificationPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/UserRuleVerificationPropertyAccessor.cs
@@ -1,0 +1,199 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="UserRuleVerificationPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class UserRuleVerification
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "executedon":
+                    return base.QueryValue(pd.Input);
+                case "isactive":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Name;
+                case "owner":
+                    return base.QueryValue(pd.Input);
+                case "rule":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next == null)
+                    {
+                        return this.Rule;
+                    }
+
+                    if (this.Rule != null)
+                    {
+                        return this.Rule.QueryValue(pd.Next.Input);
+                    }
+
+                    var sentinelrule = new BinaryRelationshipRule(Guid.Empty, null, null);
+                    return sentinelrule.QuerySentinelValue(pd.Next.Input, false);
+                case "status":
+                    return base.QueryValue(pd.Input);
+                case "violation":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "executedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "isactive":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<bool>() : null;
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "owner":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<DomainOfExpertise>() : default(DomainOfExpertise);
+                case "rule":
+                    pd.VerifyPropertyDescriptorForReferenceProperty();
+
+                    if (pd.Next != null)
+                    {
+                        return new BinaryRelationshipRule(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                    }
+
+                    return isCallerEmunerable ? (object) new List<Rule>() : default(Rule);
+                case "status":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<RuleVerificationStatusKind>() : null;
+                case "violation":
+                    return pd.Next == null ? (object) new List<RuleViolation>() : new RuleViolation(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/AutoGenThingPropertyAccessor/ValueGroupPropertyAccessor.cs
+++ b/CDP4Common/AutoGenThingPropertyAccessor/ValueGroupPropertyAccessor.cs
@@ -1,0 +1,243 @@
+// ------------------------------------------------------------------------------------------------
+// <copyright file="ValueGroupPropertyAccessor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.EngineeringModelData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.DiagramData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.PropertyAccesor;
+    using CDP4Common.ReportingData;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Generated methods that support the QueryValue logic
+    /// </summary>
+    public partial class ValueGroup
+    {
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof
+        /// </remarks>
+        public override object QueryValue(string path)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    return base.QueryThingValues(pd.Input);
+                case "revisionnumber":
+                    return base.QueryThingValues(pd.Input);
+                case "classkind":
+                    return base.QueryThingValues(pd.Input);
+                case "excludeddomain":
+                    return base.QueryThingValues(pd.Input);
+                case "excludedperson":
+                    return base.QueryThingValues(pd.Input);
+                case "modifiedon":
+                    return base.QueryThingValues(pd.Input);
+                case "thingpreference":
+                    return base.QueryThingValues(pd.Input);
+                case "alias":
+                    return base.QueryValue(pd.Input);
+                case "category":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var categoryUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && categoryUpperBound == int.MaxValue && !this.Category.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Category>();
+                        }
+
+                        var sentinelCategory = new Category(Guid.Empty, null, null);
+
+                        return sentinelCategory.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        categoryUpperBound = this.Category.Count - 1;
+                    }
+
+                    if (this.Category.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for Category property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.Category.Count - 1 < categoryUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for the Category property, the upper bound {pd.Upper.Value} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.Category[pd.Lower.Value];
+                        }
+
+                        return this.Category[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var categoryObjects = new List<Category>();
+
+                        for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                        {
+                            categoryObjects.Add(this.Category[i]);
+                        }
+
+                        return categoryObjects;
+                    }
+
+                    var categoryNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < categoryUpperBound + 1; i++)
+                    {
+                        var queryResult = this.Category[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    categoryNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                categoryNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return categoryNextObjects;
+                case "definition":
+                    return base.QueryValue(pd.Input);
+                case "hyperlink":
+                    return base.QueryValue(pd.Input);
+                case "name":
+                    return base.QueryValue(pd.Input);
+                case "shortname":
+                    return base.QueryValue(pd.Input);
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+
+        /// <summary>
+        /// Queries the value of a Sentinel object
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <param name="isCallerEmunerable">
+        /// A value indicating whether the result is a single value or an enumeration
+        /// </param>
+        /// <returns>
+        /// An object, which is either an instance or List of <see cref="Thing"/>
+        /// or an bool, int, string or List thereof 
+        /// </returns>
+        internal object QuerySentinelValue(string path, bool isCallerEmunerable)
+        {
+            var pd = PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            var propertyName = pd.Name.ToLower();
+
+            switch (propertyName)
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<Guid>() : null;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<int>() : null;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<ClassKind>() : null;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+                    return pd.Next == null ? (object) new List<DomainOfExpertise>() : new DomainOfExpertise(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "modifiedon":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<DateTime>() : null;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "alias":
+                    return pd.Next == null ? (object) new List<Alias>() : new Alias(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "category":
+                    return pd.Next == null ? (object) new List<Category>() : new Category(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "definition":
+                    return pd.Next == null ? (object) new List<Definition>() : new Definition(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "hyperlink":
+                    return pd.Next == null ? (object) new List<HyperLink>() : new HyperLink(Guid.Empty, null, null).QuerySentinelValue(pd.Next.Input, true);
+                case "name":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                case "shortname":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return isCallerEmunerable ? (object) new List<string>() : null;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on {this.ClassKind}");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/CDP4Common/CDP4Common.csproj
+++ b/CDP4Common/CDP4Common.csproj
@@ -49,6 +49,7 @@
     <Folder Include="AutoGenMetaInfo\" />
     <Folder Include="AutoGenPoco\" />
     <Folder Include="AutoGenSentinel\" />
+    <Folder Include="AutoGenThingPropertyAccessor\" />
     <Folder Include="ClasslessDto\" />
     <Folder Include="Poco\" />
     <Folder Include="RuleVerification\" />

--- a/CDP4Common/CDP4Common.csproj.DotSettings
+++ b/CDP4Common/CDP4Common.csproj.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=autogendtopropertyaccessor/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=autogenthingpropertyaccessor/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=helpers/@EntryIndexedValue">False</s:Boolean></wpf:ResourceDictionary>

--- a/CDP4Common/Helpers/PropertyDescriptor.cs
+++ b/CDP4Common/Helpers/PropertyDescriptor.cs
@@ -29,8 +29,17 @@ namespace CDP4Common.PropertyAccesor
     using System.Text.RegularExpressions;
 
     /// <summary>
-    /// The <see cref="PropertyDescriptor"/> is used ...
+    /// The <see cref="PropertyDescriptor"/> is used to convert and capture the 
+    /// (nested) property path of a Thing into the name of the parameter, the lower and
+    /// upper bound as well as the next part of the path.
     /// </summary>
+    /// <example>
+    /// definition[0..*].content
+    ///    name: definitopn
+    ///    lower: 0
+    ///    upper: 1
+    ///    next: content
+    /// </example>
     public class PropertyDescriptor
     {
         /// <summary>

--- a/CDP4Common/Helpers/PropertyDescriptor.cs
+++ b/CDP4Common/Helpers/PropertyDescriptor.cs
@@ -1,0 +1,246 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PropertyDescriptor.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2023 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, 
+//            Antoine Théate, Omar Elabiary, Jaime Bernar
+//
+//    This file is part of CDP4-COMET SDK Community Edition
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Common.PropertyAccesor
+{
+    using System;
+    using System.Text.RegularExpressions;
+
+    /// <summary>
+    /// The <see cref="PropertyDescriptor"/> is used ...
+    /// </summary>
+    public class PropertyDescriptor
+    {
+        /// <summary>
+        /// Gets or sets the name of the property
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lower bound of the property
+        /// </summary>
+        public int? Lower { get; set; }
+
+        /// <summary>
+        /// Gets or sets the upper bound of the propety
+        /// </summary>
+        public int? Upper { get; set; }
+
+        /// <summary>
+        /// Gets or sets the complete path of the current property
+        /// </summary>
+        public string PathLiteral { get; set; }
+
+        /// <summary>
+        /// Gets or sets the next part of the property, if any
+        /// </summary>
+        public string NextPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the input from which the <see cref="PropertyDescriptor"/>
+        /// has been created.
+        /// </summary>
+        public string Input { get; set; }
+
+        /// <summary>
+        /// Gets or sets the next <see cref="PropertyDescriptor"/>
+        /// </summary>
+        public PropertyDescriptor Next { get; set; }
+
+        /// <summary>
+        /// Queries the <see cref="PropertyDescriptor"/> from the <paramref name="input"/>
+        /// string. 
+        /// </summary>
+        /// <param name="input">
+        /// The string that represents a property path
+        /// </param>
+        /// <returns>
+        /// an instance of <see cref="PropertyDescriptor"/>
+        /// </returns>
+        public static PropertyDescriptor QueryPropertyDescriptor(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            if (input.Contains("-"))
+            {
+                throw new ArgumentException("The input may not contain a hyphen or minus sign");
+            }
+
+            var pattern = @"^(\w+)(?:\[(\d+)(?:\.\.(\d+|\*))?\])?";
+
+            var match = Regex.Match(input, pattern);
+
+            if (match.Success)
+            {
+                var name = match.Groups[1].Value;
+                var lowerStr = match.Groups[2].Value;
+                var upperStr = match.Groups[3].Value;
+                var next = input.Substring(match.Length).TrimStart('.');
+                
+                var lower = !string.IsNullOrEmpty(lowerStr) ? int.TryParse(lowerStr, out int lowerValue) ? lowerValue : (int?)null : null;
+
+                int? upper;
+
+                if (string.IsNullOrEmpty(upperStr))
+                {
+                    upper = null;
+                }
+                else if (upperStr == "*")
+                {
+                    upper = int.MaxValue;
+                }
+                else
+                {
+                    upper = int.TryParse(upperStr, out int upperValue) ? upperValue : (int?)null;
+                }
+
+                if (lower.HasValue && !upper.HasValue)
+                {
+                    throw new ArgumentException("when the lower bound is speficifed, so should the upper bound");
+                }
+
+                if (!lower.HasValue && upper.HasValue)
+                {
+                    throw new ArgumentException("when the upper bound is speficifed, so should the lower bound");
+                }
+
+                if (lower.HasValue & upper.HasValue)
+                {
+                    if (lower.Value < 0)
+                    {
+                        throw new ArgumentException("The lower bound may not be less than zero");
+                    }
+
+                    if (upper.Value < lower.Value)
+                    {
+                        throw new ArgumentException("The upper bound may not be less than the lower bound");
+                    }
+                }
+
+                var pathLiteral = name;
+
+                if (!string.IsNullOrEmpty(lowerStr) && !string.IsNullOrEmpty(upperStr))
+                {
+                    pathLiteral = $"{name}[{lowerStr}..{upperStr}]";
+                }
+
+                if (string.IsNullOrEmpty(next))
+                {
+                    return new PropertyDescriptor
+                    {
+                        Name = name,
+                        Lower = lower,
+                        Upper = upper,
+                        PathLiteral = pathLiteral,
+                        NextPath = next,
+                        Input = input
+                    };
+                }
+                
+                return new PropertyDescriptor
+                {
+                    Name = name,
+                    Lower = lower,
+                    Upper = upper,
+                    PathLiteral = pathLiteral,
+                    NextPath = next,
+                    Input = input,
+                    Next = PropertyDescriptor.QueryPropertyDescriptor(next)
+                };
+            }
+
+            return new PropertyDescriptor
+            {
+                Name = input,
+                Lower = null,
+                Upper = null,
+                PathLiteral = input,
+                Input = input,
+                NextPath = string.Empty
+            };
+        }
+
+        /// <summary>
+        /// Verifies whether the properties of the <see cref="PropertyDescriptor"/>
+        /// are correct for a Value property with multiplicity [0..1] or [1..1]
+        /// </summary>
+        public void VerifyPropertyDescriptorForValueProperty()
+        {
+            if (this.Lower.HasValue || this.Upper.HasValue)
+            {
+                throw new ArgumentException($"Invalid Multiplicity for { this.Name } property");
+            }
+
+            if (!string.IsNullOrEmpty(this.NextPath))
+            {
+                throw new ArgumentException($"Invalid nesting for {this.Name} property");
+            }
+        }
+
+        /// <summary>
+        /// Verifies whether the properties of the <see cref="PropertyDescriptor"/>
+        /// are correct for a Value property with multiplicity [0..*]
+        /// </summary>
+        public void VerifyPropertyDescriptorForEnumerableValueProperty()
+        {
+            if (!this.Lower.HasValue || !this.Upper.HasValue)
+            {
+                throw new ArgumentException($"Invalid Multiplicity for {this.Name} property, the lower and upper bound must be specified");
+            }
+
+            if (!string.IsNullOrEmpty(this.NextPath))
+            {
+	            throw new ArgumentException($"Invalid nesting for {this.Name} property");
+            }
+		}
+
+        /// <summary>
+        /// Verifies whether the properties of the <see cref="PropertyDescriptor"/>
+        /// are correct for a Reference property with multiplicity [0..1] or [1..1]
+        /// </summary>
+        public void VerifyPropertyDescriptorForReferenceProperty()
+        {
+            if (this.Lower.HasValue && this.Upper.HasValue)
+            {
+                throw new ArgumentException($"Invalid Multiplicity for {this.Name} property");
+            }
+        }
+
+        /// <summary>
+        /// Verifies whether the properties of the <see cref="PropertyDescriptor"/>
+        /// are correct for a Reference property with multiplicity [0..*]
+        /// </summary>
+        public void VerifyPropertyDescriptorForEnumerableReferenceProperty()
+        {
+            if (!this.Lower.HasValue || !this.Upper.HasValue)
+            {
+                throw new ArgumentException($"Invalid Multiplicity for {this.Name} property, the lower and upper bound must be specified");
+            }
+        }
+    }
+}

--- a/CDP4Common/Poco/NotThing.cs
+++ b/CDP4Common/Poco/NotThing.cs
@@ -25,6 +25,7 @@
 namespace CDP4Common
 {
     using System;
+
     using CDP4Common.CommonData;
 
     /// <summary>
@@ -76,5 +77,23 @@ namespace CDP4Common
         {
             throw new NotSupportedException();
         }
+
+		/// <summary>
+		/// Queries the value(s) of the specified property
+		/// </summary>
+		/// <param name="path">
+		/// The path of the property for which the value is to be queried
+		/// </param>
+		/// <returns>
+		/// an object that represents the value.
+		/// </returns>
+		/// <remarks>
+		/// The result may be any 
+		/// </remarks>
+		/// <exception cref="NotSupportedException">The methos is not supported by this class</exception>
+		public override object QueryValue(string path)
+        {
+			throw new NotSupportedException();
+		}
     }
 }

--- a/CDP4Common/Poco/Thing.cs
+++ b/CDP4Common/Poco/Thing.cs
@@ -771,5 +771,217 @@ namespace CDP4Common.CommonData
                 dto.PartialRoutes.Add(partialRoute);
             }
         }
+
+        /// <summary>
+        /// Queries the value(s) of the specified property
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// The result may be any 
+        /// </remarks>
+        public abstract object QueryValue(string path);
+
+        /// <summary>
+        /// Queries the value(s) of the specified property for the <see cref="Thing"/> class.
+        /// </summary>
+        /// <param name="path">
+        /// The path of the property for which the value is to be queried
+        /// </param>
+        /// <returns>
+        /// an object that represents the value.
+        /// </returns>
+        /// <remarks>
+        /// The result may be any 
+        /// </remarks>
+        protected internal object QueryThingValues(string path)
+        {
+            var pd = PropertyAccesor.PropertyDescriptor.QueryPropertyDescriptor(path);
+
+            switch (pd.Name.ToLower())
+            {
+                case "iid":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.Iid;
+                case "revisionnumber":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.RevisionNumber;
+                case "classkind":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ClassKind;
+                case "excludeddomain":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var excludedDomainUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && excludedDomainUpperBound == int.MaxValue && !this.ExcludedDomain.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<DomainOfExpertise>();
+                        }
+
+                        var sentinelDomainOfExpertise = new DomainOfExpertise(Guid.Empty, null, null);
+
+                        return sentinelDomainOfExpertise.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        excludedDomainUpperBound = this.ExcludedDomain.Count - 1;
+                    }
+
+                    if (this.ExcludedDomain.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ExcludedDomain property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ExcludedDomain.Count - 1 < excludedDomainUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ExcludedDomain property, the upper bound {excludedDomainUpperBound} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ExcludedDomain[pd.Lower.Value];
+                        }
+
+                        return this.ExcludedDomain[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var domainOfExpertiseObjects = new List<DomainOfExpertise>();
+
+                        for (var i = pd.Lower.Value; i < excludedDomainUpperBound + 1; i++)
+                        {
+                            domainOfExpertiseObjects.Add(this.ExcludedDomain[i]);
+                        }
+
+                        return domainOfExpertiseObjects;
+                    }
+
+                    var excludeddomainNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < excludedDomainUpperBound + 1; i++)
+                    {
+                        var queryResult = this.ExcludedDomain[i].QueryValue(pd.Next.Input);
+
+                        if (queryResult is IEnumerable<object> queriedValues)
+                        {
+                            foreach (var queriedValue in queriedValues)
+                            {
+                                if (queriedValue != null)
+                                {
+                                    excludeddomainNextObjects.Add(queriedValue);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (queryResult != null)
+                            {
+                                excludeddomainNextObjects.Add(queryResult);
+                            }
+                        }
+                    }
+
+                    return excludeddomainNextObjects;
+                case "excludedperson":
+                    pd.VerifyPropertyDescriptorForEnumerableReferenceProperty();
+
+                    var excludedPersonUpperBound = pd.Upper.Value;
+
+                    if (pd.Lower.Value == 0 && excludedPersonUpperBound == int.MaxValue && !this.ExcludedPerson.Any())
+                    {
+                        if (pd.Next == null)
+                        {
+                            return new List<Person>();
+                        }
+
+                        var sentinelPerson = new Person(Guid.Empty, null, null);
+
+                        return sentinelPerson.QuerySentinelValue(pd.NextPath, true);
+                    }
+
+                    if (pd.Upper.Value == int.MaxValue)
+                    {
+                        excludedPersonUpperBound = this.ExcludedPerson.Count - 1;
+                    }
+
+                    if (this.ExcludedPerson.Count - 1 < pd.Lower.Value)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ExcludedPerson property, the lower bound {pd.Lower.Value} is higher than the max index of this list.");
+                    }
+
+                    if (this.ExcludedPerson.Count - 1 < excludedPersonUpperBound)
+                    {
+                        throw new IndexOutOfRangeException($"Invalid Multiplicity for ExcludedPerson property, the upper bound {excludedPersonUpperBound} is higher than the max index of this list.");
+                    }
+
+                    if (pd.Lower.Value == pd.Upper.Value)
+                    {
+                        if (pd.Next == null)
+                        {
+                            return this.ExcludedPerson[pd.Lower.Value];
+                        }
+
+                        return this.ExcludedPerson[pd.Lower.Value].QueryValue(pd.NextPath);
+                    }
+
+                    if (pd.Next == null)
+                    {
+                        var personObjects = new List<Person>();
+
+                        for (var i = pd.Lower.Value; i < excludedPersonUpperBound + 1; i++)
+                        {
+                            personObjects.Add(this.ExcludedPerson[i]);
+                        }
+
+                        return personObjects;
+                    }
+
+                    var excludedpersonNextObjects = new List<object>();
+
+                    for (var i = pd.Lower.Value; i < excludedPersonUpperBound + 1; i++)
+                    {
+	                    var queryResult = this.ExcludedPerson[i].QueryValue(pd.Next.Input);
+
+	                    if (queryResult is IEnumerable<object> queriedValues)
+	                    {
+		                    foreach (var queriedValue in queriedValues)
+		                    {
+			                    if (queriedValue != null)
+			                    {
+				                    excludedpersonNextObjects.Add(queriedValue);
+			                    }
+		                    }
+	                    }
+	                    else
+	                    {
+		                    if (queryResult != null)
+		                    {
+			                    excludedpersonNextObjects.Add(queryResult);
+		                    }
+	                    }
+                    }
+
+                    return excludedpersonNextObjects;
+                case "modifiedOn":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ModifiedOn;
+                case "thingpreference":
+                    pd.VerifyPropertyDescriptorForValueProperty();
+                    return this.ThingPreference;
+                default:
+                    throw new ArgumentException($"The path:{path} does not exist on Thing");
+            }
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
  - Added code-generated partial classes for POCO's that are called PropertyAccessors that provide the **QuerValue** method
  - This new functionality allows to query a model with path-like strings, examples:

```
var siteDirectory = new SiteDirectory(Guid.NewGuid(), null, null);
var domainOfExpertises = (List<DomainOfExpertise>)siteDirectory.QueryValue("domain[0..*]");
var names = (List<string>) siteDirectory.QueryValue("domain[0..*].name");
var aliases = (List<Alias>)siteDirectory.QueryValue("domain[0..*].alias[0..*]");
var contents = (List<string>)siteDirectory.QueryValue("domain[0..*].alias[0..*].content");
``` 

Is going to be used to configure a CSV generator capability

<!-- Thanks for contributing to COMET-SDK! -->