### PR TITLE
[ADD] CanCreateOverride functionality to check for specific Create permissions

### DIFF
--- a/CDP4Dal.NetCore.Tests/Permission/PermissionServiceTestFixture.cs
+++ b/CDP4Dal.NetCore.Tests/Permission/PermissionServiceTestFixture.cs
@@ -1,17 +1,17 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PermissionServiceTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2023 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
-//    This file is part of CDP4-SDK Community Edition
+//    This file is part of CDP4-COMET SDK Community Edition
 //
-//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 //
-//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.
@@ -27,13 +27,17 @@ namespace CDP4Dal.Tests.Permission
     using System;
     using System.Collections.Generic;
     using System.Linq;
+
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.Exceptions;
     using CDP4Common.SiteDirectoryData;
-    using CDP4Dal.Permission;
+
     using CDP4Dal.DAL;
+    using CDP4Dal.Permission;
+
     using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
@@ -133,9 +137,10 @@ namespace CDP4Dal.Tests.Permission
 
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
+
             this.session.Setup(x => x.OpenIterations).Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>
             {
-                {this.iteration, new Tuple<DomainOfExpertise,Participant>(this.domain1,this.participant)}
+                { this.iteration, new Tuple<DomainOfExpertise, Participant>(this.domain1, this.participant) }
             });
 
             this.permissionService = new PermissionService(this.session.Object);
@@ -146,7 +151,6 @@ namespace CDP4Dal.Tests.Permission
         {
         }
 
-        #region Person Permission
         [Test]
         public void TestCanWriteFalseWithDefaultPermission()
         {
@@ -280,9 +284,6 @@ namespace CDP4Dal.Tests.Permission
             Assert.IsTrue(this.permissionService.CanRead(this.modelsetup));
             Assert.IsTrue(this.permissionService.CanWrite(this.modelsetup));
         }
-        #endregion
-
-        #region PArticipant Permission
 
         [Test]
         public void VerifyReadWriteParticipantPermission()
@@ -307,6 +308,7 @@ namespace CDP4Dal.Tests.Permission
 
             var permission =
                 this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.EngineeringModel);
+
             var defpermission =
                 this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.ElementDefinition);
 
@@ -321,7 +323,7 @@ namespace CDP4Dal.Tests.Permission
 
             this.session.Setup(x => x.OpenIterations).Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>
             {
-                {this.iteration, new Tuple<DomainOfExpertise, Participant>(null,null)}
+                { this.iteration, new Tuple<DomainOfExpertise, Participant>(null, null) }
             });
 
             Assert.IsFalse(this.permissionService.CanWrite(this.elementDef));
@@ -337,6 +339,7 @@ namespace CDP4Dal.Tests.Permission
 
             var permission =
                 this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.Requirement);
+
             var specPermission =
                 this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.RequirementsSpecification);
 
@@ -371,7 +374,6 @@ namespace CDP4Dal.Tests.Permission
             this.requirementsSpecification.Owner = this.domain2;
             Assert.IsFalse(this.permissionService.CanWrite(this.requirementsSpecification));
             Assert.IsTrue(this.permissionService.CanRead(this.requirementsSpecification));
-
         }
 
         [Test]
@@ -401,7 +403,6 @@ namespace CDP4Dal.Tests.Permission
             Assert.IsTrue(this.permissionService.CanRead(this.commonFileStore));
         }
 
-
         [Test]
         public void VerifySameAsSuperclassParticipantPermission()
         {
@@ -429,7 +430,6 @@ namespace CDP4Dal.Tests.Permission
             Assert.IsTrue(this.permissionService.CanWrite(this.valueset));
             Assert.IsTrue(this.permissionService.CanRead(this.valueset));
         }
-        #endregion
 
         [Test]
         public void VerifyCanWriteReturnsFalseWithFrozenIterationSetup()
@@ -450,6 +450,20 @@ namespace CDP4Dal.Tests.Permission
             Assert.IsFalse(this.permissionService.CanWrite(this.elementDef));
             Assert.IsFalse(this.permissionService.CanWrite(this.iteration));
             Assert.IsFalse(this.permissionService.CanWrite(ClassKind.ElementDefinition, this.iteration));
