### PR TITLE
[FIX] ICDPMessageBus inherits IDisposable and accessible from ISession interface

### DIFF
--- a/CDP4Common/CDP4Common.csproj
+++ b/CDP4Common/CDP4Common.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4Common Community Edition</Title>
-    <VersionPrefix>25.0.1</VersionPrefix>
+    <VersionPrefix>25.1.0</VersionPrefix>
     <Description>CDP4 Common Class Library that contains DTOs, POCOs</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael, Ahmed</Authors>

--- a/CDP4Common/CDP4Common.csproj
+++ b/CDP4Common/CDP4Common.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4Common Community Edition</Title>
-    <VersionPrefix>25.0.0</VersionPrefix>
+    <VersionPrefix>25.0.1</VersionPrefix>
     <Description>CDP4 Common Class Library that contains DTOs, POCOs</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael, Ahmed</Authors>

--- a/CDP4Dal/CDP4Dal.csproj
+++ b/CDP4Dal/CDP4Dal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4Dal Community Edition</Title>
-    <VersionPrefix>25.0.0</VersionPrefix>
+    <VersionPrefix>25.0.1</VersionPrefix>
     <Description>CDP4 Data Access Layer library, a consumer of an ECSS-E-TM-10-25 Annex C API</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael, Ahmed</Authors>

--- a/CDP4Dal/CDP4Dal.csproj
+++ b/CDP4Dal/CDP4Dal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4Dal Community Edition</Title>
-    <VersionPrefix>25.0.1</VersionPrefix>
+    <VersionPrefix>25.1.0</VersionPrefix>
     <Description>CDP4 Data Access Layer library, a consumer of an ECSS-E-TM-10-25 Annex C API</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael, Ahmed</Authors>

--- a/CDP4Dal/CDP4Dal.csproj
+++ b/CDP4Dal/CDP4Dal.csproj
@@ -21,6 +21,8 @@
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
       [REFACTOR] CDPMessageBus from static class to injectable interface implementation
+      [ADD] CDPMessageBus property to ISession
+      [FIX] ICDPMessageBus inherits IDisposable
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4Dal/CDPMessageBus.cs
+++ b/CDP4Dal/CDPMessageBus.cs
@@ -52,7 +52,7 @@ namespace CDP4Dal
     [Export(typeof(ICDPMessageBus))]
     [PartCreationPolicy(CreationPolicy.Shared)]
 #endif
