### PR TITLE
Time of day parameter type converts to a wrong value; fixes #328

### DIFF
--- a/CDP4Common.NetCore.Tests/Validation/DtoValueValidatorTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Validation/DtoValueValidatorTestFixture.cs
@@ -469,7 +469,7 @@ namespace CDP4Common.NetCore.Tests.Validation
             Assert.Multiple(() =>
             {
                 Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
-                Assert.That(cleanedValue3, Is.EqualTo("0001-01-01T12:45:35.0000000"));
+                Assert.That(cleanedValue3, Is.EqualTo("0001-01-01T12:45:35.0000000+01:00"));
             });
 
             result = this.timeOfDayParameterType.Validate(new DateTime(2001, 1, 1, 12, 45, 35, DateTimeKind.Utc), out _);

--- a/CDP4Common.NetCore.Tests/Validation/DtoValueValidatorTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Validation/DtoValueValidatorTestFixture.cs
@@ -431,8 +431,8 @@ namespace CDP4Common.NetCore.Tests.Validation
             {
                 Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
                 Assert.That(this.valueSet.Manual[0], Is.EqualTo("14:00:12"));
-                Assert.That(this.valueSet.Computed[0], Is.EqualTo("14:00:12Z"));
-                Assert.That(this.valueSet.Reference[0], Is.EqualTo("17:49:30.453Z"));
+                Assert.That(this.valueSet.Computed[0], Is.EqualTo("14:00:12"));
+                Assert.That(this.valueSet.Reference[0], Is.EqualTo("17:49:30"));
             });
 
             this.valueSet.Computed[0] = "0001-01-01T14:00:12.0000000";
@@ -453,7 +453,7 @@ namespace CDP4Common.NetCore.Tests.Validation
             Assert.Multiple(() =>
             {
                 Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
-                Assert.That(cleanedValue, Is.EqualTo("12:45:35Z"));
+                Assert.That(cleanedValue, Is.EqualTo("12:45:35"));
             });
 
             result = this.timeOfDayParameterType.Validate(new DateTime(2001, 1, 1, 12, 45, 35, DateTimeKind.Utc), out _);

--- a/CDP4Common.NetCore.Tests/Validation/DtoValueValidatorTestFixture.cs
+++ b/CDP4Common.NetCore.Tests/Validation/DtoValueValidatorTestFixture.cs
@@ -431,8 +431,8 @@ namespace CDP4Common.NetCore.Tests.Validation
             {
                 Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
                 Assert.That(this.valueSet.Manual[0], Is.EqualTo("14:00:12"));
-                Assert.That(this.valueSet.Computed[0], Is.EqualTo("14:00:12"));
-                Assert.That(this.valueSet.Reference[0], Is.EqualTo("17:49:30"));
+                Assert.That(this.valueSet.Computed[0], Is.EqualTo("0001-01-01T14:00:12.0000000Z"));
+                Assert.That(this.valueSet.Reference[0], Is.EqualTo("17:49:30.453Z"));
             });
 
             this.valueSet.Computed[0] = "0001-01-01T14:00:12.0000000";
@@ -441,19 +441,35 @@ namespace CDP4Common.NetCore.Tests.Validation
             Assert.Multiple(() =>
             {
                 Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
-                Assert.That(this.valueSet.Computed[0], Is.EqualTo("14:00:12"));
+                Assert.That(this.valueSet.Computed[0], Is.EqualTo("0001-01-01T14:00:12.0000000"));
             });
 
             this.valueSet.Manual[0] = "0001-01-02T14:00:12.0000000";
             result = this.timeOfDayParameterType.ValidateAndCleanup(this.valueSet, null);
             Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Invalid));
 