+        }
+
+        [Test]
+        public void VarifyCanCreateOverrideReturnsExpectedResult()
+        {
+            this.session.Setup(x => x.ActivePersonParticipants).Returns(new List<Participant> { this.participant });
+
+            var permission = this.personRole.PersonPermission.Single(x => x.ObjectClass == ClassKind.EngineeringModelSetup);
+            permission.AccessRight = PersonAccessRightKind.MODIFY;
+            Assert.That(this.permissionService.CanCreateOverride(ClassKind.EngineeringModelSetup, ClassKind.SiteDirectory), Is.False);
+
+            permission.AccessRight = PersonAccessRightKind.MODIFY_IF_PARTICIPANT;
+            Assert.That(this.permissionService.CanCreateOverride(ClassKind.EngineeringModelSetup, ClassKind.SiteDirectory), Is.True);
+            Assert.That(this.permissionService.CanCreateOverride(ClassKind.EngineeringModelSetup, ClassKind.EngineeringModelSetup), Is.False);
         }
     }
 }

--- a/CDP4Dal.NetCore.Tests/Permission/PermissionServiceTestFixture.cs
+++ b/CDP4Dal.NetCore.Tests/Permission/PermissionServiceTestFixture.cs
@@ -453,7 +453,7 @@ namespace CDP4Dal.Tests.Permission
         }
 
         [Test]
-        public void VarifyCanCreateOverrideReturnsExpectedResult()
+        public void VerifyCanCreateOverrideReturnsExpectedResult()
         {
             this.session.Setup(x => x.ActivePersonParticipants).Returns(new List<Participant> { this.participant });
 

--- a/CDP4Dal.Tests/Permission/PermissionServiceTestFixture.cs
+++ b/CDP4Dal.Tests/Permission/PermissionServiceTestFixture.cs
@@ -1,17 +1,17 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PermissionServiceTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2023 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
-//    This file is part of CDP4-SDK Community Edition
+//    This file is part of CDP4-COMET SDK Community Edition
 //
-//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 //
-//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.
@@ -27,13 +27,17 @@ namespace CDP4Dal.Tests.Permission
     using System;
     using System.Collections.Generic;
     using System.Linq;
+
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.Exceptions;
     using CDP4Common.SiteDirectoryData;
-    using CDP4Dal.Permission;
+
     using CDP4Dal.DAL;
+    using CDP4Dal.Permission;
+
     using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
@@ -133,9 +137,10 @@ namespace CDP4Dal.Tests.Permission
 
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
+
             this.session.Setup(x => x.OpenIterations).Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>
             {
-                {this.iteration, new Tuple<DomainOfExpertise,Participant>(this.domain1,this.participant)}
+                { this.iteration, new Tuple<DomainOfExpertise, Participant>(this.domain1, this.participant) }
             });
 
             this.permissionService = new PermissionService(this.session.Object);
@@ -146,7 +151,6 @@ namespace CDP4Dal.Tests.Permission
         {
         }
 
-        #region Person Permission
         [Test]
         public void TestCanWriteFalseWithDefaultPermission()
         {
@@ -280,9 +284,6 @@ namespace CDP4Dal.Tests.Permission
             Assert.IsTrue(this.permissionService.CanRead(this.modelsetup));
             Assert.IsTrue(this.permissionService.CanWrite(this.modelsetup));
         }
-        #endregion
-
-        #region PArticipant Permission
 
         [Test]
         public void VerifyReadWriteParticipantPermission()
@@ -307,6 +308,7 @@ namespace CDP4Dal.Tests.Permission
 
             var permission =
                 this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.EngineeringModel);
+
             var defpermission =
                 this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.ElementDefinition);
 
@@ -321,7 +323,7 @@ namespace CDP4Dal.Tests.Permission
 
             this.session.Setup(x => x.OpenIterations).Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>
             {
-                {this.iteration, new Tuple<DomainOfExpertise, Participant>(null,null)}
+                { this.iteration, new Tuple<DomainOfExpertise, Participant>(null, null) }
             });
 
             Assert.IsFalse(this.permissionService.CanWrite(this.elementDef));