-    public class CDPMessageBus : ICDPMessageBus, IDisposable
+    public class CDPMessageBus : ICDPMessageBus
     {
         /// <summary>
         /// The <see cref="Dictionary{TKey,TValue}"/> holding the subscriptions.

--- a/CDP4Dal/CDPMessageBus.cs
+++ b/CDP4Dal/CDPMessageBus.cs
@@ -52,7 +52,7 @@ namespace CDP4Dal
     [Export(typeof(ICDPMessageBus))]
     [PartCreationPolicy(CreationPolicy.Shared)]
 #endif
-    public class CDPMessageBus : ICDPMessageBus
+    public sealed class CDPMessageBus : ICDPMessageBus
     {
         /// <summary>
         /// The <see cref="Dictionary{TKey,TValue}"/> holding the subscriptions.

--- a/CDP4Dal/ICDPMessageBus.cs
+++ b/CDP4Dal/ICDPMessageBus.cs
@@ -33,7 +33,7 @@ namespace CDP4Dal
     /// <summary>
     /// Defines the properties and methods of the <see cref="ICDPMessageBus"/> interface
     /// </summary>
-    public interface ICDPMessageBus
+    public interface ICDPMessageBus : IDisposable
     {
         /// <summary>
         /// Number of currently active Observables in this instance of the <see cref="ICDPMessageBus"/>;

--- a/CDP4Dal/ISession.cs
+++ b/CDP4Dal/ISession.cs
@@ -117,6 +117,11 @@ namespace CDP4Dal
         IReadOnlyDictionary<Iteration, Tuple<DomainOfExpertise,Participant> > OpenIterations { get; }
 
         /// <summary>
+        /// Gets the <see cref="ICDPMessageBus"/> that handles messaging for this session
+        /// </summary>
+        ICDPMessageBus CDPMessageBus { get; }
+
+        /// <summary>
         /// Retrieves the <see cref="SiteDirectory"/> in the context of the current session
         /// </summary>
         /// <returns>

--- a/CDP4JsonFileDal/CDP4JsonFileDal.csproj
+++ b/CDP4JsonFileDal/CDP4JsonFileDal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4JsonFileDal Community Edition</Title>
-    <VersionPrefix>25.0.0</VersionPrefix>
+    <VersionPrefix>25.0.1</VersionPrefix>
     <Description>CDP4 Json File Dal Plugin</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [UPGRADE] CDP4Common 25.0.0
+      [UPGRADE] CDP4Common 25.0.1
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4JsonFileDal/CDP4JsonFileDal.csproj
+++ b/CDP4JsonFileDal/CDP4JsonFileDal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4JsonFileDal Community Edition</Title>
-    <VersionPrefix>25.0.1</VersionPrefix>
+    <VersionPrefix>25.1.0</VersionPrefix>
     <Description>CDP4 Json File Dal Plugin</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [UPGRADE] CDP4Common 25.0.1
+      [UPGRADE] CDP4Common 25.1.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4JsonSerializer/CDP4JsonSerializer.csproj
+++ b/CDP4JsonSerializer/CDP4JsonSerializer.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4JsonSerializer Community Edition</Title>
-    <VersionPrefix>25.0.1</VersionPrefix>
+    <VersionPrefix>25.1.0</VersionPrefix>
     <Description>CDP4 JSON Serialization Library</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25 JSON</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [UPGRADE] CDP4Common 25.0.1
+      [UPGRADE] CDP4Common 25.1.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4JsonSerializer/CDP4JsonSerializer.csproj
+++ b/CDP4JsonSerializer/CDP4JsonSerializer.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4JsonSerializer Community Edition</Title>
-    <VersionPrefix>25.0.0</VersionPrefix>
+    <VersionPrefix>25.0.1</VersionPrefix>
     <Description>CDP4 JSON Serialization Library</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25 JSON</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [UPGRADE] CDP4Common 25.0.0
+      [UPGRADE] CDP4Common 25.0.1
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4MessagePackSerializer/CDP4MessagePackSerializer.csproj
+++ b/CDP4MessagePackSerializer/CDP4MessagePackSerializer.csproj
@@ -4,7 +4,7 @@
       <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
       <Company>RHEA System S.A.</Company>
       <Title>CDP4MessagePackSerializer Community Edition</Title>
-      <VersionPrefix>25.0.0</VersionPrefix>
+      <VersionPrefix>25.0.1</VersionPrefix>
       <Description>CDP4 MessagePack Serialization Library</Description>
       <Copyright>Copyright © RHEA System S.A.</Copyright>
       <Authors>Sam, Alex, Alexander, Nathanael, Antoine, Omar</Authors>
@@ -20,7 +20,7 @@
       <PackageTags>CDP COMET ECSS-E-TM-10-25 MessagePack</PackageTags>
       <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
       <PackageReleaseNotes>
-        [UPGRADE] CDP4Common 25.0.0
+        [UPGRADE] CDP4Common 25.0.1
       </PackageReleaseNotes>
       <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4MessagePackSerializer/CDP4MessagePackSerializer.csproj
+++ b/CDP4MessagePackSerializer/CDP4MessagePackSerializer.csproj
@@ -4,7 +4,7 @@
       <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
       <Company>RHEA System S.A.</Company>
       <Title>CDP4MessagePackSerializer Community Edition</Title>
-      <VersionPrefix>25.0.1</VersionPrefix>
+      <VersionPrefix>25.1.0</VersionPrefix>
       <Description>CDP4 MessagePack Serialization Library</Description>
       <Copyright>Copyright © RHEA System S.A.</Copyright>
       <Authors>Sam, Alex, Alexander, Nathanael, Antoine, Omar</Authors>
@@ -20,7 +20,7 @@
       <PackageTags>CDP COMET ECSS-E-TM-10-25 MessagePack</PackageTags>
       <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
       <PackageReleaseNotes>
-        [UPGRADE] CDP4Common 25.0.1
+        [UPGRADE] CDP4Common 25.1.0
       </PackageReleaseNotes>
       <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4Reporting/CDP4Reporting.csproj
+++ b/CDP4Reporting/CDP4Reporting.csproj
@@ -4,7 +4,7 @@
      <TargetFrameworks>netstandard2.0</TargetFrameworks>
      <Company>RHEA System S.A.</Company>
      <Title>CDP4Reporting Community Edition</Title>
-      <VersionPrefix>25.0.1</VersionPrefix>
+      <VersionPrefix>25.1.0</VersionPrefix>
      <Description>CDP4 Reporting</Description>
      <Copyright>Copyright © RHEA System S.A.</Copyright>
      <Authors>Sam, Alex, Alexander</Authors>
@@ -20,7 +20,7 @@
      <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
      <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
      <PackageReleaseNotes>
-       [UPGRADE] CDP4Common 25.0.1
+       [UPGRADE] CDP4Common 25.1.0
      </PackageReleaseNotes>
      <LangVersion>latest</LangVersion>
      <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/CDP4Reporting/CDP4Reporting.csproj
+++ b/CDP4Reporting/CDP4Reporting.csproj
@@ -4,7 +4,7 @@
      <TargetFrameworks>netstandard2.0</TargetFrameworks>
      <Company>RHEA System S.A.</Company>
      <Title>CDP4Reporting Community Edition</Title>
-      <VersionPrefix>25.0.0</VersionPrefix>
+      <VersionPrefix>25.0.1</VersionPrefix>
      <Description>CDP4 Reporting</Description>
      <Copyright>Copyright © RHEA System S.A.</Copyright>
      <Authors>Sam, Alex, Alexander</Authors>
@@ -20,7 +20,7 @@
      <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
      <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
      <PackageReleaseNotes>
-       [UPGRADE] CDP4Common 25.0.0
+       [UPGRADE] CDP4Common 25.0.1
      </PackageReleaseNotes>
      <LangVersion>latest</LangVersion>
      <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/CDP4RequirementsVerification/CDP4RequirementsVerification.csproj
+++ b/CDP4RequirementsVerification/CDP4RequirementsVerification.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4RequirementsVerification Community Edition</Title>
-      <VersionPrefix>25.0.1</VersionPrefix>
+      <VersionPrefix>25.1.0</VersionPrefix>
     <Description>CDP4 Class Library that provides requirement verification</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Alex, Alexander, Yevhen, Nathanael</Authors>
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [UPGRADE] CDP4Common 25.0.1
+      [UPGRADE] CDP4Common 25.1.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4RequirementsVerification/CDP4RequirementsVerification.csproj
+++ b/CDP4RequirementsVerification/CDP4RequirementsVerification.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4RequirementsVerification Community Edition</Title>
-      <VersionPrefix>25.0.0</VersionPrefix>
+      <VersionPrefix>25.0.1</VersionPrefix>
     <Description>CDP4 Class Library that provides requirement verification</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Alex, Alexander, Yevhen, Nathanael</Authors>
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [UPGRADE] CDP4Common 25.0.0
+      [UPGRADE] CDP4Common 25.0.1
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4Rules/CDP4Rules.csproj
+++ b/CDP4Rules/CDP4Rules.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4Rules Community Edition</Title>
-    <VersionPrefix>25.0.0</VersionPrefix>
+    <VersionPrefix>25.0.1</VersionPrefix>
     <Description>CDP4 Class Library that provides Model Analysis and Rule Checking</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Alex, Alexander, Yevhen, Nathanael</Authors>
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [UPGRADE] CDP4Common 25.0.0
+      [UPGRADE] CDP4Common 25.0.1
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4Rules/CDP4Rules.csproj
+++ b/CDP4Rules/CDP4Rules.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4Rules Community Edition</Title>
-    <VersionPrefix>25.0.1</VersionPrefix>
+    <VersionPrefix>25.1.0</VersionPrefix>
     <Description>CDP4 Class Library that provides Model Analysis and Rule Checking</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Alex, Alexander, Yevhen, Nathanael</Authors>
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [UPGRADE] CDP4Common 25.0.1
+      [UPGRADE] CDP4Common 25.1.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4ServicesDal/CDP4ServicesDal.csproj
+++ b/CDP4ServicesDal/CDP4ServicesDal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4ServicesDal Community Edition</Title>
-    <VersionPrefix>25.0.0</VersionPrefix>
+    <VersionPrefix>25.0.1</VersionPrefix>
     <Description>CDP4ServicesDal Dal Plugin</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [UPGRADE] CDP4Common 25.0.0
+      [UPGRADE] CDP4Common 25.0.1
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4ServicesDal/CDP4ServicesDal.csproj
+++ b/CDP4ServicesDal/CDP4ServicesDal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4ServicesDal Community Edition</Title>
-    <VersionPrefix>25.0.1</VersionPrefix>
+    <VersionPrefix>25.1.0</VersionPrefix>
     <Description>CDP4ServicesDal Dal Plugin</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [UPGRADE] CDP4Common 25.0.1
+      [UPGRADE] CDP4Common 25.1.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4Web/CDP4Web.csproj
+++ b/CDP4Web/CDP4Web.csproj
@@ -5,7 +5,7 @@
         <LangVersion>latest</LangVersion>
         <Company>RHEA System S.A.</Company>
         <Title>CDP4Web Community Edition</Title>
-        <VersionPrefix>25.0.0</VersionPrefix>
+        <VersionPrefix>25.0.1</VersionPrefix>
         <Description>CDP4Web Dedicated Sdk for CDPServicesDal</Description>
         <Copyright>Copyright © RHEA System S.A.</Copyright>
         <Authors>Sam, Alex, Alexander, Nathanael, Antoine, Omar, Jaime</Authors>
@@ -21,7 +21,7 @@
         <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
         <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
         <PackageReleaseNotes>
-          [UPGRADE] CDP4Common 25.0.0
+          [UPGRADE] CDP4Common 25.0.1
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/CDP4Web/CDP4Web.csproj
+++ b/CDP4Web/CDP4Web.csproj
@@ -5,7 +5,7 @@
         <LangVersion>latest</LangVersion>
         <Company>RHEA System S.A.</Company>
         <Title>CDP4Web Community Edition</Title>
-        <VersionPrefix>25.0.1</VersionPrefix>
+        <VersionPrefix>25.1.0</VersionPrefix>
         <Description>CDP4Web Dedicated Sdk for CDPServicesDal</Description>
         <Copyright>Copyright © RHEA System S.A.</Copyright>
         <Authors>Sam, Alex, Alexander, Nathanael, Antoine, Omar, Jaime</Authors>
@@ -21,7 +21,7 @@
         <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
         <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
         <PackageReleaseNotes>
-          [UPGRADE] CDP4Common 25.0.1
+          [UPGRADE] CDP4Common 25.1.0
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/CDP4WspDal/CDP4WspDal.csproj
+++ b/CDP4WspDal/CDP4WspDal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4WspDal Community Edition</Title>
-    <VersionPrefix>25.0.1</VersionPrefix>
+    <VersionPrefix>25.1.0</VersionPrefix>
     <Description>CDP4 WSP Dal Plugin</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [UPGRADE] CDP4Common 25.0.1
+      [UPGRADE] CDP4Common 25.1.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4WspDal/CDP4WspDal.csproj
+++ b/CDP4WspDal/CDP4WspDal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net47;net471;net472;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Company>RHEA System S.A.</Company>
     <Title>CDP4WspDal Community Edition</Title>
-    <VersionPrefix>25.0.0</VersionPrefix>
+    <VersionPrefix>25.0.1</VersionPrefix>
     <Description>CDP4 WSP Dal Plugin</Description>
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [UPGRADE] CDP4Common 25.0.0
+      [UPGRADE] CDP4Common 25.0.1
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
[ADD] ISession now implements CDPMessageBus property
[FIX] ICDPMessageBus inherits IDisposable