### PR TITLE
Fix #326: Allow to have space before/after | for enums

### DIFF
--- a/CDP4Common.NetCore.Tests/Validation/DtoValueValidatorTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Validation/DtoValueValidatorTestFixture.cs
@@ -365,6 +365,24 @@ namespace CDP4Common.NetCore.Tests.Validation
 
             result = this.enumerationParameterType.Validate(42, things, out _);
             Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Invalid));
+
+            this.valueSet.Manual[0] = "low | medium";
+            result = this.enumerationParameterType.ValidateAndCleanup(this.valueSet, null, things);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
+                Assert.That(this.valueSet.Manual[0], Is.EqualTo("low|medium"));
+            });
+
+            this.valueSet.Manual[0] = "low  |  medium";
+            result = this.enumerationParameterType.ValidateAndCleanup(this.valueSet, null, things);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
+                Assert.That(this.valueSet.Manual[0], Is.EqualTo("low|medium"));
+            });
         }
 
         [Test]

--- a/CDP4Common.Tests/Validation/DtoValueValidatorTestFixture.cs
+++ b/CDP4Common.Tests/Validation/DtoValueValidatorTestFixture.cs
@@ -365,6 +365,24 @@ namespace CDP4Common.Tests.Validation
 
             result = this.enumerationParameterType.Validate(42, things, out _);
             Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Invalid));
+            
+            this.valueSet.Manual[0] = "low | medium";
+            result = this.enumerationParameterType.ValidateAndCleanup(this.valueSet, null, things);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
+                Assert.That(this.valueSet.Manual[0], Is.EqualTo("low|medium"));
+            });
+
+            this.valueSet.Manual[0] = "low  |  medium";
+            result = this.enumerationParameterType.ValidateAndCleanup(this.valueSet, null, things);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
+                Assert.That(this.valueSet.Manual[0], Is.EqualTo("low|medium"));
+            });
         }
 
         [Test]

--- a/CDP4Common/Validation/ObjectValueValidator.cs
+++ b/CDP4Common/Validation/ObjectValueValidator.cs
@@ -28,6 +28,7 @@ namespace CDP4Common.Validation
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using System.Text.RegularExpressions;
 
     using CDP4Common.Helpers;
     using CDP4Common.SiteDirectoryData;
@@ -254,7 +255,12 @@ namespace CDP4Common.Validation
             }
 
             var values = castedString.Split(Constants.MultiValueEnumSeparator);
-            
+
+            for (var valueIndex = 0; valueIndex < values.Length; valueIndex++)
+            {
+                values[valueIndex] =  Regex.Replace(values[valueIndex], @"^\s*|\s*$", "");
+            }
+
             if (!isMultiSelectAllowed && values.Length > 1)
             {
                 cleanedValue = null;
@@ -281,7 +287,7 @@ namespace CDP4Common.Validation
 
             if (Array.Exists(values, enumerationValue => allowedValues.Any(x => x.Trim() == enumerationValue)))
             {
-                cleanedValue = castedString;
+                cleanedValue = string.Join($"{Constants.MultiValueEnumSeparator}", values);
                 Logger.Debug("Enumeration {0} validated", castedString);
                 return ValidationResult.ValidResult();
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #326 

Space before/after the '|' separator for multi-values enumeration is now allowed
<!-- Thanks for contributing to COMET-SDK! -->