@@ -337,6 +339,7 @@ namespace CDP4Dal.Tests.Permission
 
             var permission =
                 this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.Requirement);
+
             var specPermission =
                 this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.RequirementsSpecification);
 
@@ -371,7 +374,6 @@ namespace CDP4Dal.Tests.Permission
             this.requirementsSpecification.Owner = this.domain2;
             Assert.IsFalse(this.permissionService.CanWrite(this.requirementsSpecification));
             Assert.IsTrue(this.permissionService.CanRead(this.requirementsSpecification));
-
         }
 
         [Test]
@@ -401,7 +403,6 @@ namespace CDP4Dal.Tests.Permission
             Assert.IsTrue(this.permissionService.CanRead(this.commonFileStore));
         }
 
-
         [Test]
         public void VerifySameAsSuperclassParticipantPermission()
         {
@@ -429,7 +430,6 @@ namespace CDP4Dal.Tests.Permission
             Assert.IsTrue(this.permissionService.CanWrite(this.valueset));
             Assert.IsTrue(this.permissionService.CanRead(this.valueset));
         }
-        #endregion
 
         [Test]
         public void VerifyCanWriteReturnsFalseWithFrozenIterationSetup()
@@ -450,6 +450,20 @@ namespace CDP4Dal.Tests.Permission
             Assert.IsFalse(this.permissionService.CanWrite(this.elementDef));
             Assert.IsFalse(this.permissionService.CanWrite(this.iteration));
             Assert.IsFalse(this.permissionService.CanWrite(ClassKind.ElementDefinition, this.iteration));
+        }
+
+        [Test]
+        public void VarifyCanCreateOverrideReturnsExpectedResult()
+        {
+            this.session.Setup(x => x.ActivePersonParticipants).Returns(new List<Participant> { this.participant });
+
+            var permission = this.personRole.PersonPermission.Single(x => x.ObjectClass == ClassKind.EngineeringModelSetup);
+            permission.AccessRight = PersonAccessRightKind.MODIFY;
+            Assert.That(this.permissionService.CanCreateOverride(ClassKind.EngineeringModelSetup, ClassKind.SiteDirectory), Is.False);
+
+            permission.AccessRight = PersonAccessRightKind.MODIFY_IF_PARTICIPANT;
+            Assert.That(this.permissionService.CanCreateOverride(ClassKind.EngineeringModelSetup, ClassKind.SiteDirectory), Is.True);
+            Assert.That(this.permissionService.CanCreateOverride(ClassKind.EngineeringModelSetup, ClassKind.EngineeringModelSetup), Is.False);
         }
     }
 }

--- a/CDP4Dal.Tests/Permission/PermissionServiceTestFixture.cs
+++ b/CDP4Dal.Tests/Permission/PermissionServiceTestFixture.cs
@@ -453,7 +453,7 @@ namespace CDP4Dal.Tests.Permission
         }
 
         [Test]
-        public void VarifyCanCreateOverrideReturnsExpectedResult()
+        public void VerifyCanCreateOverrideReturnsExpectedResult()
         {
             this.session.Setup(x => x.ActivePersonParticipants).Returns(new List<Participant> { this.participant });
 

--- a/CDP4Dal/CDP4Dal.csproj
+++ b/CDP4Dal/CDP4Dal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4Dal Community Edition</Title>
-    <VersionPrefix>24.1.1</VersionPrefix>
+    <VersionPrefix>24.2.0</VersionPrefix>
     <Description>CDP4 Data Access Layer library, a consumer of an ECSS-E-TM-10-25 Annex C API</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael, Ahmed</Authors>
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-        [UPGRADE] CDP4Common 24.1.1
+        [UPGRADE] CDP4Common 24.2.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4Dal/Permission/IPermissionService.cs
+++ b/CDP4Dal/Permission/IPermissionService.cs
@@ -1,17 +1,17 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IPermissionService.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2023 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
 //
-//    This file is part of CDP4-SDK Community Edition
+//    This file is part of CDP4-COMET SDK Community Edition
 //
-//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 //
-//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.
@@ -61,5 +61,16 @@ namespace CDP4Dal.Permission
         /// <param name="containerThing">The <see cref="Thing"/> to write to</param>
         /// <returns>True if Write operation can be performed.</returns>
         bool CanWrite(ClassKind classKind, Thing containerThing);
+
+        /// <summary>
+        /// Normally permission to Create, Update or Delete is handled by the CanWrite methods.
+        /// In some cases Create is allowed to be performed based on <see cref="PersonAccessRightKind"/>, but Update and Delete are not.
+        /// This method is an extra method that can be performed to check if Create is allowed, based on the TopContainer <see cref="ClassKind"/>
+        /// and the <see cref="ClassKind"/> of the <see cref="Thing"/> to create.
+        /// </summary>
+        /// <param name="classKind">The <see cref="ClassKind"/> that ultimately determines the permissions.</param>
+        /// <param name="containerClassKind">The <see cref="ClassKind"/> of the top container class where to create the classKind</param>
+        /// <returns>True if Create operation can be performed.</returns>
+        bool CanCreateOverride(ClassKind classKind, ClassKind containerClassKind);
     }
 }