-            result = this.timeOfDayParameterType.Validate(new DateTime(1, 1, 1, 12, 45, 35, DateTimeKind.Utc), out var cleanedValue);
+            result = this.timeOfDayParameterType.Validate(new DateTime(1, 1, 1, 12, 45, 35, DateTimeKind.Utc), out var cleanedValue1);
 
             Assert.Multiple(() =>
             {
                 Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
-                Assert.That(cleanedValue, Is.EqualTo("12:45:35"));
+                Assert.That(cleanedValue1, Is.EqualTo("0001-01-01T12:45:35.0000000Z"));
+            });
+
+            result = this.timeOfDayParameterType.Validate(new DateTime(1, 1, 1, 12, 45, 35, DateTimeKind.Unspecified), out var cleanedValue2);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
+                Assert.That(cleanedValue2, Is.EqualTo("0001-01-01T12:45:35.0000000"));
+            });
+
+            result = this.timeOfDayParameterType.Validate(new DateTime(1, 1, 1, 12, 45, 35, DateTimeKind.Local), out var cleanedValue3);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
+                Assert.That(cleanedValue3, Is.EqualTo("0001-01-01T12:45:35.0000000"));
             });
 
             result = this.timeOfDayParameterType.Validate(new DateTime(2001, 1, 1, 12, 45, 35, DateTimeKind.Utc), out _);

--- a/CDP4Common.Tests/Validation/DtoValueValidatorTestFixture.cs
+++ b/CDP4Common.Tests/Validation/DtoValueValidatorTestFixture.cs
@@ -414,7 +414,6 @@ namespace CDP4Common.Tests.Validation
             Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Invalid));
         }
 
-
         [Test]
         public void VerifyTimeOfDayParameterTypeValidationAndCleanup()
         {
@@ -432,8 +431,8 @@ namespace CDP4Common.Tests.Validation
             {
                 Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
                 Assert.That(this.valueSet.Manual[0], Is.EqualTo("14:00:12"));
-                Assert.That(this.valueSet.Computed[0], Is.EqualTo("14:00:12"));
-                Assert.That(this.valueSet.Reference[0], Is.EqualTo("17:49:30"));
+                Assert.That(this.valueSet.Computed[0], Is.EqualTo("0001-01-01T14:00:12.0000000Z"));
+                Assert.That(this.valueSet.Reference[0], Is.EqualTo("17:49:30.453Z"));
             });
 
             this.valueSet.Computed[0] = "0001-01-01T14:00:12.0000000";
@@ -442,19 +441,35 @@ namespace CDP4Common.Tests.Validation
             Assert.Multiple(() =>
             {
                 Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
-                Assert.That(this.valueSet.Computed[0], Is.EqualTo("14:00:12"));
+                Assert.That(this.valueSet.Computed[0], Is.EqualTo("0001-01-01T14:00:12.0000000"));
             });
 
             this.valueSet.Manual[0] = "0001-01-02T14:00:12.0000000";
             result = this.timeOfDayParameterType.ValidateAndCleanup(this.valueSet, null);
             Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Invalid));
 
-            result = this.timeOfDayParameterType.Validate(new DateTime(1, 1, 1, 12, 45, 35, DateTimeKind.Utc), out var cleanedValue);
+            result = this.timeOfDayParameterType.Validate(new DateTime(1, 1, 1, 12, 45, 35, DateTimeKind.Utc), out var cleanedValue1);
 
             Assert.Multiple(() =>
             {
                 Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
-                Assert.That(cleanedValue, Is.EqualTo("12:45:35"));
+                Assert.That(cleanedValue1, Is.EqualTo("0001-01-01T12:45:35.0000000Z"));
+            });
+
+            result = this.timeOfDayParameterType.Validate(new DateTime(1, 1, 1, 12, 45, 35, DateTimeKind.Unspecified), out var cleanedValue2);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
+                Assert.That(cleanedValue2, Is.EqualTo("0001-01-01T12:45:35.0000000"));
+            });
+
+            result = this.timeOfDayParameterType.Validate(new DateTime(1, 1, 1, 12, 45, 35, DateTimeKind.Local), out var cleanedValue3);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
+                Assert.That(cleanedValue3, Is.EqualTo("0001-01-01T12:45:35.0000000"));
             });
 
             result = this.timeOfDayParameterType.Validate(new DateTime(2001, 1, 1, 12, 45, 35, DateTimeKind.Utc), out _);

--- a/CDP4Common.Tests/Validation/DtoValueValidatorTestFixture.cs
+++ b/CDP4Common.Tests/Validation/DtoValueValidatorTestFixture.cs
@@ -469,7 +469,7 @@ namespace CDP4Common.Tests.Validation
             Assert.Multiple(() =>
             {
                 Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
-                Assert.That(cleanedValue3, Is.EqualTo("0001-01-01T12:45:35.0000000"));
+                Assert.That(cleanedValue3, Is.EqualTo("0001-01-01T12:45:35.0000000+01:00"));
             });
 
             result = this.timeOfDayParameterType.Validate(new DateTime(2001, 1, 1, 12, 45, 35, DateTimeKind.Utc), out _);

--- a/CDP4Common.Tests/Validation/DtoValueValidatorTestFixture.cs
+++ b/CDP4Common.Tests/Validation/DtoValueValidatorTestFixture.cs
@@ -432,8 +432,8 @@ namespace CDP4Common.Tests.Validation
             {
                 Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
                 Assert.That(this.valueSet.Manual[0], Is.EqualTo("14:00:12"));
-                Assert.That(this.valueSet.Computed[0], Is.EqualTo("14:00:12Z"));
-                Assert.That(this.valueSet.Reference[0], Is.EqualTo("17:49:30.453Z"));
+                Assert.That(this.valueSet.Computed[0], Is.EqualTo("14:00:12"));
+                Assert.That(this.valueSet.Reference[0], Is.EqualTo("17:49:30"));
             });
 
             this.valueSet.Computed[0] = "0001-01-01T14:00:12.0000000";
@@ -454,7 +454,7 @@ namespace CDP4Common.Tests.Validation
             Assert.Multiple(() =>
             {
                 Assert.That(result.ResultKind, Is.EqualTo(ValidationResultKind.Valid));
-                Assert.That(cleanedValue, Is.EqualTo("12:45:35Z"));
+                Assert.That(cleanedValue, Is.EqualTo("12:45:35"));
             });
 
             result = this.timeOfDayParameterType.Validate(new DateTime(2001, 1, 1, 12, 45, 35, DateTimeKind.Utc), out _);