--- a/CDP4Dal/Permission/PermissionService.cs
+++ b/CDP4Dal/Permission/PermissionService.cs
@@ -1,17 +1,17 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PermissionService.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2023 RHEA System S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft, Yevhen Ikonnykov
 //
-//    This file is part of CDP4-SDK Community Edition
+//    This file is part of CDP4-COMET SDK Community Edition
 //
-//    The CDP4-SDK Community Edition is free software; you can redistribute it and/or
+//    The CDP4-COMET SDK Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 //
-//    The CDP4-SDK Community Edition is distributed in the hope that it will be useful,
+//    The CDP4-COMET SDK Community Edition is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.
@@ -300,6 +300,32 @@ namespace CDP4Dal.Permission
         }
 
         /// <summary>
+        /// Normally permission to Create, Update or Delete is handled by the CanWrite methods.
+        /// In some cases Create is allowed to be performed based on <see cref="PersonAccessRightKind"/>, but Update and Delete are not.
+        /// This method is an extra method that can be performed to check if Create is allowed, based on the TopContainer <see cref="ClassKind"/>
+        /// and the <see cref="ClassKind"/> of the <see cref="Thing"/> to create.
+        /// </summary>
+        /// <param name="classKind">The <see cref="ClassKind"/> that ultimately determines the permissions.</param>
+        /// <param name="containerClassKind">The <see cref="ClassKind"/> of the top container class where to create the classKind</param>
+        /// <returns>True if Create operation can be performed.</returns>
+        public bool CanCreateOverride(ClassKind classKind, ClassKind containerClassKind)
+        {
+            logger.Trace("CanCreate invoked on ClassKind {0} and Container ClassKind {1}", classKind, containerClassKind);
+
+            if (this.Session.Dal.IsReadOnly)
+            {
+                return false;
+            }
+
+            if (containerClassKind == ClassKind.SiteDirectory && classKind == ClassKind.EngineeringModelSetup)
+            {
+                return this.CanCreateOverrideSiteDirectoryContainedThing(classKind, containerClassKind);
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Returns whether a Write operation can be performed by the active user on the current <see cref="EngineeringModel"/> contained
         /// <see cref="Thing"/> based on the supplied <see cref="Type"/>. The <see cref="Type"/> ultimately determines the access.
         /// </summary>
@@ -511,6 +537,12 @@ namespace CDP4Dal.Permission
                 case PersonAccessRightKind.MODIFY:
                     return true;
                 case PersonAccessRightKind.MODIFY_IF_PARTICIPANT:
+                    if (classKind == ClassKind.EngineeringModelSetup && containerThing is SiteDirectory)
+                    {
+                        //If a participant has MODIFY_IF_PARTICIPANT access right on EngineeringModelSetup and SiteDirectory is sent as the Container, he/she is allowed to create a new EngineeringModelSetup.
+                        return true;
+                    }
+
                     if (containerThing is EngineeringModelSetup setup)
                     {
                         return setup.Participant.Any(x => x.Person == this.Session.ActivePerson);
@@ -522,6 +554,55 @@ namespace CDP4Dal.Permission
                                             this.Session.RetrieveSiteDirectory()
                                                 .Model.SelectMany(ems => this.Session.GetEngineeringModelSetupRdlChain(ems));
                         return rdl.Contains(containerThing);
+                    }
+
+                    return false;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Normally permission to Create, Update or Delete is handled by the CanWrite methods.
+        /// In some cases Create is allowed to be performed based on <see cref="PersonAccessRightKind"/>, but Update and Delete are not.
+        /// This method is an extra method that can be performed to check if Create is allowed, based on the TopContainer <see cref="ClassKind"/>
+        /// and the <see cref="ClassKind"/> of the <see cref="Thing"/> to create.
+        /// </summary>
+        /// <param name="classKind">The <see cref="ClassKind"/> that ultimately determines the permissions.</param>
+        /// <param name="containerClassKind">The <see cref="ClassKind"/> that determine the permission</param>
+        /// <returns>True if Write operation can be performed.</returns>
+        /// <remarks>
+        /// This method should only be called to check for a specific (override) situation.
+        /// It does not cover all the Create scenario's, only the custom/overridden scenario's
+        /// </remarks>
+        private bool CanCreateOverrideSiteDirectoryContainedThing(ClassKind classKind, ClassKind containerClassKind)
+        {
+            var person = this.Session.ActivePerson;
+            
+            if (person == null)
+            {
+                return false;
+            }
+
+            var personRole = this.Session.ActivePerson.Role;
+            
+            if (personRole == null)
+            {
+                return false;
+            }
+
+            var permission = personRole.PersonPermission.SingleOrDefault(p => p.ObjectClass == classKind);
+
+            // if the permission is not found or superclass derivation is used then get the default one.
+            var accessRightKind = permission?.AccessRight ?? StaticDefaultPermissionProvider.GetDefaultPersonPermission(containerClassKind.ToString());
+
+            switch (accessRightKind)
+            {
+                case PersonAccessRightKind.MODIFY_IF_PARTICIPANT:
+                    if (classKind == ClassKind.EngineeringModelSetup && containerClassKind == ClassKind.SiteDirectory)
+                    {
+                        //If a participant has MODIFY_IF_PARTICIPANT access right on EngineeringModelSetup and SiteDirectory is sent as the Container, he/she is allowed to create a new EngineeringModelSetup.
+                        return true;
                     }
 
                     return false;

--- a/CDP4Dal/Permission/PermissionService.cs
+++ b/CDP4Dal/Permission/PermissionService.cs
@@ -34,7 +34,7 @@ namespace CDP4Dal.Permission
     using CDP4Common.Helpers;
     using CDP4Common.MetaInfo;
     using CDP4Common.SiteDirectoryData;
-    
+
     using NLog;
 
     /// <summary>
@@ -123,6 +123,7 @@ namespace CDP4Dal.Permission
         private bool CanReadEngineeringModelContainedThing(Thing thing, Type thingType)
         {
             var engineeringModel = thing.TopContainer;
+
             var participant =
                 this.Session.ActivePersonParticipants.FirstOrDefault(
                     p => ((EngineeringModelSetup)p.Container).EngineeringModelIid == engineeringModel.Iid);
@@ -173,12 +174,14 @@ namespace CDP4Dal.Permission
         private bool CanReadSiteDirectoryContainedThing(Thing thing, Type thingType)
         {
             var person = this.Session.ActivePerson;
+
             if (person == null)
             {
                 return false;
             }
 
             var personRole = this.Session.ActivePerson.Role;
+
             if (personRole == null)
             {
                 return false;
@@ -219,6 +222,7 @@ namespace CDP4Dal.Permission
                         var rdl =
                             this.Session.RetrieveSiteDirectory()
                                 .Model.SelectMany(ems => this.Session.GetEngineeringModelSetupRdlChain(ems));
+
                         return rdl.Contains(thing);
                     }
 
@@ -256,6 +260,7 @@ namespace CDP4Dal.Permission
             this.CheckOwnedThing(thing);
 
             var topContainerClassKind = thing.TopContainer.ClassKind;
+
             switch (topContainerClassKind)
             {
                 case ClassKind.SiteDirectory:
@@ -288,6 +293,7 @@ namespace CDP4Dal.Permission
             this.CheckOwnedThing(containerThing);
 
             var topContainerClassKind = containerThing.TopContainer.ClassKind;
+
             switch (topContainerClassKind)
             {
                 case ClassKind.SiteDirectory:
@@ -339,6 +345,7 @@ namespace CDP4Dal.Permission
             var engineeringModel = thing.TopContainer;
 
             var iteration = thing is Iteration it ? it : thing.GetContainerOfType<Iteration>();
+
             if (iteration?.IterationSetup.FrozenOn != null)
             {
                 return false;
@@ -445,12 +452,14 @@ namespace CDP4Dal.Permission
         private bool CanWriteSiteDirectoryContainedThing(Thing thing, Type thingType)
         {
             var person = this.Session.ActivePerson;
+
             if (person == null)
             {
                 return false;
             }
 
             var personRole = this.Session.ActivePerson.Role;
+
             if (personRole == null)
             {
                 return false;
@@ -489,6 +498,7 @@ namespace CDP4Dal.Permission
                         var rdl =
                             this.Session.RetrieveSiteDirectory()
                                 .Model.SelectMany(ems => this.Session.GetEngineeringModelSetupRdlChain(ems));
+
                         return rdl.Contains(thing);
                     }
 
@@ -512,12 +522,14 @@ namespace CDP4Dal.Permission
         private bool CanWriteSiteDirectoryContainedThing(ClassKind classKind, Thing containerThing, ClassKind thingType)
         {
             var person = this.Session.ActivePerson;
+
             if (person == null)
             {
                 return false;
             }
 
             var personRole = this.Session.ActivePerson.Role;
+
             if (personRole == null)
             {
                 return false;
@@ -537,11 +549,6 @@ namespace CDP4Dal.Permission
                 case PersonAccessRightKind.MODIFY:
                     return true;
                 case PersonAccessRightKind.MODIFY_IF_PARTICIPANT:
-                    if (classKind == ClassKind.EngineeringModelSetup && containerThing is SiteDirectory)
-                    {
-                        //If a participant has MODIFY_IF_PARTICIPANT access right on EngineeringModelSetup and SiteDirectory is sent as the Container, he/she is allowed to create a new EngineeringModelSetup.
-                        return true;
-                    }
 
                     if (containerThing is EngineeringModelSetup setup)
                     {
@@ -551,8 +558,9 @@ namespace CDP4Dal.Permission
                     if (containerThing is SiteReferenceDataLibrary)
                     {
                         var rdl =
-                                            this.Session.RetrieveSiteDirectory()
-                                                .Model.SelectMany(ems => this.Session.GetEngineeringModelSetupRdlChain(ems));
+                            this.Session.RetrieveSiteDirectory()
+                                .Model.SelectMany(ems => this.Session.GetEngineeringModelSetupRdlChain(ems));
+
                         return rdl.Contains(containerThing);
                     }
 
@@ -578,14 +586,14 @@ namespace CDP4Dal.Permission
         private bool CanCreateOverrideSiteDirectoryContainedThing(ClassKind classKind, ClassKind containerClassKind)
         {
             var person = this.Session.ActivePerson;
-            
+
             if (person == null)
             {
                 return false;
             }
 
             var personRole = this.Session.ActivePerson.Role;
-            
+
             if (personRole == null)
             {
                 return false;
@@ -662,9 +670,9 @@ namespace CDP4Dal.Permission
             participant = null;
 
             if (iteration != null
-                   && this.Session.OpenIterations.TryGetValue(iteration, out var participation)
-                   && participation.Item1 != null
-                   && participation.Item2 != null)
+                && this.Session.OpenIterations.TryGetValue(iteration, out var participation)
+                && participation.Item1 != null
+                && participation.Item2 != null)
             {
                 participant = participation.Item2;
                 return true;


### PR DESCRIPTION


### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
[ADD] CanCreateOverride functionality to check for specific Create permissions