--- a/CDP4Common/Validation/ObjectValueValidator.cs
+++ b/CDP4Common/Validation/ObjectValueValidator.cs
@@ -500,11 +500,6 @@ namespace CDP4Common.Validation
 
                     if (value is DateTime dtValue)
                     {
-                        if (dtValue.Kind == DateTimeKind.Local)
-                        {
-                            dtValue = DateTime.SpecifyKind(dtValue, DateTimeKind.Unspecified);
-                        }
-
                         cleanedValue = dtValue.ToString("o");
                         Logger.Debug("TimeOfDay {0} validated", cleanedValue);
                         return ValidationResult.ValidResult();

--- a/CDP4Common/Validation/ObjectValueValidator.cs
+++ b/CDP4Common/Validation/ObjectValueValidator.cs
@@ -62,7 +62,7 @@ namespace CDP4Common.Validation
         /// </summary>
         /// <param name="dateTime">The <see cref="DateTime" /> to check</param>
         /// <returns>True if the provided <see cref="DateTime" /> is a defualt <see cref="DateTime" /></returns>
-        public static bool IsDefaultDateTime(this DateTime dateTime)
+        public static bool IsDefaultDate(this DateTime dateTime)
         {
             return dateTime.Year == 1 && dateTime.Month == 1 && dateTime.Day == 1;
         }
@@ -477,9 +477,9 @@ namespace CDP4Common.Validation
 
                 var isDateTime = DateTime.TryParse(parsedString, CultureInfo.InvariantCulture,  DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.RoundtripKind, out var dateTime);
 
-                if (isDateTime && dateTime.IsDefaultDateTime())
+                if (isDateTime && dateTime.IsDefaultDate())
                 {
-                    cleanedValue = dateTime.ToString("HH:mm:ss");
+                    cleanedValue = parsedString;
                     Logger.Debug("TimeOfDay {0} validated", parsedString);
                     return ValidationResult.ValidResult();
                 }
@@ -489,12 +489,26 @@ namespace CDP4Common.Validation
             {
                 var timeOfDayValue = Convert.ToDateTime(value, CultureInfo.InvariantCulture);
 
-                if (timeOfDayValue.IsDefaultDateTime())
+                if (timeOfDayValue.IsDefaultDate())
                 {
-                    cleanedValue = timeOfDayValue.ToString("HH:mm:ss");
+                    if (value is string stringValue)
+                    {
+                        cleanedValue = stringValue;
+                        Logger.Debug("TimeOfDay {0} validated", cleanedValue);
+                        return ValidationResult.ValidResult();
+                    }
 
-                    Logger.Debug("TimeOfDay {0} validated", value);
-                    return ValidationResult.ValidResult();
+                    if (value is DateTime dtValue)
+                    {
+                        if (dtValue.Kind == DateTimeKind.Local)
+                        {
+                            dtValue = DateTime.SpecifyKind(dtValue, DateTimeKind.Unspecified);
+                        }
+
+                        cleanedValue = dtValue.ToString("o");
+                        Logger.Debug("TimeOfDay {0} validated", cleanedValue);
+                        return ValidationResult.ValidResult();
+                    }
                 }
             }
             catch (Exception ex)

--- a/CDP4Common/Validation/ObjectValueValidator.cs
+++ b/CDP4Common/Validation/ObjectValueValidator.cs
@@ -28,7 +28,6 @@ namespace CDP4Common.Validation
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
-    using System.Text.RegularExpressions;
 
     using CDP4Common.Helpers;
     using CDP4Common.SiteDirectoryData;
@@ -480,7 +479,7 @@ namespace CDP4Common.Validation
 
                 if (isDateTime && dateTime.IsDefaultDateTime())
                 {
-                    cleanedValue = ToTimeOfDay(dateTime);
+                    cleanedValue = dateTime.ToString("HH:mm:ss");
                     Logger.Debug("TimeOfDay {0} validated", parsedString);
                     return ValidationResult.ValidResult();
                 }
@@ -492,7 +491,7 @@ namespace CDP4Common.Validation
 
                 if (timeOfDayValue.IsDefaultDateTime())
                 {
-                    cleanedValue = ToTimeOfDay(timeOfDayValue);
+                    cleanedValue = timeOfDayValue.ToString("HH:mm:ss");
 
                     Logger.Debug("TimeOfDay {0} validated", value);
                     return ValidationResult.ValidResult();
@@ -510,41 +509,6 @@ namespace CDP4Common.Validation
                 ResultKind = ValidationResultKind.Invalid,
                 Message = $"'{value}' is not a valid Time of Day, for valid Time Of Day formats see http://www.w3.org/TR/xmlschema-2/#time."
             };
-        }
-
-        /// <summary>
-        /// Converts a <see cref="DateTime"/> object to a CDP compliant TimeOfDay string representation
-        /// </summary>
-        /// <param name="dateTime">The <see cref="DateTime"/></param>
-        /// <returns>The correct string format</returns>
-        private static string ToTimeOfDay(DateTime dateTime)
-        {
-            string cleanedValue;
-
-            if (dateTime.Kind == DateTimeKind.Utc)
-            {
-                if (dateTime.Millisecond > 0)
-                {
-                    cleanedValue = dateTime.ToString("HH:mm:ss.fffZ");
-                }
-                else
-                {
-                    cleanedValue = dateTime.ToString("HH:mm:ssZ");
-                }
-            }
-            else
-            {
-                if (dateTime.Millisecond > 0)
-                {
-                    cleanedValue = dateTime.ToString("HH:mm:ss.fff");
-                }
-                else
-                {
-                    cleanedValue = dateTime.ToString("HH:mm:ss");
-                }
-            }
-
-            return cleanedValue;
         }
     }
 }

--- a/CDP4Dal/CDP4Dal.csproj
+++ b/CDP4Dal/CDP4Dal.csproj
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-        [BUMP] To CDP4Common 26.6.2
+        [BUMP] To CDP4Common 26.6.2 
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Time of day parameter type converts to a wrong value